### PR TITLE
ci: use GitHub-hosted macOS release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
   macos-arm64:
     needs: verify
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: macos-15
     outputs:
       signed: ${{ steps.signing.outputs.enabled }}
     env:


### PR DESCRIPTION
## Summary
- run the macOS release build on the available GitHub-hosted macOS 15 runner
- preserve optional signing so releases can build unsigned when credentials are absent

## Validation
- parsed `.github/workflows/release.yml` with Ruby Psych
- `git diff --check`