### PR TITLE
ci: use GitHub-hosted release runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   verify:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: useblacksmith/checkout@v1
       - uses: dtolnay/rust-toolchain@master
@@ -36,7 +36,7 @@ jobs:
 
   linux-x64:
     needs: verify
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: useblacksmith/checkout@v1
       - uses: dtolnay/rust-toolchain@master
@@ -158,7 +158,7 @@ jobs:
 
   publish:
     needs: [linux-x64, macos-arm64]
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     env:


### PR DESCRIPTION
## Summary
- run all release jobs on GitHub-hosted runners
- avoid the current Blacksmith runner adoption delays
- preserve optional macOS signing and unsigned fallback

## Validation
- parsed `.github/workflows/release.yml` with Ruby Psych
- `git diff --check`