### PR TITLE
fix(tui): hide internal notifications on resume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.87"
+version = "0.1.88"
 dependencies = [
  "a2a-protocol-client",
  "a2a-protocol-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.1.87"
+version = "0.1.88"
 edition = "2024"
 rust-version = "1.94.0"
 publish = false

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -789,8 +789,11 @@ impl App {
                 ItemKind::Developer if is_compaction_summary(item) => {
                     self.push_block(Block::Notice("context compacted".into()));
                 }
-                ItemKind::System | ItemKind::Developer | ItemKind::Context => continue,
-                ItemKind::User | ItemKind::Notification => {
+                ItemKind::System
+                | ItemKind::Developer
+                | ItemKind::Context
+                | ItemKind::Notification => continue,
+                ItemKind::User => {
                     let mut next_media = 0;
                     let text = item
                         .parts
@@ -1926,6 +1929,22 @@ mod tests {
         assert!(
             matches!(app.blocks.first(), Some(Block::Notice(text)) if text == "context compacted")
         );
+    }
+
+    #[test]
+    fn restored_transcript_hides_internal_notifications() {
+        let transcript = vec![
+            Item::text(ItemKind::User, "run the build"),
+            Item::notification("Background tool call completed: very long raw output"),
+            Item::text(ItemKind::Assistant, "the build passed"),
+        ];
+        let mut app = app();
+
+        app.restore_transcript("session".into(), &transcript);
+
+        assert_eq!(app.blocks.len(), 2);
+        assert!(matches!(&app.blocks[0], Block::User(text) if text == "run the build"));
+        assert!(matches!(&app.blocks[1], Block::Agent(text) if text == "the build passed"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- stop rendering internal transcript notifications as visible notices when the TUI resumes a session
- keep restored user and assistant messages unchanged
- bump Kit to 0.1.88 and add a regression test for background tool completion payloads

## Root cause

Background task completions are persisted as model-visible `ItemKind::Notification` entries. Live ACP replay already suppresses these internal entries, but the TUI's direct transcript restoration path grouped them with user messages. On resume, that rendered the complete background result—including raw build output—as a faint notice.

## Testing

- `cargo fmt --check`
- `cargo test 'tui::app::tests::restor' --lib`
- `git diff --check`
