### PR TITLE
feat(tui): show elapsed time for completed turns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "a2a-protocol-client",
  "a2a-protocol-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.1.88"
+version = "0.1.89"
 edition = "2024"
 rust-version = "1.94.0"
 publish = false

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -288,6 +288,7 @@ pub enum Block {
         millis: Option<u64>,
     },
     Tool(ToolCall),
+    TurnDuration(u64),
     Notice(String),
     Error(String),
 }
@@ -932,6 +933,12 @@ impl App {
         })
     }
 
+    fn stop_turn_timer(&mut self) -> Option<u64> {
+        self.turn_started
+            .take()
+            .map(|started| u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX))
+    }
+
     pub fn toast_text(&self) -> Option<&str> {
         self.toast
             .as_ref()
@@ -1073,13 +1080,16 @@ impl App {
                 self.close_thought();
                 self.agent_stream_sealed = true;
                 let interrupted = self.phase == Phase::Cancelling;
+                let turn_millis = self.stop_turn_timer();
                 self.phase = Phase::Idle;
-                self.turn_started = None;
                 self.active_autonomous_turn_id = None;
                 match (interrupted, error) {
                     (true, _) => self.note("turn interrupted"),
                     (false, Some(error)) => self.push_block(Block::Error(error)),
                     (false, None) => {}
+                }
+                if let Some(millis) = turn_millis {
+                    self.push_block(Block::TurnDuration(millis));
                 }
             }
             Update::TurnEnded { id, error } => {
@@ -1089,8 +1099,8 @@ impl App {
                 self.close_thought();
                 self.agent_stream_sealed = true;
                 let interrupted = self.phase == Phase::Cancelling;
+                let turn_millis = self.stop_turn_timer();
                 self.phase = Phase::Idle;
-                self.turn_started = None;
                 self.active_turn_id = None;
                 self.active_autonomous_turn_id = None;
                 self.compacting = false;
@@ -1114,6 +1124,9 @@ impl App {
                     (true, _) => self.note("turn interrupted"),
                     (false, Some(error)) => self.push_block(Block::Error(error)),
                     (false, None) => {}
+                }
+                if let Some(millis) = turn_millis {
+                    self.push_block(Block::TurnDuration(millis));
                 }
             }
         }
@@ -2082,6 +2095,23 @@ mod tests {
     }
 
     #[test]
+    fn completed_turn_duration_is_recorded_at_the_end() {
+        let mut app = app();
+        let id = app.push_user("hello".into());
+        app.turn_started = Some(Instant::now() - Duration::from_secs(65));
+
+        app.apply(Update::TurnEnded {
+            id: Some(id),
+            error: None,
+        });
+
+        assert!(matches!(
+            app.blocks.last(),
+            Some(Block::TurnDuration(millis)) if *millis >= 65_000
+        ));
+    }
+
+    #[test]
     fn autonomous_turn_is_visible_and_cancellable() {
         let mut app = app();
 
@@ -2094,9 +2124,10 @@ mod tests {
         app.apply(Update::AutonomousTurnEnded { id: 7, error: None });
 
         assert!(!app.working());
-        assert!(
-            matches!(app.blocks.last(), Some(Block::Notice(text)) if text == "turn interrupted")
-        );
+        assert!(matches!(
+            app.blocks.as_slice(),
+            [.., Block::Notice(text), Block::TurnDuration(_)] if text == "turn interrupted"
+        ));
     }
 
     #[test]

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -429,11 +429,30 @@ pub fn pulse(kind: Pulse, tick: usize) -> &'static str {
 /// Human-readable elapsed time, sized to the magnitude.
 pub fn duration(millis: u64) -> String {
     if millis < 1_000 {
-        format!("{millis}ms")
-    } else if millis < 60_000 {
-        format!("{:.1}s", millis as f64 / 1000.0)
+        return format!("{millis}ms");
+    }
+    if millis < 60_000 {
+        return format!("{:.1}s", millis as f64 / 1000.0);
+    }
+
+    let seconds = millis / 1_000;
+    let minutes = seconds / 60;
+    let hours = minutes / 60;
+    let days = hours / 24;
+    let weeks = days / 7;
+    let seconds = seconds % 60;
+    let minutes = minutes % 60;
+    let hours = hours % 24;
+    let days = days % 7;
+
+    if weeks > 0 {
+        format!("{weeks}w{days}d {hours}h{minutes:02}m{seconds:02}s")
+    } else if days > 0 {
+        format!("{days}d {hours}h{minutes:02}m{seconds:02}s")
+    } else if hours > 0 {
+        format!("{hours}h{minutes:02}m{seconds:02}s")
     } else {
-        format!("{}m{:02}s", millis / 60_000, (millis % 60_000) / 1000)
+        format!("{minutes}m{seconds:02}s")
     }
 }
 
@@ -447,6 +466,17 @@ mod tests {
         Appearance, DARK, LIGHT, Palette, appearance_of, contrast, forced, from_colorfgbg,
         palette_of, parse_background,
     };
+
+    #[test]
+    fn formats_turn_durations_through_weeks() {
+        assert_eq!(super::duration(999), "999ms");
+        assert_eq!(super::duration(1_000), "1.0s");
+        assert_eq!(super::duration(60_000), "1m00s");
+        assert_eq!(super::duration(3_600_000), "1h00m00s");
+        assert_eq!(super::duration(86_400_000), "1d 0h00m00s");
+        assert_eq!(super::duration(604_800_000), "1w0d 0h00m00s");
+        assert_eq!(super::duration(788_645_000), "1w2d 3h04m05s");
+    }
 
     fn roles(palette: &'static Palette) -> [(&'static str, Color); 8] {
         [

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -567,6 +567,13 @@ fn transcript_block_lines(
             ))),
             Some(call.id.clone()),
         ),
+        Block::TurnDuration(millis) => (
+            uncopyable(plain_lines(vec![Line::from(Span::styled(
+                format!("· took {}", theme::duration(*millis)),
+                theme::faint(),
+            ))])),
+            None,
+        ),
         Block::Notice(text) => (
             uncopyable(plain_lines(vec![Line::from(Span::styled(
                 format!("· {text}"),
@@ -1351,6 +1358,21 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn completed_turn_duration_is_rendered() {
+        let mut app = App::new(
+            PathBuf::from("/Users/dev/projects/kit"),
+            "openai-subscription".into(),
+            "gpt-5.4".into(),
+            "127.0.0.1:7331".into(),
+        );
+        app.blocks.push(Block::TurnDuration(788_645_000));
+
+        let frame = render(&mut app, 80, 12);
+
+        assert!(frame.contains("· took 1w2d 3h04m05s"), "{frame}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Records elapsed time when a turn completes and renders it as a faint footer in the transcript. Extends elapsed-time formatting through hours, days, and weeks (for example, `1w2d 3h04m05s`) and bumps Kit to 0.1.89.

## Impact

Completed turns now retain their elapsed time in the current TUI transcript, while all existing duration displays use compact units for long-running work.