### PR TITLE
feat: publish multi-platform container images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Send only inputs required to compile the Kit binary.
+**
+!Cargo.toml
+!Cargo.lock
+!rust-toolchain.toml
+!build.rs
+!src/
+!src/**
+!docs/
+!docs/user/
+!docs/user/**
+!Dockerfile
+!.dockerignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,224 @@ jobs:
             --prerelease="$prerelease"
           )
           if [[ $prerelease == false ]]; then
-            edit_args+=(--latest)
+            newest_stable=$(
+              gh release list --repo "$GITHUB_REPOSITORY" --limit 100 \
+                --json tagName,isDraft,isPrerelease \
+                --jq '.[] | select((.isDraft | not) and (.isPrerelease | not)) | .tagName' \
+                | sort -V | tail -1
+            )
+            if [[ $GITHUB_REF_NAME == "$newest_stable" ]]; then
+              edit_args+=(--latest)
+            fi
           fi
           gh release edit "${edit_args[@]}"
+
+  container-build:
+    name: Build container images (${{ matrix.arch }})
+    needs: publish
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Read container version
+        id: version
+        shell: bash
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push slim image by digest
+        id: slim
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          target: slim
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            REVISION=${{ github.sha }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and push Bookworm image by digest
+        id: bookworm
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          target: bookworm
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            REVISION=${{ github.sha }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and push Alpine image by digest
+        id: alpine
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          target: alpine
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            REVISION=${{ github.sha }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export image digests
+        env:
+          SLIM_DIGEST: ${{ steps.slim.outputs.digest }}
+          BOOKWORM_DIGEST: ${{ steps.bookworm.outputs.digest }}
+          ALPINE_DIGEST: ${{ steps.alpine.outputs.digest }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests/{slim,bookworm,alpine}
+          touch "/tmp/digests/slim/${SLIM_DIGEST#sha256:}"
+          touch "/tmp/digests/bookworm/${BOOKWORM_DIGEST#sha256:}"
+          touch "/tmp/digests/alpine/${ALPINE_DIGEST#sha256:}"
+      - name: Upload image digests
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: container-digests-${{ matrix.arch }}
+          path: /tmp/digests
+          if-no-files-found: error
+          retention-days: 1
+
+  containers:
+    name: Publish container image manifests
+    needs: [publish, container-build]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Download image digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: container-digests-*
+          path: /tmp/digests
+          merge-multiple: true
+      - name: Read release metadata
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          if [[ $GITHUB_REF_NAME == *-pre* ]]; then
+            echo "floating=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          newest_stable=$(
+            gh release list --repo "$GITHUB_REPOSITORY" --limit 100 \
+              --json tagName,isDraft,isPrerelease \
+              --jq '.[] | select((.isDraft | not) and (.isPrerelease | not)) | .tagName' \
+              | sort -V | tail -1
+          )
+          if [[ $GITHUB_REF_NAME == "$newest_stable" ]]; then
+            echo "floating=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "floating=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate slim image metadata
+        id: slim-meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.IMAGE }}
+          flavor: latest=false
+          tags: |
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=${{ github.ref_name }}-slim
+            type=raw,value=latest,enable=${{ steps.release.outputs.floating == 'true' }}
+            type=raw,value=slim,enable=${{ steps.release.outputs.floating == 'true' }}
+      - name: Publish slim manifest
+        env:
+          METADATA: ${{ steps.slim-meta.outputs.json }}
+        shell: bash
+        run: |
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$METADATA")
+          mapfile -t digests < <(find /tmp/digests/slim -type f -printf "${IMAGE}@sha256:%f\n")
+          args=()
+          for tag in "${tags[@]}"; do args+=(--tag "$tag"); done
+          docker buildx imagetools create "${args[@]}" "${digests[@]}"
+
+      - name: Generate Bookworm image metadata
+        id: bookworm-meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.IMAGE }}
+          flavor: latest=false
+          tags: |
+            type=raw,value=${{ github.ref_name }}-bookworm
+            type=raw,value=bookworm,enable=${{ steps.release.outputs.floating == 'true' }}
+      - name: Publish Bookworm manifest
+        env:
+          METADATA: ${{ steps.bookworm-meta.outputs.json }}
+        shell: bash
+        run: |
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$METADATA")
+          mapfile -t digests < <(find /tmp/digests/bookworm -type f -printf "${IMAGE}@sha256:%f\n")
+          args=()
+          for tag in "${tags[@]}"; do args+=(--tag "$tag"); done
+          docker buildx imagetools create "${args[@]}" "${digests[@]}"
+
+      - name: Generate Alpine image metadata
+        id: alpine-meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.IMAGE }}
+          flavor: latest=false
+          tags: |
+            type=raw,value=${{ github.ref_name }}-alpine
+            type=raw,value=alpine,enable=${{ steps.release.outputs.floating == 'true' }}
+      - name: Publish Alpine manifest
+        env:
+          METADATA: ${{ steps.alpine-meta.outputs.json }}
+        shell: bash
+        run: |
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$METADATA")
+          mapfile -t digests < <(find /tmp/digests/alpine -type f -printf "${IMAGE}@sha256:%f\n")
+          args=()
+          for tag in "${tags[@]}"; do args+=(--tag "$tag"); done
+          docker buildx imagetools create "${args[@]}" "${digests[@]}"
+
+      - name: Verify container package is public
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          package=${GITHUB_REPOSITORY#*/}
+          visibility=$(
+            gh api "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${package}" \
+              --jq .visibility
+          )
+          if [[ $visibility != public ]]; then
+            echo "::error::Set the ${package} container package visibility to public, then rerun this workflow."
+            echo "https://github.com/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${package}/settings"
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.86"
+version = "0.1.87"
 dependencies = [
  "a2a-protocol-client",
  "a2a-protocol-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.1.86"
+version = "0.1.87"
 edition = "2024"
 rust-version = "1.94.0"
 publish = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,152 @@
+# syntax=docker/dockerfile:1
+
+# Published flavors are built from the named final stages: bookworm, slim,
+# and alpine. The unqualified image uses the final `default` stage, which
+# intentionally aliases slim.
+ARG RUST_VERSION=1.94.0
+ARG DEBIAN_SUITE=bookworm
+ARG ALPINE_VERSION=3.23
+ARG VERSION=source
+ARG REVISION=unknown
+
+FROM rust:${RUST_VERSION}-slim-${DEBIAN_SUITE} AS builder-gnu
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+ARG TARGETARCH
+
+COPY Cargo.toml Cargo.lock rust-toolchain.toml build.rs ./
+COPY src ./src
+COPY docs/user ./docs/user
+
+RUN --mount=type=cache,id=kit-cargo-registry,sharing=locked,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=kit-gnu-target-${TARGETARCH},sharing=locked,target=/src/target \
+    cargo build --locked --release --bin kit \
+    && strip --strip-unneeded target/release/kit \
+    && cp target/release/kit /kit
+
+# Alpine is a separate musl build. Do not copy the glibc artifact above into
+# this stage or add a libc compatibility shim to the runtime image.
+FROM rust:${RUST_VERSION}-alpine${ALPINE_VERSION} AS builder-musl
+
+RUN apk add --no-cache \
+        build-base \
+        cmake \
+        linux-headers \
+        perl \
+        pkgconf
+
+WORKDIR /src
+ARG TARGETARCH
+
+COPY Cargo.toml Cargo.lock rust-toolchain.toml build.rs ./
+COPY src ./src
+COPY docs/user ./docs/user
+
+RUN --mount=type=cache,id=kit-cargo-registry,sharing=locked,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=kit-musl-target-${TARGETARCH},sharing=locked,target=/src/target \
+    cargo build --locked --release --bin kit \
+    && strip --strip-unneeded target/release/kit \
+    && cp target/release/kit /kit
+
+FROM debian:${DEBIAN_SUITE} AS bookworm
+
+ARG VERSION
+ARG REVISION
+LABEL org.opencontainers.image.title="Kit" \
+      org.opencontainers.image.description="Directory-rooted coding agent runtime" \
+      org.opencontainers.image.source="https://github.com/speakeasy-api/kit" \
+      org.opencontainers.image.url="https://github.com/speakeasy-api/kit" \
+      org.opencontainers.image.documentation="https://github.com/speakeasy-api/kit#readme" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 1000 kit \
+    && useradd --uid 1000 --gid 1000 --create-home --no-log-init --shell /bin/sh kit \
+    && mkdir -p /workspace \
+    && chown kit:kit /workspace
+
+COPY --from=builder-gnu /kit /usr/local/bin/kit
+
+ENV HOME=/home/kit
+WORKDIR /workspace
+USER kit
+
+EXPOSE 8081
+STOPSIGNAL SIGTERM
+ENTRYPOINT ["/usr/local/bin/kit"]
+CMD ["--help"]
+
+FROM debian:${DEBIAN_SUITE}-slim AS slim
+
+ARG VERSION
+ARG REVISION
+LABEL org.opencontainers.image.title="Kit" \
+      org.opencontainers.image.description="Directory-rooted coding agent runtime" \
+      org.opencontainers.image.source="https://github.com/speakeasy-api/kit" \
+      org.opencontainers.image.url="https://github.com/speakeasy-api/kit" \
+      org.opencontainers.image.documentation="https://github.com/speakeasy-api/kit#readme" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 1000 kit \
+    && useradd --uid 1000 --gid 1000 --create-home --no-log-init --shell /bin/sh kit \
+    && mkdir -p /workspace \
+    && chown kit:kit /workspace
+
+COPY --from=builder-gnu /kit /usr/local/bin/kit
+
+ENV HOME=/home/kit
+WORKDIR /workspace
+USER kit
+
+# Remote ACP examples conventionally bind this port. Kit does not open a
+# listener unless the selected command asks it to.
+EXPOSE 8081
+STOPSIGNAL SIGTERM
+ENTRYPOINT ["/usr/local/bin/kit"]
+CMD ["--help"]
+
+FROM alpine:${ALPINE_VERSION} AS alpine
+
+ARG VERSION
+ARG REVISION
+LABEL org.opencontainers.image.title="Kit" \
+      org.opencontainers.image.description="Directory-rooted coding agent runtime" \
+      org.opencontainers.image.source="https://github.com/speakeasy-api/kit" \
+      org.opencontainers.image.url="https://github.com/speakeasy-api/kit" \
+      org.opencontainers.image.documentation="https://github.com/speakeasy-api/kit#readme" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}"
+
+RUN apk add --no-cache ca-certificates \
+    && addgroup -S -g 1000 kit \
+    && adduser -S -D -u 1000 -G kit -h /home/kit -s /bin/sh kit \
+    && mkdir -p /workspace \
+    && chown kit:kit /workspace
+
+COPY --from=builder-musl /kit /usr/local/bin/kit
+
+ENV HOME=/home/kit
+WORKDIR /workspace
+USER kit
+
+EXPOSE 8081
+STOPSIGNAL SIGTERM
+ENTRYPOINT ["/usr/local/bin/kit"]
+CMD ["--help"]
+
+# Keep the unqualified image on the conservative glibc/slim flavor.
+FROM slim AS default

--- a/README.md
+++ b/README.md
@@ -32,6 +32,50 @@ kit --version
 Pin a release by appending its version, for example
 `github:speakeasy-api/kit@0.1.83`.
 
+### Container image flavors
+
+The repository Dockerfile builds three user-agnostic runtime flavors. The
+unqualified `default` target aliases `slim`.
+
+```sh
+docker build --target bookworm -t kit:bookworm . # Debian/glibc
+docker build --target slim -t kit:slim .         # Debian slim/glibc (default)
+docker build --target alpine -t kit:alpine .     # Alpine/musl
+docker build -t kit:local .                      # same as slim
+```
+
+Each release publishes public `linux/amd64` and `linux/arm64` images to
+`ghcr.io/speakeasy-api/kit`. Versioned tags include `v<version>`,
+`v<version>-slim`, `v<version>-bookworm`, and `v<version>-alpine`. The newest
+stable release also updates `latest`, `slim`, `bookworm`, and `alpine`;
+prereleases and older stable reruns do not update floating tags. GitHub creates a new GHCR package as private, so an
+organization administrator must set the package visibility to public after its
+first push; the release workflow verifies this setting. For example:
+
+```sh
+docker pull ghcr.io/speakeasy-api/kit:v0.1.87
+```
+
+The Debian flavors share a native glibc build; Alpine uses a separate native musl
+build. All flavors include CA certificates and a POSIX shell, and run as the
+non-root `kit` user with UID and GID `1000` from `/workspace`. Bind-mounted
+workspaces must be writable by that identity.
+
+The base images intentionally omit Git, language toolchains, and project-specific
+utilities. A downstream image can install what it needs by switching to root and
+then restoring the `kit` user:
+
+```dockerfile
+FROM ghcr.io/speakeasy-api/kit:v0.1.87-slim
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+USER kit
+```
+
+Run `docker run --rm kit:local --version` to verify a local build.
+
 ## Run
 
 Authenticate your ChatGPT subscription once, then start the TUI:


### PR DESCRIPTION
## Summary

Adds user-agnostic Bookworm, slim, and Alpine Kit container images. Each release publishes native `linux/amd64` and `linux/arm64` manifests to `ghcr.io/speakeasy-api/kit`, with slim as the default flavor.

## Motivation

Kit currently ships binaries and package-manager integrations, but no supported container base for downstream agent environments. Publishing minimal Kit images provides a consistent foundation without coupling Kit to project-specific tools, language runtimes, or Git.

## Impact

Customers can run Kit directly from GHCR or extend a documented base image for their own environments. All flavors run as the non-root `kit` user with UID/GID `1000`, so bind-mounted workspaces must be writable by that identity.

The change affects the release pipeline after GitHub release publication. It does not change existing Kit command behavior or binary distribution.

## Technical details

### Image flavors

- `slim` uses Debian Bookworm Slim with glibc and is the default image.
- `bookworm` uses the full Debian Bookworm runtime with glibc.
- `alpine` uses Alpine 3.23 and a separately compiled musl binary.
- Each runtime contains only Kit, CA certificates, and a POSIX shell.

### Multi-platform publication

Release jobs build `linux/amd64` and `linux/arm64` images on native GitHub-hosted runners. Each architecture is pushed by digest, then combined into a public multi-platform manifest without architecture-specific public tags.

### Tag behavior

Every release publishes versioned flavor tags:

- Slim: `v<version>` and `v<version>-slim`
- Bookworm: `v<version>-bookworm`
- Alpine: `v<version>-alpine`

Only the newest stable release updates `latest`, `slim`, `bookworm`, and `alpine`. Prereleases and reruns of older stable releases do not move floating tags.

### Runtime contract

All flavors run from `/workspace` as `kit`, UID/GID `1000`. The images expose port `8081` for remote ACP usage and use `SIGTERM` as the stop signal. OCI metadata records the Kit version and source revision.

### GHCR visibility

The workflow authenticates with `GITHUB_TOKEN` and `packages: write`; no additional registry secret is required. GitHub may create the package as private on its first push, so the workflow verifies public visibility and reports the package settings URL if an organization administrator must make the one-time change.