### PR TITLE
fix: use Git CLI for Cargo dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
+[net]
+git-fetch-with-cli = true
+
 [target.'cfg(target_os = "macos")']
 runner = ["scripts/codesign-runner.sh"]


### PR DESCRIPTION
## Summary

Configure Cargo to fetch Git dependencies through the system Git CLI instead of its embedded Git transport.

## Motivation

Some contributors rewrite GitHub HTTPS URLs to SSH and rely on SSH configuration that Cargo's embedded transport cannot use. Delegating Git fetches to the system client lets Cargo use their existing SSH configuration and credential helpers, preventing authenticated Git dependencies from blocking `cargo build --locked`.

## Impact

This affects dependency fetching during builds only. Runtime behavior is unchanged.
