### PR TITLE
feat(tui): refresh terminal presentation and project context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.99"
+version = "0.1.100"
 dependencies = [
  "a2a-protocol-client",
  "a2a-protocol-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.1.99"
+version = "0.1.100"
 edition = "2024"
 rust-version = "1.94.0"
 publish = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ FROM debian:${DEBIAN_SUITE} AS bookworm
 ARG VERSION
 ARG REVISION
 LABEL org.opencontainers.image.title="Kit" \
-      org.opencontainers.image.description="Directory-rooted coding agent runtime" \
+      org.opencontainers.image.description="Coding agent runtime and terminal client" \
       org.opencontainers.image.source="https://github.com/speakeasy-api/kit" \
       org.opencontainers.image.url="https://github.com/speakeasy-api/kit" \
       org.opencontainers.image.documentation="https://github.com/speakeasy-api/kit#readme" \
@@ -91,7 +91,7 @@ FROM debian:${DEBIAN_SUITE}-slim AS slim
 ARG VERSION
 ARG REVISION
 LABEL org.opencontainers.image.title="Kit" \
-      org.opencontainers.image.description="Directory-rooted coding agent runtime" \
+      org.opencontainers.image.description="Coding agent runtime and terminal client" \
       org.opencontainers.image.source="https://github.com/speakeasy-api/kit" \
       org.opencontainers.image.url="https://github.com/speakeasy-api/kit" \
       org.opencontainers.image.documentation="https://github.com/speakeasy-api/kit#readme" \
@@ -124,7 +124,7 @@ FROM alpine:${ALPINE_VERSION} AS alpine
 ARG VERSION
 ARG REVISION
 LABEL org.opencontainers.image.title="Kit" \
-      org.opencontainers.image.description="Directory-rooted coding agent runtime" \
+      org.opencontainers.image.description="Coding agent runtime and terminal client" \
       org.opencontainers.image.source="https://github.com/speakeasy-api/kit" \
       org.opencontainers.image.url="https://github.com/speakeasy-api/kit" \
       org.opencontainers.image.documentation="https://github.com/speakeasy-api/kit#readme" \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kit
 
-Kit is a small, directory-rooted coding-agent runtime.
+Kit is a coding agent runtime and terminal client.
 
 It exposes:
 
@@ -9,7 +9,7 @@ It exposes:
 - a Ratatui ACP client
 - one model-visible tool: `compose`, backed by released Runlet
 - hidden compose children for bundled Kit documentation, shell commands, hunk edits, reusable ACP subagents, A2A calls, Agent Skills, and MCP discovery/authentication
-- `AGENTS.md` instructions loaded from the runtime root and its ancestors
+- `AGENTS.md` instructions loaded from the working directory and its ancestors
 - Agent Skills discovered from `<root>/.agents/skills`, `~/.agents/skills`, and validated local or checksum-pinned archive [Agent Plugins](docs/user/agent-plugins.md)
 - OpenAI subscription access through Kit's native ChatGPT OAuth login
 - OpenRouter through AgentKit's OpenRouter provider adapter
@@ -269,8 +269,8 @@ the fully resolved settings, including an explicit false, to its TUI server and
 nested `acp.kit` children. The OTLP subscriber exports only AgentKit loop/MCP
 semantic targets and omits source location, thread, tracing target, and span
 busy/idle metadata. ACP profiles are trusted, strict `command`/`args` argv
-configurations: Kit does not invoke a shell and always sets the child cwd to the
-runtime root. Multiple names may be configured. `[subagent].harness` selects the
+configurations: Kit does not invoke a shell and always sets the child cwd to Kit's
+working directory. Multiple names may be configured. `[subagent].harness` selects the
 default; references must use the fully qualified `acp.<name>` form. When
 omitted, `acp.kit` runs the current executable with `acp` as its base argv. An
 explicit `[acp.kit]` overrides that executable/base argv. In both cases Kit then
@@ -291,8 +291,8 @@ spawns it directly, so shell quoting, pipes, environment assignments, and
 compound commands do not work. Use an executable on `PATH` for a portable
 configuration, or an absolute path for a machine-specific one. The agent must
 keep stdout protocol-only, may log to stderr, and must support `initialize`,
-`session/new`, and `session/prompt`. Kit sets its cwd to the runtime root and
-inherits the parent environment.
+`session/new`, and `session/prompt`. Kit sets its cwd to Kit's working directory
+and inherits the parent environment.
 
 For example, these profiles pin the npm adapters while leaving the executable
 lookup portable:

--- a/docs/user/agent-plugins.md
+++ b/docs/user/agent-plugins.md
@@ -20,7 +20,7 @@ subdir = "optional/plugin/path"
 
 Aliases must contain 1–64 lowercase ASCII letters, digits, or single hyphens, with an alphanumeric first and last character. Duplicate plugin manifest names are an error.
 
-A relative `path` is resolved against Kit's runtime root, not the configuration directory. An absolute path is used directly. Local packages are validated on every startup and remain mutable local content.
+A relative `path` is resolved against Kit's working directory, not the configuration directory. An absolute path is used directly. Local packages are validated on every startup and remain mutable local content.
 
 For an `archive`, provide the final archive URL. Kit does not clone Git repositories, translate forge URLs, select branches or tags, or automatically update plugins. `sha256` is mandatory and identifies the exact downloaded bytes. HTTPS is required, except that explicit loopback HTTP URLs are accepted for local testing. Redirects from HTTPS must remain HTTPS. URL credentials and fragments are rejected.
 

--- a/docs/user/compose-and-local-tools.md
+++ b/docs/user/compose-and-local-tools.md
@@ -68,7 +68,7 @@ Loading progressively discloses the skill's full `SKILL.md` body, directory, and
 
 ## Run commands with `shell`
 
-`shell({ command, timeout_seconds? })` runs with the canonical runtime root as its working directory. On Unix it uses `sh -lc`; on Windows it uses `cmd /C`. Standard input is null. The default timeout is 120 seconds, and accepted `timeout_seconds` values are 1 through 3600.
+`shell({ command, timeout_seconds? })` runs from Kit's canonical working directory. On Unix it uses `sh -lc`; on Windows it uses `cmd /C`. Standard input is null. The default timeout is 120 seconds, and accepted `timeout_seconds` values are 1 through 3600.
 
 A normally completed command returns:
 
@@ -82,11 +82,11 @@ Stdout and stderr are captured separately and remain complete for downstream Run
 
 Only the final compose return value crosses the model-context boundary. When its serialized form exceeds 8 KiB, Kit writes the complete result to `compose-output.json` under the call's artifact directory and returns `{ preview, artifact, original_bytes }` to the model. The preview contains bounded head and tail text separated by a `compose output spilled` marker. Compose final results have a 64 MiB safety limit. Return focused summaries when possible; inspect only a narrow artifact range when the complete final result is not needed in context.
 
-The runtime root is a working directory, not an operating-system security boundary. A shell command can use absolute paths, `..`, the network, and any credentials or files allowed to the Kit process. Quote untrusted values, inspect destructive commands before running them, and avoid putting secrets into command text or returned output. There is no automatic rollback for shell side effects.
+Kit's working directory is project context, not an operating-system security boundary. A shell command can use absolute paths, `..`, the network, and any credentials or files allowed to the Kit process. Quote untrusted values, inspect destructive commands before running them, and avoid putting secrets into command text or returned output. There is no automatic rollback for shell side effects.
 
 ## Make exact file changes with `edit`
 
-`edit` operates on one file path with `op: "add"`, `"edit"`, or `"delete"`. Relative paths are resolved from the runtime root. Absolute paths, `..`, and paths through symlinks are accepted, so `edit` can change files outside the root when the Kit process has permission. Paths must be non-empty.
+`edit` operates on one file path with `op: "add"`, `"edit"`, or `"delete"`. Relative paths are resolved from Kit's working directory. Absolute paths, `..`, and paths through symlinks are accepted, so `edit` can change files outside the root when the Kit process has permission. Paths must be non-empty.
 
 An edit hunk replaces `old` while using optional `context_before` and `context_after` as its exact anchor:
 

--- a/docs/user/getting-started-and-configuration.md
+++ b/docs/user/getting-started-and-configuration.md
@@ -1,6 +1,6 @@
 # Getting Started and Configuring Kit
 
-Kit is a directory-rooted coding-agent runtime. Choose a project directory as the runtime root, authenticate the model provider, and then use the installed `kit` binary interactively, for one prompt, or as an ACP/A2A server. Run `kit --help` and `kit <command> --help` for the current, exhaustive command-line reference.
+Kit is a coding agent runtime and terminal client. Choose a project working directory, authenticate the model provider, and then use the installed `kit` binary interactively, for one prompt, or as an ACP/A2A server. Run `kit --help` and `kit <command> --help` for the current, exhaustive command-line reference.
 
 Run `kit init` to write the recommended `~/.kit/config.toml` and an empty `~/.kit/mcp.json` when those files do not exist. It selects `gpt-5.6-sol` and file-backed credentials in `~/.kit/credentials`. The command leaves existing files unchanged.
 
@@ -90,7 +90,7 @@ credential. Revoke the API key remotely in the Speakeasy dashboard.
 
 ## Run common command workflows
 
-The runtime root must exist and be a directory. If `--root` is omitted, Kit uses configured `root`, then `.`. A bad path reports `could not open runtime root`; a non-directory reports `runtime root is not a directory`.
+The working directory must exist and be a directory. If `--root` is omitted, Kit uses configured `root`, then `.`. A bad path reports `could not open working directory`; a non-directory reports `working directory is not a directory`. This directory supplies project context and relative-path resolution; it does not restrict filesystem access.
 
 ### Interactive terminal client with `kit tui`
 
@@ -245,7 +245,7 @@ For example, with `model = "gpt-5.4"` in TOML, `kit prompt --model anthropic/cla
 
 ## Project instructions from `AGENTS.md`
 
-Kit discovers `AGENTS.md` files at the runtime root and its ancestor directories and loads their content into the initial transcript as agent context. Put repository-wide guidance in a higher-level `AGENTS.md` and project-specific guidance nearer the selected root. Choose `--root` deliberately because it controls both the working directory and which `AGENTS.md` instruction chain is loaded.
+Kit discovers `AGENTS.md` files at the project working directory and its ancestor directories and loads their content into the initial transcript as agent context. Put repository-wide guidance in a higher-level `AGENTS.md` and project-specific guidance nearer the selected root. Choose `--root` deliberately because it controls both the working directory and which `AGENTS.md` instruction chain is loaded.
 
 If startup reports `could not load AGENTS.md context`, inspect the `AGENTS.md` files at the root and above it for read or loading problems. Changing `~/.kit/config.toml` does not replace project instructions; configuration selects runtime behavior, while `AGENTS.md` supplies instructions to the agent.
 

--- a/docs/user/security-limits-and-troubleshooting.md
+++ b/docs/user/security-limits-and-troubleshooting.md
@@ -1,17 +1,17 @@
 # Security, Limits, and Troubleshooting
 
-Kit is a directory-rooted coding-agent runtime, not a security boundary. Treat the model, prompts, configured ACP harnesses, MCP servers, and remote A2A agents according to the access they receive. For command-specific options, use `kit --help` and `kit <command> --help`; this page describes behavior and boundaries rather than every CLI flag.
+Kit is a coding agent runtime, not a security boundary. Treat the model, prompts, configured ACP harnesses, MCP servers, and remote A2A agents according to the access they receive. For command-specific options, use `kit --help` and `kit <command> --help`; this page describes behavior and boundaries rather than every CLI flag.
 
-## Trust model and runtime root
+## Trust model and working directory
 
-The runtime root is the working directory and project context, **not a sandbox**. Kit canonicalizes the root at startup and rejects a missing root (`could not open runtime root`) or a non-directory (`runtime root is not a directory`). An ACP client must open exactly that root and cannot add `additional_directories`.
+`--root` selects Kit's working directory and project context; it is **not a sandbox**. Kit canonicalizes the directory at startup and rejects a missing path (`could not open working directory`) or a non-directory (`working directory is not a directory`). An ACP client must open exactly that project context and cannot add `additional_directories`.
 
 The root does not confine processes:
 
 - `shell` starts the platform shell with the root as its current directory. The command can read or change anything allowed by the Kit process, including paths outside the root, the network, and inherited environment variables.
 - ACP subagents are child processes started directly from trusted local `command` and `args` profiles, with the same root as their current directory. They inherit normal child-process host access; selecting a harness is not isolation.
 - MCP stdio servers are local processes, while MCP HTTP servers and A2A agents are remote trust domains. Tool arguments, prompts, and returned data cross those boundaries.
-- `edit` resolves relative paths from the runtime root, but also accepts `..`, absolute paths, and paths through symlinks. It can change any filesystem path allowed by the Kit process.
+- `edit` resolves relative paths from Kit's working directory, but also accepts `..`, absolute paths, and paths through symlinks. It can change any filesystem path allowed by the Kit process.
 
 Kit has no general permissions or interactive approval framework for its own tools. The fact that only `compose` is model-visible organizes tool use; it does not make hidden `shell`, `edit`, subagent, A2A, or MCP calls harmless. Review requested work and run Kit with the least host, repository, network, and account access appropriate for it.
 
@@ -99,7 +99,7 @@ Provider context windows, model token limits, child-agent turn limits, remote ra
 ### Kit does not start or the TUI exits before opening a session
 
 1. Run `kit --version` and `kit <command> --help` to verify the installed binary and command syntax.
-2. If the diagnostic says `could not open runtime root` or `runtime root is not a directory`, verify that `--root` exists, is a directory, and is accessible to the Kit process.
+2. If the diagnostic says `could not open working directory` or `working directory is not a directory`, verify that `--root` exists, is a directory, and is accessible to the Kit process.
 3. If A2A binding fails or the port is taken, omit the fixed address to get an available loopback port, choose another loopback port, or use `kit acp` when HTTP is unnecessary.
 4. If the failure mentions OpenAI subscription credentials, run status and login with the same persistent `--credential-store keychain` or `--credential-store file --credential-dir ...` used by the runtime; standalone login rejects `memory`. Ensure loopback port 1455 or 1457 is available. Retry without pasting secrets into the prompt.
 
@@ -107,7 +107,7 @@ Provider context windows, model token limits, child-agent turn limits, remote ra
 
 1. For `shell command timed out`, reduce the task, diagnose a blocked subprocess, or intentionally raise `timeout_seconds` within 1–3600. An interrupt kills Kit's child command but still inspect for partial side effects.
 2. When a result reports `compose output spilled`, inspect a small relevant range from its artifact instead of returning the full artifact to model context. Internal Runlet consumers receive complete shell output before this boundary guard runs.
-3. For `path must be non-empty`, provide either a path relative to the runtime root or an absolute path.
+3. For `path must be non-empty`, provide either a path relative to Kit's working directory or an absolute path.
 4. For a hunk mismatch or ambiguity, reread the file and provide more unique exact context.
 
 ### A subagent fails, hangs, or cannot fork

--- a/docs/user/subagents-and-acp-harnesses.md
+++ b/docs/user/subagents-and-acp-harnesses.md
@@ -64,7 +64,7 @@ Text-only turns omit `updates`. Capture is limited to 64 update objects and 64 K
 
 ## Choose the built-in `acp.kit` harness
 
-`acp.kit` is always available and is the default when `[subagent].harness` is not configured. By default Kit launches the installed `kit` executable as `kit acp`, whose default stdio protocol is ACP v1. A built-in child inherits the runtime root, provider, model, MCP configuration and credential storage, cancellation, and nesting depth. An explicit `subagent.model` selection overrides the inherited model for that ACP session. It does not start an A2A listener.
+`acp.kit` is always available and is the default when `[subagent].harness` is not configured. By default Kit launches the installed `kit` executable as `kit acp`, whose default stdio protocol is ACP v1. A built-in child inherits Kit's working directory, provider, model, MCP configuration and credential storage, cancellation, and nesting depth. An explicit `subagent.model` selection overrides the inherited model for that ACP session. It does not start an A2A listener.
 
 You can override only the executable and base arguments while preserving built-in Kit behavior:
 
@@ -82,7 +82,7 @@ Built-in subagent transcripts are durable on disk, but their reusable parent-own
 
 ## Configure a generic ACP v1 harness
 
-Generic external child harnesses remain ACP v1: they must speak newline-delimited JSON-RPC over stdio and support `initialize`, `session/new`, and `session/prompt`. `session/fork` and `session/close` are optional capabilities. Keep stdout protocol-only; the agent may log to stderr. Kit runs the executable directly with the runtime root as its current working directory and inherits the parent environment. It does not invoke a shell, so pipes, environment assignments, compound commands, and shell quoting in `command` or `args` do not work.
+Generic external child harnesses remain ACP v1: they must speak newline-delimited JSON-RPC over stdio and support `initialize`, `session/new`, and `session/prompt`. `session/fork` and `session/close` are optional capabilities. Keep stdout protocol-only; the agent may log to stderr. Kit runs the executable directly from Kit's working directory and inherits the parent environment. It does not invoke a shell, so pipes, environment assignments, compound commands, and shell quoting in `command` or `args` do not work.
 
 Configure trusted argv profiles in `~/.kit/config.toml`:
 

--- a/docs/user/tui-and-sessions.md
+++ b/docs/user/tui-and-sessions.md
@@ -154,13 +154,11 @@ This repair does not hide general JSONL damage. Errors including `invalid transc
 
 While a session is open, Kit can reconstruct a transcript path deleted from disk using its still-open file and can reacquire a missing lock only if no other owner won the lock. It fails closed if another process owns recovery authority. After an abnormal TUI shutdown, restarting with `--resume` should be the first recovery attempt; add `--force` only after confirming the remaining lock is stale.
 
-### Colours on light and dark terminals
+### Terminal colours and Speakeasy branding
 
-The TUI draws on the terminal's own background, so it asks the terminal for that background over OSC 11 at startup and picks a dark or light palette to match. Terminals that do not answer within 100 ms fall back to `COLORFGBG`, and then to the dark palette.
+The TUI inherits the terminal's configured foreground and background. Functional accents use ANSI colour slots, so success, warning, error, focus, and muted text follow the user's terminal palette instead of a Kit-specific dark or light theme. Selection uses the terminal's reversed style, and Kit does not probe or repaint the terminal background.
 
-Windows builds do not query the terminal at all: they use `KIT_THEME` if it is set, and the dark palette otherwise.
-
-Set `KIT_THEME=light` or `KIT_THEME=dark` to override the detection — useful under multiplexers or remote sessions that report the wrong background, or answer for a different terminal than the one in front of you. Any other value, including unset, keeps automatic detection.
+The empty starter screen adds a decorative Speakeasy rainbow line beneath the Kit name. Once a session has transcript content, the line moves beneath the header and spans the terminal width when the terminal is tall enough to show it without displacing required content. Terminals that advertise 24-bit colour receive the Speakeasy brand ramp; limited-colour terminals receive an ANSI approximation from their configured palette. No status or instruction depends on distinguishing those colours.
 
 ### TUI startup and terminal recovery
 

--- a/src/acp_child.rs
+++ b/src/acp_child.rs
@@ -231,7 +231,7 @@ impl AcpHarnesses {
             command
         };
         // Every trusted profile is spawned directly (never through a shell)
-        // with the runtime root as cwd.
+        // with Kit's working directory as cwd.
         command.current_dir(&config.root);
         Ok(command)
     }
@@ -300,7 +300,7 @@ struct LaunchContext {
 impl LaunchContext {
     fn error(&self, phase: &str, error: impl std::fmt::Display) -> String {
         format!(
-            "ACP harness {phase}: {error} (harness={:?}, source={}, cwd=runtime root)",
+            "ACP harness {phase}: {error} (harness={:?}, source={}, cwd=Kit working directory)",
             self.harness, self.source
         )
     }
@@ -1258,7 +1258,7 @@ mod tests {
         let error = context.error("handshake timeout", "no response within 30 seconds");
         assert!(error.contains("harness=\"acp.safe-name\""));
         assert!(error.contains("source=configured ACP profile"));
-        assert!(error.contains("cwd=runtime root"));
+        assert!(error.contains("cwd=Kit working directory"));
         assert!(!error.contains("secret-command-name"));
         assert!(!error.contains("secret-argument"));
         assert!(!error.contains("/private/runtime/root"));
@@ -1321,7 +1321,7 @@ mod tests {
         assert!(error.contains("protocol handshake failure"), "{error}");
         assert!(error.contains("harness=\"acp.broken\""), "{error}");
         assert!(error.contains("source=configured ACP profile"), "{error}");
-        assert!(error.contains("cwd=runtime root"), "{error}");
+        assert!(error.contains("cwd=Kit working directory"), "{error}");
         assert!(
             error.contains("the child did not complete the ACP handshake"),
             "{error}"
@@ -1379,7 +1379,7 @@ mod tests {
         assert!(error.contains("17"), "{error}");
         assert!(error.contains("harness=\"acp.exits\""), "{error}");
         assert!(error.contains("source=configured ACP profile"), "{error}");
-        assert!(error.contains("cwd=runtime root"), "{error}");
+        assert!(error.contains("cwd=Kit working directory"), "{error}");
         assert!(!error.contains("python3"), "{error}");
         assert!(!error.contains("raise SystemExit"), "{error}");
         assert!(!error.contains(root.path().to_string_lossy().as_ref()));
@@ -1565,7 +1565,7 @@ mod tests {
             assert!(error.contains("spawn failure"), "{error}");
             assert!(error.contains("harness=\"acp.broken\""), "{error}");
             assert!(error.contains("source=configured ACP profile"), "{error}");
-            assert!(error.contains("cwd=runtime root"), "{error}");
+            assert!(error.contains("cwd=Kit working directory"), "{error}");
             assert!(!error.contains("kit-test-acp-executable-that-does-not-exist"));
             assert!(!error.contains(root.path().to_string_lossy().as_ref()));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use kit::tools::CredentialStorage;
 use serde::Deserialize;
 
 #[derive(Parser)]
-#[command(version, about = "Lean directory-rooted coding agent runtime")]
+#[command(version, about = "Coding agent runtime and terminal client")]
 struct Cli {
     #[command(flatten)]
     telemetry: TelemetryArgs,
@@ -407,7 +407,7 @@ enum Command {
     },
     /// Serve ACP on stdio with A2A, remote ACP, or both over HTTP.
     Serve {
-        /// Runtime root (defaults to config or `.`).
+        /// Working directory and project context (defaults to config or `.`).
         #[arg(long)]
         root: Option<PathBuf>,
         /// Model name (defaults to config or `gpt-5.4`).
@@ -454,6 +454,7 @@ enum Command {
         /// ACP wire protocol version.
         #[arg(long, value_enum, default_value = "1")]
         protocol_version: AcpProtocolVersion,
+        /// Working directory and project context (defaults to config or `.`).
         #[arg(long)]
         root: Option<PathBuf>,
         #[arg(long)]
@@ -475,7 +476,7 @@ enum Command {
     },
     /// Run one persisted prompt, print its answer and session id, then exit.
     Prompt {
-        /// Runtime root (defaults to config or `.`).
+        /// Working directory and project context (defaults to config or `.`).
         #[arg(long)]
         root: Option<PathBuf>,
         /// Model name (defaults to config or `gpt-5.4`).
@@ -499,7 +500,7 @@ enum Command {
     },
     /// Start the ACP-backed terminal client.
     Tui {
-        /// Runtime root (defaults to config or `.`).
+        /// Working directory and project context (defaults to config or `.`).
         #[arg(long)]
         root: Option<PathBuf>,
         /// Model name (defaults to config or `gpt-5.4`).

--- a/src/protocols/a2a.rs
+++ b/src/protocols/a2a.rs
@@ -128,7 +128,7 @@ pub(crate) fn dispatcher(
     let card = AgentCard {
         url: None,
         name: "Kit".into(),
-        description: "Directory-rooted coding agent".into(),
+        description: "Coding agent runtime".into(),
         version: env!("CARGO_PKG_VERSION").into(),
         supported_interfaces: vec![AgentInterface {
             url,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -302,10 +302,10 @@ impl Runtime {
         let root = root
             .as_ref()
             .canonicalize()
-            .map_err(|error| format!("could not open runtime root: {error}"))?;
+            .map_err(|error| format!("could not open working directory: {error}"))?;
         if !root.is_dir() {
             return Err(format!(
-                "runtime root is not a directory: {}",
+                "working directory is not a directory: {}",
                 root.display()
             ));
         }
@@ -970,7 +970,7 @@ impl Runtime {
     fn system_prompt(&self, depth: usize) -> String {
         format!(
             concat!(
-                "You are a coding agent using Kit version {} as your harness, rooted at {}. ",
+                "You are a coding agent using Kit version {} as your harness, working in {}. This is your cwd and project context, not a filesystem boundary. ",
                 "Make minimal changes, inspect before editing, and run the smallest useful check. ",
                 "Keep tool output lean: use targeted paths, ranges, filters, and bounded `head`/`tail` output. Do not dump whole trees, generated files, long successful build logs, credential files, or environment contents.\n\n",
                 "Use compose as a dependency graph: independent calls and `for` iterations run concurrently, including effectful calls; ",

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -23,7 +23,7 @@ impl ShellTool {
             root,
             spec: ToolSpec::new(
                 ToolName::new("shell"),
-                "Run a shell command with the runtime root as its working directory.",
+                "Run a shell command from Kit's working directory. Commands can access any path allowed to the Kit process.",
                 json!({
                     "type": "object",
                     "properties": {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2326,7 +2326,7 @@ impl App {
 
     /// The selected text, reconstructed from the rendered rows: rows wrapped
     /// from one logical line rejoin, trailing padding is dropped, and fenced
-    /// code loses the two-column display indent it is drawn with.
+    /// code loses the two-column display gutter it is drawn with.
     pub fn selection_text(&self) -> Option<String> {
         let selection = self.selection?;
         let (start, end) = selection.ordered();
@@ -2346,10 +2346,12 @@ impl App {
                 .collect();
             let from = if line == start.0 { start.1 } else { 0 };
             let to = if line == end.0 { end.1 + 1 } else { usize::MAX };
-            let mut fragment = column_slice(&text, from, to).trim_end().to_string();
-            if row.1.1.is_some() && from == 0 && fragment.starts_with("  ") {
-                fragment.drain(..2);
+            let mut fragment = column_slice(&text, from, to);
+            if row.1.1.is_some() && from < 2 && (text.starts_with('│') || text.starts_with("  "))
+            {
+                fragment = column_slice(fragment, 2 - from, usize::MAX);
             }
+            let fragment = fragment.trim_end().to_string();
             let logical = row.1.2.map(|index| (block, index));
             match (logical, last_logical) {
                 (Some(current), Some(previous)) if current == previous => {

--- a/src/tui/markdown.rs
+++ b/src/tui/markdown.rs
@@ -151,22 +151,20 @@ fn block_line(raw: &str, trimmed: &str) -> LinkedLine {
     if let Some(quoted) = trimmed.strip_prefix("> ") {
         let mut spans = vec![plain_span(format!("{indent}▏ "), theme::faint())];
         spans.extend(inline(quoted, theme::dim().add_modifier(Modifier::ITALIC)));
-        return LinkedLine { spans };
+        return LinkedLine::new(spans).with_leading_gutter();
     }
     if let Some(item) = bullet(trimmed) {
         let mut spans = vec![plain_span(format!("{indent}• "), theme::accent())];
         spans.extend(inline(item, theme::text()));
-        return LinkedLine { spans };
+        return LinkedLine::new(spans).with_leading_gutter();
     }
-    LinkedLine {
-        spans: inline(raw, theme::text()),
-    }
+    LinkedLine::new(inline(raw, theme::text()))
 }
 
 fn heading_line(indent: String, heading: &str, style: Style) -> LinkedLine {
     let mut spans = vec![plain_span(indent, Style::default())];
     spans.extend(inline(heading, style));
-    LinkedLine { spans }
+    LinkedLine::new(spans)
 }
 
 fn bullet(trimmed: &str) -> Option<&str> {
@@ -177,9 +175,10 @@ fn bullet(trimmed: &str) -> Option<&str> {
 
 fn code_line(raw: &str) -> LinkedLine {
     plain_line(Line::from(vec![
-        Span::styled("  ", theme::code()),
+        Span::styled("│ ", theme::faint()),
         Span::styled(raw.replace('\t', "    "), theme::code()),
     ]))
+    .with_leading_gutter()
 }
 
 fn code_frame(label: &str) -> LinkedLine {
@@ -353,7 +352,7 @@ fn inline_with_link_destinations(
         let (delimiter, style) = if tail.starts_with("**") {
             ("**", base.add_modifier(Modifier::BOLD))
         } else if tail.starts_with('`') {
-            ("`", theme::code())
+            ("`", theme::inline_code())
         } else if tail.starts_with('*') {
             ("*", base.add_modifier(Modifier::ITALIC))
         } else {
@@ -400,7 +399,7 @@ fn inline_with_link_destinations(
             spans.push(plain_span(std::mem::take(&mut plain), base));
         }
         if delimiter == "`" {
-            spans.push(plain_span(body[..close].to_string(), style));
+            spans.push(plain_span(format!("`{}`", &body[..close]), style));
         } else {
             spans.extend(inline_with_link_destinations(
                 &body[..close],
@@ -430,7 +429,9 @@ mod tests {
         let lines = render("text\n```rust\nlet x = 1;\n```\nmore");
         assert_eq!(lines.len(), 5);
         assert!(lines[1].spans[0].content.contains("rust"));
+        assert_eq!(lines[2].spans[0].content, "│ ");
         assert!(lines[2].spans[1].content.contains("let x = 1;"));
+        assert_eq!(lines[2].spans[1].style.bg, None);
     }
 
     #[test]
@@ -480,7 +481,14 @@ mod tests {
             .iter()
             .map(|span| span.content.as_ref())
             .collect();
-        assert_eq!(contents, ["run ", "cargo test", " and ", "stop"]);
+        assert_eq!(contents, ["run ", "`cargo test`", " and ", "stop"]);
+        assert!(line.spans[1].style.add_modifier.contains(Modifier::BOLD));
+        assert!(
+            !line.spans[1]
+                .style
+                .add_modifier
+                .contains(Modifier::REVERSED)
+        );
     }
 
     #[test]
@@ -606,7 +614,7 @@ mod tests {
             .map(|span| span.span.content.as_ref())
             .collect();
 
-        assert_eq!(joined, "[label](https://example.com/docs)");
+        assert_eq!(joined, "`[label](https://example.com/docs)`");
         assert!(linked_urls(source).is_empty());
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1110,7 +1110,6 @@ fn prompt_blocks(prompt: &SubmittedPrompt) -> Result<Vec<ContentBlock>, String> 
 }
 
 fn enter() -> std::io::Result<(DefaultTerminal, image::ImageRuntime)> {
-    theme::detect();
     let terminal = ratatui::try_init()?;
     // Query after entering the alternate screen but before the event stream owns
     // terminal input, as required by ratatui-image. The query has a short bound.

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,329 +1,47 @@
 //! Colours and glyphs for the terminal client.
 //!
-//! Every colour is drawn on the terminal's own background, which the client
-//! never paints over, so a palette built for a dark terminal washes out to
-//! nothing on a light one. The palette is therefore chosen once at startup
-//! from the background the terminal reports, and every call site asks for a
-//! role — `text`, `dim`, `accent` — rather than a fixed colour.
-
-use std::{
-    sync::atomic::{AtomicU8, Ordering},
-    time::Duration,
-};
+//! Functional UI colours use the terminal's defaults and ANSI palette, so the
+//! client follows the user's terminal theme. Speakeasy's true-colour ramp is
+//! reserved for decorative brand moments and falls back to ANSI colours when
+//! the terminal does not advertise 24-bit colour.
 
 use ratatui::style::{Color, Modifier, Style};
 
-/// Which way round the terminal's colours run.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Appearance {
-    Dark,
-    Light,
+const BRAND_RGB: [Color; 9] = [
+    Color::Rgb(0x32, 0x0f, 0x1e),
+    Color::Rgb(0xc8, 0x32, 0x28),
+    Color::Rgb(0xfb, 0x87, 0x3f),
+    Color::Rgb(0xd2, 0xdc, 0x91),
+    Color::Rgb(0x5a, 0x82, 0x50),
+    Color::Rgb(0x00, 0x23, 0x14),
+    Color::Rgb(0x00, 0x14, 0x3c),
+    Color::Rgb(0x28, 0x73, 0xd7),
+    Color::Rgb(0x9b, 0xc3, 0xff),
+];
+
+const BRAND_ANSI: [Color; 9] = [
+    Color::Magenta,
+    Color::Red,
+    Color::Yellow,
+    Color::Yellow,
+    Color::Green,
+    Color::Green,
+    Color::Blue,
+    Color::Blue,
+    Color::Cyan,
+];
+
+/// Speakeasy's warm-to-cool brand ramp, with a terminal-palette fallback.
+pub fn brand_rainbow() -> &'static [Color; 9] {
+    brand_rainbow_for(crossterm::style::available_color_count())
 }
 
-/// One colour per role the client draws in.
-struct Palette {
-    accent: Color,
-    user: Color,
-    running: Color,
-    success: Color,
-    warn: Color,
-    error: Color,
-    dim: Color,
-    faint: Color,
-    text: Color,
-    code_fg: Color,
-    code_bg: Color,
-    bar_bg: Color,
-    selection_bg: Color,
-}
-
-const DARK: Palette = Palette {
-    accent: Color::Rgb(94, 205, 190),
-    user: Color::Rgb(137, 180, 250),
-    running: Color::Rgb(197, 168, 250),
-    success: Color::Rgb(126, 200, 130),
-    warn: Color::Rgb(230, 180, 100),
-    error: Color::Rgb(240, 120, 120),
-    dim: Color::Rgb(122, 130, 145),
-    faint: Color::Rgb(78, 85, 98),
-    text: Color::Rgb(215, 220, 228),
-    code_fg: Color::Rgb(232, 200, 140),
-    code_bg: Color::Rgb(30, 33, 41),
-    bar_bg: Color::Rgb(24, 27, 34),
-    selection_bg: Color::Rgb(62, 76, 110),
-};
-
-/// The same roles at the same hues, darkened to carry on a light terminal.
-const LIGHT: Palette = Palette {
-    accent: Color::Rgb(0, 102, 93),
-    user: Color::Rgb(26, 86, 190),
-    running: Color::Rgb(103, 58, 183),
-    success: Color::Rgb(24, 110, 60),
-    warn: Color::Rgb(132, 78, 0),
-    error: Color::Rgb(186, 32, 40),
-    dim: Color::Rgb(88, 96, 112),
-    faint: Color::Rgb(128, 136, 152),
-    text: Color::Rgb(32, 36, 44),
-    code_fg: Color::Rgb(124, 72, 16),
-    code_bg: Color::Rgb(234, 236, 240),
-    bar_bg: Color::Rgb(216, 220, 228),
-    selection_bg: Color::Rgb(184, 202, 235),
-};
-
-/// The palette in force, as an [`Appearance`] discriminant.
-///
-/// Dark is the default: it is what every terminal that answers no question at
-/// all gets, and what the client drew with before light terminals were read.
-static CHOSEN: AtomicU8 = AtomicU8::new(DARK_CODE);
-
-const DARK_CODE: u8 = 0;
-const LIGHT_CODE: u8 = 1;
-
-/// How long the terminal gets to answer the background query.
-///
-/// Terminals that do not implement it answer nothing, so this is dead time on
-/// startup for them and has to stay short enough not to be felt.
-const PROBE: Duration = Duration::from_millis(100);
-
-/// Reads the terminal's background and fixes the palette for the session.
-///
-/// Called once before the alternate screen is entered, while the terminal can
-/// still be asked a question and answer it on stdin.
-pub fn detect() {
-    set(detected());
-}
-
-pub fn set(appearance: Appearance) {
-    CHOSEN.store(
-        match appearance {
-            Appearance::Dark => DARK_CODE,
-            Appearance::Light => LIGHT_CODE,
-        },
-        Ordering::Relaxed,
-    );
-}
-
-pub fn appearance() -> Appearance {
-    if CHOSEN.load(Ordering::Relaxed) == LIGHT_CODE {
-        Appearance::Light
+fn brand_rainbow_for(color_count: u16) -> &'static [Color; 9] {
+    if color_count == u16::MAX {
+        &BRAND_RGB
     } else {
-        Appearance::Dark
+        &BRAND_ANSI
     }
-}
-
-fn palette() -> &'static Palette {
-    palette_of(appearance())
-}
-
-fn palette_of(appearance: Appearance) -> &'static Palette {
-    match appearance {
-        Appearance::Dark => &DARK,
-        Appearance::Light => &LIGHT,
-    }
-}
-
-fn detected() -> Appearance {
-    if let Some(forced) = std::env::var("KIT_THEME").ok().as_deref().and_then(forced) {
-        return forced;
-    }
-    if let Some(background) = probe_background(PROBE) {
-        return appearance_of(background);
-    }
-    std::env::var("COLORFGBG")
-        .ok()
-        .as_deref()
-        .and_then(from_colorfgbg)
-        .unwrap_or(Appearance::Dark)
-}
-
-/// An explicit choice, for terminals that answer wrongly or not at all.
-fn forced(value: &str) -> Option<Appearance> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "light" => Some(Appearance::Light),
-        "dark" => Some(Appearance::Dark),
-        _ => None,
-    }
-}
-
-/// The appearance implied by a background colour.
-fn appearance_of((red, green, blue): (u8, u8, u8)) -> Appearance {
-    let luminance = 0.2126 * f64::from(red) + 0.7152 * f64::from(green) + 0.0722 * f64::from(blue);
-    if luminance > 127.5 {
-        Appearance::Light
-    } else {
-        Appearance::Dark
-    }
-}
-
-/// `COLORFGBG`, the pre-OSC convention: foreground and background as palette
-/// indices, sometimes with a cursor colour wedged between them.
-fn from_colorfgbg(value: &str) -> Option<Appearance> {
-    let background: u8 = value.rsplit(';').next()?.trim().parse().ok()?;
-    // Indices 0-6 and 8 are the dark half of the ANSI palette; 7 and 9-15 are
-    // the light half, and anything above that is the 256-colour cube, where
-    // the greyscale ramp ends light.
-    match background {
-        0..=6 | 8 => Some(Appearance::Dark),
-        7 | 9..=15 => Some(Appearance::Light),
-        _ => None,
-    }
-}
-
-/// Pulls the background out of an OSC 11 reply, once the reply is complete.
-///
-/// Terminals answer `ESC ] 11 ; rgb:RRRR/GGGG/BBBB` closed by either BEL or
-/// ST, with components of one to four hex digits. An answer still in flight
-/// reads as no answer, so the caller keeps waiting rather than parsing half a
-/// colour.
-fn parse_background(reply: &[u8]) -> Option<(u8, u8, u8)> {
-    let text = String::from_utf8_lossy(reply);
-    let body = text.split("rgb:").nth(1)?;
-    let end = terminator(body)?;
-    let mut components = body[..end].split('/');
-    let color = (
-        component(components.next()?)?,
-        component(components.next()?)?,
-        component(components.next()?)?,
-    );
-    components.next().is_none().then_some(color)
-}
-
-/// Where the answer ends: BEL, or ST written out in full as `ESC` `\\`.
-///
-/// A reply that stops on a lone `ESC` is still arriving. Ending it there would
-/// take the colour but leave the backslash behind, and the event loop would
-/// then read it as the first thing the user typed.
-fn terminator(body: &str) -> Option<usize> {
-    body.find('\x07')
-        .into_iter()
-        .chain(body.find("\x1b\\"))
-        .min()
-}
-
-/// One hex component of an OSC colour, scaled to eight bits.
-fn component(digits: &str) -> Option<u8> {
-    let width = digits.len();
-    if !(1..=4).contains(&width) {
-        return None;
-    }
-    let value = u32::from_str_radix(digits, 16).ok()?;
-    let full = u32::from(u16::MAX);
-    // Widen to 16 bits by repeating the digits, the way X11 reads short specs,
-    // then narrow to the eight bits a terminal colour is written in.
-    let widened = value * (full / (16u32.pow(width as u32) - 1));
-    Some((widened >> 8) as u8)
-}
-
-/// Asks the terminal for its background colour over OSC 11.
-///
-/// The query goes to the controlling terminal rather than stdout so a client
-/// with its output redirected still reaches the terminal, and is asked with
-/// the terminal in raw mode, since a cooked terminal holds the reply back
-/// until the user presses return.
-#[cfg(unix)]
-fn probe_background(timeout: Duration) -> Option<(u8, u8, u8)> {
-    let mut tty = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open("/dev/tty")
-        .ok()?;
-    // Without raw mode the terminal holds the reply back until the user
-    // presses return, so an unaskable terminal is left alone entirely.
-    crossterm::terminal::enable_raw_mode().ok()?;
-    let background = ask(&mut tty, timeout);
-    let _ = crossterm::terminal::disable_raw_mode();
-    background
-}
-
-/// Puts the OSC 11 question to a terminal and waits out its answer.
-///
-/// Whatever the terminal says arrives in pieces, so the reply is read until it
-/// parses or the deadline passes: a terminal that does not implement the query
-/// says nothing at all, and must not hold up startup for longer than that.
-#[cfg(unix)]
-fn ask(tty: &mut std::fs::File, timeout: Duration) -> Option<(u8, u8, u8)> {
-    use std::{
-        io::{Read, Write},
-        os::fd::AsRawFd,
-        time::Instant,
-    };
-
-    tty.write_all(b"\x1b]11;?\x1b\\").ok()?;
-    tty.flush().ok()?;
-    let deadline = Instant::now() + timeout;
-    let mut reply = Vec::new();
-    loop {
-        let left = deadline.saturating_duration_since(Instant::now());
-        if left.is_zero() {
-            return None;
-        }
-        let mut poll = libc::pollfd {
-            fd: tty.as_raw_fd(),
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        // SAFETY: one initialised descriptor, owned by `tty` and open for the
-        // whole call, waited on for a bounded time.
-        let ready = unsafe { libc::poll(&raw mut poll, 1, left.as_millis() as i32) };
-        // A signal cutting the wait short is not an answer either way, and
-        // the deadline still bounds what is left of the wait.
-        if ready < 0 && interrupted() {
-            continue;
-        }
-        if ready <= 0 {
-            return None;
-        }
-        let mut chunk = [0u8; 64];
-        match tty.read(&mut chunk) {
-            Ok(0) => return None,
-            Ok(read) => reply.extend_from_slice(&chunk[..read]),
-            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(_) => return None,
-        }
-        if let Some(background) = parse_background(&reply) {
-            return Some(background);
-        }
-        // A terminal that answers something else — or a keystroke that arrives
-        // first — must not keep the client waiting either.
-        if reply.len() > 256 {
-            return None;
-        }
-    }
-}
-
-/// Whether the last `poll` failed only because a signal arrived.
-#[cfg(unix)]
-fn interrupted() -> bool {
-    std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted
-}
-
-#[cfg(not(unix))]
-fn probe_background(_timeout: Duration) -> Option<(u8, u8, u8)> {
-    None
-}
-
-/// The WCAG contrast ratio between two true colours.
-///
-/// Every palette entry is checked against the background it is drawn on, so
-/// the ratio is what the tests assert on rather than the colours themselves.
-#[cfg(test)]
-pub fn contrast(color: Color, background: Color) -> f64 {
-    fn luminance(color: Color) -> f64 {
-        let Color::Rgb(red, green, blue) = color else {
-            panic!("the client draws in true colour");
-        };
-        let channel = |value: u8| {
-            let value = f64::from(value) / 255.0;
-            if value <= 0.03928 {
-                value / 12.92
-            } else {
-                ((value + 0.055) / 1.055).powf(2.4)
-            }
-        };
-        0.2126 * channel(red) + 0.7152 * channel(green) + 0.0722 * channel(blue)
-    }
-    let (one, two) = (luminance(color), luminance(background));
-    (one.max(two) + 0.05) / (one.min(two) + 0.05)
 }
 
 /// Activity indicators, one per kind of work.
@@ -363,52 +81,48 @@ impl Pulse {
     }
 }
 
-pub fn accent_color() -> Color {
-    palette().accent
+pub const fn accent_color() -> Color {
+    Color::Cyan
 }
 
-pub fn user_color() -> Color {
-    palette().user
+pub const fn user_color() -> Color {
+    Color::Blue
 }
 
-pub fn running_color() -> Color {
-    palette().running
+pub const fn running_color() -> Color {
+    Color::Cyan
 }
 
-pub fn success_color() -> Color {
-    palette().success
+pub const fn success_color() -> Color {
+    Color::Green
 }
 
-pub fn warn_color() -> Color {
-    palette().warn
+pub const fn warn_color() -> Color {
+    Color::Yellow
 }
 
-pub fn error_color() -> Color {
-    palette().error
+pub const fn error_color() -> Color {
+    Color::Red
 }
 
-pub fn text_color() -> Color {
-    palette().text
-}
-
-pub fn bar_bg() -> Color {
-    palette().bar_bg
+pub const fn text_color() -> Color {
+    Color::Reset
 }
 
 pub fn text() -> Style {
-    Style::default().fg(palette().text)
+    Style::default()
 }
 
 pub fn dim() -> Style {
-    Style::default().fg(palette().dim)
+    Style::default().add_modifier(Modifier::DIM)
 }
 
 pub fn faint() -> Style {
-    Style::default().fg(palette().faint)
+    Style::default().fg(Color::DarkGray)
 }
 
 pub fn accent() -> Style {
-    Style::default().fg(palette().accent)
+    Style::default().fg(accent_color())
 }
 
 pub fn bold(color: Color) -> Style {
@@ -416,15 +130,19 @@ pub fn bold(color: Color) -> Style {
 }
 
 pub fn code() -> Style {
-    Style::default().fg(palette().code_fg).bg(palette().code_bg)
+    Style::default()
+}
+
+pub fn inline_code() -> Style {
+    Style::default().add_modifier(Modifier::BOLD)
 }
 
 pub fn bar() -> Style {
-    Style::default().fg(palette().dim).bg(palette().bar_bg)
+    Style::default()
 }
 
 pub fn selection() -> Style {
-    Style::default().bg(palette().selection_bg)
+    Style::default().add_modifier(Modifier::REVERSED)
 }
 
 /// The frame this indicator shows on an animation tick.
@@ -465,222 +183,53 @@ pub fn duration(millis: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use ratatui::style::Color;
+    use ratatui::style::{Color, Modifier};
 
-    use std::time::Duration;
-
-    use super::{
-        Appearance, DARK, LIGHT, Palette, appearance_of, contrast, forced, from_colorfgbg,
-        palette_of, parse_background,
-    };
+    use super::{BRAND_ANSI, BRAND_RGB, bar, brand_rainbow_for, code, duration, selection, text};
 
     #[test]
     fn formats_turn_durations_through_weeks() {
-        assert_eq!(super::duration(999), "999ms");
-        assert_eq!(super::duration(1_000), "1.0s");
-        assert_eq!(super::duration(60_000), "1m00s");
-        assert_eq!(super::duration(3_600_000), "1h00m00s");
-        assert_eq!(super::duration(86_400_000), "1d 0h00m00s");
-        assert_eq!(super::duration(604_800_000), "1w0d 0h00m00s");
-        assert_eq!(super::duration(788_645_000), "1w2d 3h04m05s");
-    }
-
-    fn roles(palette: &'static Palette) -> [(&'static str, Color); 8] {
-        [
-            ("accent", palette.accent),
-            ("user", palette.user),
-            ("running", palette.running),
-            ("success", palette.success),
-            ("warn", palette.warn),
-            ("error", palette.error),
-            ("dim", palette.dim),
-            ("text", palette.text),
-        ]
+        assert_eq!(duration(0), "0ms");
+        assert_eq!(duration(999), "999ms");
+        assert_eq!(duration(1_000), "1.0s");
+        assert_eq!(duration(60_000), "1m00s");
+        assert_eq!(duration(3_600_000), "1h00m00s");
+        assert_eq!(duration(86_400_000), "1d 0h00m00s");
+        assert_eq!(duration(604_800_000), "1w0d 0h00m00s");
+        assert_eq!(duration(788_645_000), "1w2d 3h04m05s");
     }
 
     #[test]
-    fn dark_palette_is_unchanged() {
-        assert_eq!(DARK.text, Color::Rgb(215, 220, 228));
-        assert_eq!(DARK.accent, Color::Rgb(94, 205, 190));
-        assert_eq!(DARK.dim, Color::Rgb(122, 130, 145));
-        assert_eq!(DARK.faint, Color::Rgb(78, 85, 98));
-        assert_eq!(DARK.code_bg, Color::Rgb(30, 33, 41));
-        assert_eq!(DARK.bar_bg, Color::Rgb(24, 27, 34));
-    }
-
-    #[test]
-    fn light_palette_carries_on_a_white_terminal() {
-        let white = Color::Rgb(255, 255, 255);
-        for (role, color) in roles(&LIGHT) {
-            let contrast = contrast(color, white);
-            assert!(contrast >= 4.5, "{role} is {contrast:.2}:1 on white");
-        }
-        // Faint is meant to recede, but not below the dark palette's own
-        // faintest reading, which is legible on a black terminal.
-        assert!(contrast(LIGHT.faint, white) >= contrast(DARK.faint, Color::Rgb(0, 0, 0)));
-    }
-
-    #[test]
-    fn dark_palette_carries_on_a_black_terminal() {
-        let black = Color::Rgb(0, 0, 0);
-        for (role, color) in roles(&DARK) {
-            let contrast = contrast(color, black);
-            assert!(contrast >= 4.5, "{role} is {contrast:.2}:1 on black");
-        }
-    }
-
-    #[test]
-    fn palette_chrome_stays_legible_against_its_own_fills() {
-        for (name, palette) in [("dark", &DARK), ("light", &LIGHT)] {
-            let bar = contrast(palette.dim, palette.bar_bg);
-            assert!(bar >= 4.0, "{name} status bar is {bar:.2}:1");
-            let code = contrast(palette.code_fg, palette.code_bg);
-            assert!(code >= 4.5, "{name} inline code is {code:.2}:1");
-        }
-    }
-
-    #[test]
-    fn background_luminance_picks_the_palette() {
-        assert_eq!(appearance_of((255, 255, 255)), Appearance::Light);
-        assert_eq!(appearance_of((250, 246, 236)), Appearance::Light);
-        assert_eq!(appearance_of((0, 0, 0)), Appearance::Dark);
-        assert_eq!(appearance_of((30, 33, 41)), Appearance::Dark);
-        // Solarized: light and dark share a hue and differ only in level.
-        assert_eq!(appearance_of((253, 246, 227)), Appearance::Light);
-        assert_eq!(appearance_of((0, 43, 54)), Appearance::Dark);
-    }
-
-    #[test]
-    fn reads_a_terminals_osc_reply() {
-        assert_eq!(
-            parse_background(b"\x1b]11;rgb:ffff/ffff/ffff\x1b\\"),
-            Some((255, 255, 255))
-        );
-        assert_eq!(
-            parse_background(b"\x1b]11;rgb:1e1e/2121/2929\x07"),
-            Some((30, 33, 41))
-        );
-        // Short components are widened the way X11 reads them.
-        assert_eq!(
-            parse_background(b"\x1b]11;rgb:f/0/0\x07"),
-            Some((255, 0, 0))
-        );
-        assert_eq!(
-            parse_background(b"\x1b]11;rgb:ff/80/00\x07"),
-            Some((255, 128, 0))
-        );
-    }
-
-    #[test]
-    fn waits_out_a_reply_that_is_still_arriving() {
-        assert_eq!(parse_background(b"\x1b]11;rgb:ffff/ff"), None);
-        assert_eq!(parse_background(b""), None);
-        assert_eq!(parse_background(b"\x1b]11;rgb:ffff/ffff\x07"), None);
-        assert_eq!(parse_background(b"\x1b]11;rgb:zz/zz/zz\x07"), None);
-        assert_eq!(parse_background(b"\x1b]11;rgb:1/2/3/4\x07"), None);
-    }
-
-    /// Reading the colour off a half-arrived ST would leave the backslash in
-    /// the terminal's buffer, where the event loop reads it as a keystroke.
-    #[test]
-    fn holds_out_for_the_whole_terminator() {
-        let split = b"\x1b]11;rgb:1e1e/2121/2929\x1b";
-        assert_eq!(parse_background(split), None);
-        let mut whole = split.to_vec();
-        whole.push(b'\\');
-        assert_eq!(parse_background(&whole), Some((30, 33, 41)));
-    }
-
-    /// A stand-in terminal on one end of a socket pair: the probe writes its
-    /// query into it and reads the answer back, exactly as it would from a
-    /// terminal, without needing this test to own one.
-    #[cfg(unix)]
-    fn terminal() -> (std::fs::File, std::fs::File) {
-        use std::os::fd::FromRawFd;
-
-        let mut ends = [0; 2];
-        // SAFETY: a stream socket pair, whose two descriptors are handed
-        // straight to `File` and closed when those are dropped.
-        let made =
-            unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, ends.as_mut_ptr()) };
-        assert_eq!(made, 0, "socketpair");
-        // SAFETY: both descriptors are fresh and owned by nothing else.
-        unsafe {
-            (
-                std::fs::File::from_raw_fd(ends[0]),
-                std::fs::File::from_raw_fd(ends[1]),
-            )
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn asks_the_terminal_and_waits_for_its_answer() {
-        use std::io::{Read, Write};
-
-        let (mut client, mut terminal) = terminal();
-        let answering = std::thread::spawn(move || {
-            let mut query = [0; 16];
-            let read = terminal.read(&mut query).expect("query arrives");
-            assert_eq!(&query[..read], b"\x1b]11;?\x1b\\");
-            // Terminals answer in whatever pieces they please.
-            terminal
-                .write_all(b"\x1b]11;rgb:fdfd/f6f6")
-                .expect("first half");
-            terminal.flush().expect("flush");
-            std::thread::sleep(Duration::from_millis(20));
-            terminal.write_all(b"/e3e3\x1b").expect("second half");
-            terminal.flush().expect("flush");
-            std::thread::sleep(Duration::from_millis(20));
-            terminal.write_all(b"\\").expect("terminator");
-            terminal.flush().expect("flush");
-            terminal
-        });
-        assert_eq!(
-            super::ask(&mut client, Duration::from_secs(5)),
-            Some((253, 246, 227))
-        );
-        assert_eq!(appearance_of((253, 246, 227)), Appearance::Light);
-        drop(answering.join().expect("the terminal answers"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn gives_up_on_a_terminal_that_never_answers() {
-        let (mut client, terminal) = terminal();
-        let started = std::time::Instant::now();
-        assert_eq!(super::ask(&mut client, Duration::from_millis(50)), None);
+    fn functional_styles_inherit_the_terminal_background() {
+        assert_eq!(text().fg, None);
+        assert_eq!(text().bg, None);
+        assert_eq!(code().bg, None);
+        assert_eq!(bar().bg, None);
+        assert!(!bar().add_modifier.contains(Modifier::DIM));
+        assert_eq!(super::running_color(), Color::Cyan);
+        assert!(selection().add_modifier.contains(Modifier::REVERSED));
         assert!(
-            started.elapsed() < Duration::from_secs(1),
-            "startup stalled"
+            !super::inline_code()
+                .add_modifier
+                .contains(Modifier::REVERSED)
         );
-        drop(terminal);
     }
 
     #[test]
-    fn reads_the_colorfgbg_convention() {
-        assert_eq!(from_colorfgbg("15;0"), Some(Appearance::Dark));
-        assert_eq!(from_colorfgbg("0;15"), Some(Appearance::Light));
-        assert_eq!(from_colorfgbg("0;default;15"), Some(Appearance::Light));
-        assert_eq!(from_colorfgbg("15;default;0"), Some(Appearance::Dark));
-        assert_eq!(from_colorfgbg("0;7"), Some(Appearance::Light));
-        assert_eq!(from_colorfgbg("7;default"), None);
-        assert_eq!(from_colorfgbg(""), None);
+    fn true_colour_uses_the_speakeasy_brand_ramp() {
+        assert_eq!(brand_rainbow_for(u16::MAX), &BRAND_RGB);
+        assert_eq!(BRAND_RGB[0], Color::Rgb(0x32, 0x0f, 0x1e));
+        assert_eq!(BRAND_RGB[8], Color::Rgb(0x9b, 0xc3, 0xff));
     }
 
     #[test]
-    fn each_appearance_draws_from_its_own_palette() {
-        assert_eq!(palette_of(Appearance::Dark).text, DARK.text);
-        assert_eq!(palette_of(Appearance::Light).text, LIGHT.text);
-        assert_ne!(DARK.text, LIGHT.text);
-        assert_ne!(DARK.code_bg, LIGHT.code_bg);
-    }
-
-    #[test]
-    fn an_explicit_choice_overrides_the_terminal() {
-        assert_eq!(forced("light"), Some(Appearance::Light));
-        assert_eq!(forced(" DARK "), Some(Appearance::Dark));
-        assert_eq!(forced("auto"), None);
-        assert_eq!(forced(""), None);
+    fn limited_colour_uses_the_terminal_palette() {
+        assert_eq!(brand_rainbow_for(256), &BRAND_ANSI);
+        assert_eq!(brand_rainbow_for(8), &BRAND_ANSI);
+        assert!(
+            BRAND_ANSI
+                .iter()
+                .all(|color| !matches!(color, Color::Rgb(..)))
+        );
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -40,6 +40,7 @@ const SIDE_BY_SIDE_WIDTH: u16 = 108;
 const GRAPH_WIDTH: u16 = 46;
 const MAX_PROMPT_ROWS: usize = 10;
 const MAX_PENDING_STEER_ROWS: usize = 3;
+const HEADER_SEPARATOR: &str = "  ·  ";
 /// Rows of raw tool output rendered when a card is opened.
 const MAX_OUTPUT_ROWS: usize = 400;
 
@@ -58,8 +59,11 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App, images: &mut ImageRuntime) {
         + 2;
     let logs_rows = if app.show_logs { 9 } else { 0 };
     let pending_rows = app.pending_steers.len().min(MAX_PENDING_STEER_ROWS) as u16;
+    let minimum_rows = 1 + 3 + logs_rows + pending_rows + prompt_rows + 1;
+    let rainbow_fits = frame.area().height >= minimum_rows.saturating_add(1);
+    let header_rows = 1 + u16::from(!app.blocks.is_empty() && rainbow_fits);
     let [header, body, logs, pending, prompt, status] = Layout::vertical([
-        Constraint::Length(1),
+        Constraint::Length(header_rows),
         Constraint::Min(3),
         Constraint::Length(logs_rows),
         Constraint::Length(pending_rows),
@@ -283,26 +287,22 @@ fn draw_header(frame: &mut Frame<'_>, app: &App, area: Rect) {
         || app.root.display().to_string(),
         |name| name.to_string_lossy().into_owned(),
     );
+    let version = format!("v{} ", env!("CARGO_PKG_VERSION"));
     let mut spans = vec![
         Span::styled(" kit ", theme::bold(theme::accent_color())),
+        Span::styled(version.clone(), theme::faint()),
         Span::styled("▏ ", theme::faint()),
-        Span::styled(root, theme::text()),
-        Span::styled("  ·  ", theme::faint()),
-        Span::styled(format!("{} / {}", app.provider, app.model), theme::dim()),
-        Span::styled("  ·  ", theme::faint()),
-        Span::styled(format!("effort {}", app.reasoning_effort), theme::dim()),
-        Span::styled("  ·  ", theme::faint()),
-        Span::styled(
-            format!(
-                "session {}",
-                app.session_id.as_deref().unwrap_or("starting")
-            ),
-            theme::dim(),
-        ),
+    ];
+    // Keep complete high-value fields and drop low-priority fields rather than
+    // clipping a session ID or context-window value into something misleading.
+    let mut fields = vec![
+        (2, root, theme::text()),
+        (3, format!("{} / {}", app.provider, app.model), theme::dim()),
+        (1, format!("effort {}", app.reasoning_effort), theme::dim()),
     ];
     if let Some(usage) = app.usage {
-        spans.push(Span::styled("  ·  ", theme::faint()));
-        spans.push(Span::styled(
+        fields.push((
+            4,
             format!(
                 "{} {}/{}",
                 percent(usage.used, usage.size),
@@ -312,9 +312,55 @@ fn draw_header(frame: &mut Frame<'_>, app: &App, area: Rect) {
             theme::dim(),
         ));
     }
-    spans.push(Span::styled("  ·  ", theme::faint()));
-    spans.push(Span::styled(format!("a2a {}", app.a2a), theme::dim()));
-    frame.render_widget(Paragraph::new(Line::from(spans)).style(theme::bar()), area);
+    fields.push((
+        5,
+        format!(
+            "session {}",
+            app.session_id.as_deref().unwrap_or("starting")
+        ),
+        theme::dim(),
+    ));
+    fields.push((0, format!("a2a {}", app.a2a), theme::dim()));
+
+    let prefix_width = Line::from(spans.clone()).width();
+    let header_width = |fields: &[(u8, String, Style)]| {
+        prefix_width
+            + fields
+                .iter()
+                .map(|(_, text, _)| UnicodeWidthStr::width(text.as_str()))
+                .sum::<usize>()
+            + fields.len().saturating_sub(1) * UnicodeWidthStr::width(HEADER_SEPARATOR)
+    };
+    while header_width(&fields) > area.width as usize {
+        let Some(index) = fields
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, (priority, _, _))| *priority)
+            .map(|(index, _)| index)
+        else {
+            break;
+        };
+        fields.remove(index);
+    }
+    for (index, (_, text, style)) in fields.into_iter().enumerate() {
+        if index > 0 {
+            spans.push(Span::styled(HEADER_SEPARATOR, theme::faint()));
+        }
+        spans.push(Span::styled(text, style));
+    }
+    let metadata = Rect { height: 1, ..area };
+    frame.render_widget(
+        Paragraph::new(Line::from(spans)).style(theme::bar()),
+        metadata,
+    );
+    if area.height > 1 {
+        let rainbow = Rect {
+            y: area.y + 1,
+            height: 1,
+            ..area
+        };
+        frame.render_widget(Paragraph::new(rainbow_line(area.width as usize)), rainbow);
+    }
 }
 
 fn draw_body(frame: &mut Frame<'_>, app: &mut App, images: &mut ImageRuntime, area: Rect) {
@@ -525,17 +571,30 @@ fn draw_selection(
     }
 }
 
+fn rainbow_line(width: usize) -> Line<'static> {
+    let colors = theme::brand_rainbow();
+    Line::from(
+        colors
+            .iter()
+            .enumerate()
+            .filter_map(|(index, color)| {
+                let start = index * width / colors.len();
+                let end = (index + 1) * width / colors.len();
+                (end > start)
+                    .then(|| Span::styled("━".repeat(end - start), Style::default().fg(*color)))
+            })
+            .collect::<Vec<_>>(),
+    )
+}
+
 fn welcome() -> Paragraph<'static> {
     let lines = vec![
         Line::default(),
-        Line::from(Span::styled("kit", theme::bold(theme::accent_color()))),
-        Line::from(Span::styled(
-            "a directory-rooted coding agent",
-            theme::dim(),
-        )),
+        Line::from(Span::styled("kit", theme::bold(theme::text_color()))),
+        rainbow_line(27),
         Line::default(),
         Line::from(Span::styled(
-            "ask for a change, a review, or a command to run",
+            "Ask for a change, review, or command.",
             theme::text(),
         )),
         Line::default(),
@@ -549,9 +608,9 @@ fn welcome() -> Paragraph<'static> {
 
 fn hint(left_key: &str, left: &str, right_key: &str, right: &str) -> Line<'static> {
     Line::from(vec![
-        Span::styled(format!("{left_key:>5} "), theme::accent()),
+        Span::styled(format!("{left_key:>5} "), theme::bold(theme::text_color())),
         Span::styled(format!("{left:<18}"), theme::dim()),
-        Span::styled(format!("{right_key:>5} "), theme::accent()),
+        Span::styled(format!("{right_key:>5} "), theme::bold(theme::text_color())),
         Span::styled(right.to_string(), theme::dim()),
     ])
 }
@@ -724,7 +783,7 @@ fn transcript_block_lines(
         Block::Error(text) => (
             uncopyable(plain_lines(vec![Line::from(vec![
                 Span::styled("✗ ", theme::bold(theme::error_color())),
-                Span::styled(text.clone(), Style::default().fg(theme::error_color())),
+                Span::styled(text.clone(), theme::text()),
             ])])),
             None,
         ),
@@ -751,13 +810,18 @@ fn plain_lines(lines: Vec<Line<'static>>) -> Vec<LinkedLine> {
 }
 
 fn user_line(text: &str, first: bool) -> LinkedLine {
-    let style = theme::bold(theme::user_color());
     let mut spans = vec![LinkedSpan {
-        span: Span::styled(if first { "› " } else { "  " }, style),
+        span: Span::styled(
+            if first { "› " } else { "  " },
+            theme::bold(theme::user_color()),
+        ),
         url: None,
     }];
-    spans.extend(markdown::inline_spans(text, style));
-    LinkedLine { spans }
+    spans.extend(markdown::inline_spans(
+        text,
+        theme::bold(theme::text_color()),
+    ));
+    LinkedLine::new(spans).with_leading_gutter()
 }
 
 fn thought_lines(
@@ -1143,7 +1207,7 @@ fn draw_pending_steers(frame: &mut Frame<'_>, app: &App, area: Rect) {
             .join(" ");
         Line::from(vec![
             Span::styled("  › ", theme::bold(theme::user_color())),
-            Span::styled(text, theme::bold(theme::user_color())),
+            Span::styled(text, theme::bold(theme::text_color())),
             Span::styled("  · pending", theme::faint()),
         ])
     }));
@@ -1228,7 +1292,7 @@ fn draw_status(frame: &mut Frame<'_>, app: &App, area: Rect) {
         Phase::Cancelling => vec![
             Span::styled(
                 format!(" {} ", theme::pulse(theme::Pulse::Status, app.tick)),
-                theme::bar(),
+                Style::default().fg(theme::warn_color()),
             ),
             Span::styled("stopping", Style::default().fg(theme::warn_color())),
         ],
@@ -1239,23 +1303,19 @@ fn draw_status(frame: &mut Frame<'_>, app: &App, area: Rect) {
         Phase::Working => vec![
             Span::styled(
                 format!(" {} ", theme::pulse(theme::Pulse::Status, app.tick)),
-                Style::default()
-                    .fg(theme::accent_color())
-                    .bg(theme::bar_bg()),
+                Style::default().fg(theme::accent_color()),
             ),
             Span::styled(
                 format!("working {}", theme::duration(app.elapsed())),
-                Style::default()
-                    .fg(theme::accent_color())
-                    .bg(theme::bar_bg()),
+                Style::default().fg(theme::accent_color()),
             ),
         ],
     };
     if let Some(toast) = app.toast_text() {
-        left.push(Span::styled("  ", theme::bar()));
+        left.push(Span::styled("  ", theme::dim()));
         left.push(Span::styled(
             toast.to_string(),
-            Style::default().fg(theme::warn_color()).bg(theme::bar_bg()),
+            Style::default().fg(theme::warn_color()),
         ));
     }
     let hints = "⏎ send   ⇧⏎ newline   ^g graph   ^l log   ^c quit ";
@@ -1263,8 +1323,8 @@ fn draw_status(frame: &mut Frame<'_>, app: &App, area: Rect) {
     let gap = (area.width as usize)
         .saturating_sub(used + hints.chars().count())
         .max(1);
-    left.push(Span::styled(" ".repeat(gap), theme::bar()));
-    left.push(Span::styled(hints, theme::bar()));
+    left.push(Span::styled(" ".repeat(gap), theme::dim()));
+    left.push(Span::styled(hints, theme::dim()));
     frame.render_widget(Paragraph::new(Line::from(left)).style(theme::bar()), area);
 }
 
@@ -1354,91 +1414,6 @@ mod tests {
                 },
             ]
         );
-    }
-
-    /// `sample()` with every clock stopped.
-    ///
-    /// The contrast comparison renders the transcript twice, once per palette,
-    /// and reads the two frames cell against cell. A duration still counting
-    /// up between the two renders would widen a card's label in one of them
-    /// and shift every cell after it.
-    fn frozen() -> App {
-        use std::time::Duration;
-
-        let mut app = sample();
-        app.turn_started = None;
-        app.tick = 0;
-        app.toast = None;
-        for block in &mut app.blocks {
-            let Block::Tool(call) = block else { continue };
-            call.status = agent_client_protocol::schema::v2::ToolCallStatus::Completed;
-            call.finished = Some(call.started + Duration::from_millis(120));
-            for (index, child) in call.children.iter_mut().enumerate() {
-                child.millis = Some(40 * (index as u64 + 1));
-            }
-        }
-        app
-    }
-
-    /// Every colour the client picks on a light terminal must read at least
-    /// as well as the colour it picks for the same cell on a dark one. A dark
-    /// palette on a light terminal is what makes the transcript vanish: its
-    /// colours all sit a few shades from white.
-    #[test]
-    fn a_light_terminal_reads_as_well_as_a_dark_one() {
-        use ratatui::style::Color;
-
-        use crate::tui::theme::{self, Appearance, contrast};
-
-        // What the terminal itself paints where the client sets no colour.
-        fn ink(appearance: Appearance, paper: Color) -> Vec<(String, f64)> {
-            theme::set(appearance);
-            let mut app = frozen();
-            let mut terminal = Terminal::new(TestBackend::new(100, 40)).expect("terminal");
-            let mut images = crate::tui::image::ImageRuntime::disabled();
-            terminal
-                .draw(|frame| draw(frame, &mut app, &mut images))
-                .expect("draw succeeds");
-            let buffer = terminal.backend().buffer().clone();
-            theme::set(Appearance::Dark);
-            (0..buffer.area.height)
-                .flat_map(|row| (0..buffer.area.width).map(move |column| (column, row)))
-                .map(|cell| {
-                    let cell = &buffer[cell];
-                    let background = match cell.bg {
-                        Color::Reset => paper,
-                        background => background,
-                    };
-                    let contrast = match cell.fg {
-                        _ if cell.symbol().trim().is_empty() => f64::INFINITY,
-                        Color::Reset => f64::INFINITY,
-                        foreground => contrast(foreground, background),
-                    };
-                    (cell.symbol().to_string(), contrast)
-                })
-                .collect()
-        }
-
-        let light = ink(Appearance::Light, Color::Rgb(255, 255, 255));
-        let dark = ink(Appearance::Dark, Color::Rgb(0, 0, 0));
-        assert_eq!(light.len(), dark.len());
-        assert!(
-            light.iter().any(|(_, contrast)| contrast.is_finite()),
-            "the frame draws no colour at all"
-        );
-        // Deliberately quiet chrome — faint text on the status bar — reads low
-        // in either palette, so each cell is held to whichever is weaker: the
-        // legibility floor, or what the dark palette already settled for.
-        for ((symbol, light), (drawn, dark)) in light.into_iter().zip(dark) {
-            // Both frames are drawn from the same stopped clock, so a cell
-            // holding different text means the comparison has slipped.
-            assert_eq!(symbol, drawn, "the two frames drew different text");
-            let wanted = dark.min(4.5);
-            assert!(
-                light + 0.01 >= wanted,
-                "{symbol:?} reads at {light:.2}:1 on a light terminal, short of {wanted:.2}:1"
-            );
-        }
     }
 
     #[test]
@@ -1811,7 +1786,7 @@ mod tests {
         let frame = render(&mut app, 100, 24);
         let row = frame
             .lines()
-            .position(|line| line.contains("  cargo check"))
+            .position(|line| line.contains("│ cargo check"))
             .expect("code row is on screen");
 
         app.handle_mouse(MouseEvent {
@@ -1952,7 +1927,7 @@ mod tests {
         let frame = render(&mut app, 100, 24);
         let row = frame
             .lines()
-            .position(|line| line.contains("  cargo check"))
+            .position(|line| line.contains("│ cargo check"))
             .expect("code row is on screen");
         let line = app.scroll + (row - app.transcript_top);
         app.selection = Some(Selection {
@@ -1960,6 +1935,96 @@ mod tests {
             head: (line, app.transcript_width.saturating_sub(1)),
         });
         assert_eq!(app.selection_text().as_deref(), Some("cargo check"));
+    }
+
+    #[test]
+    fn selection_copy_strips_empty_and_wrapped_code_gutters() {
+        use crate::tui::app::Selection;
+
+        let mut app = App::new(
+            PathBuf::from("/tmp/kit"),
+            "openai-subscription".into(),
+            "gpt-5.4".into(),
+            "0:0".into(),
+        );
+        let code = "one\n\n  abcdefghijklmnopqrstuvwxyz0123456789\ntwo";
+        app.blocks
+            .push(Block::Agent(format!("```text\n{code}\n```")));
+        let frame = render(&mut app, 24, 24);
+        let first = frame
+            .lines()
+            .position(|line| line.contains("│ one"))
+            .expect("first code row is on screen");
+        let closing = frame
+            .lines()
+            .position(|line| line.contains("└─ text"))
+            .expect("closing fence is on screen");
+        app.selection = Some(Selection {
+            anchor: (app.scroll + first - app.transcript_top, 0),
+            head: (
+                app.scroll + closing - app.transcript_top - 1,
+                app.transcript_width.saturating_sub(1),
+            ),
+        });
+
+        assert_eq!(app.selection_text().as_deref(), Some(code));
+    }
+
+    #[test]
+    fn narrow_code_selection_preserves_source_indentation() {
+        use crate::tui::app::Selection;
+
+        let mut app = App::new(
+            PathBuf::from("/tmp/kit"),
+            "openai-subscription".into(),
+            "gpt-5.4".into(),
+            "0:0".into(),
+        );
+        app.blocks.push(Block::Agent("```text\n 界x\n```".into()));
+        let _ = render(&mut app, 5, 24);
+        let rows = &app.transcript_cache[0]
+            .as_ref()
+            .expect("agent block is cached")
+            .rows;
+        let selected = rows
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| row.1.2 == Some(1))
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        app.selection = Some(Selection {
+            anchor: (*selected.first().expect("code has a first row"), 0),
+            head: (
+                *selected.last().expect("code has a last row"),
+                app.transcript_width.saturating_sub(1),
+            ),
+        });
+
+        assert_eq!(app.selection_text().as_deref(), Some(" 界x"));
+    }
+
+    #[test]
+    fn wrapped_prose_selection_preserves_space_before_styled_text() {
+        use crate::tui::app::Selection;
+
+        let mut app = App::new(
+            PathBuf::from("/tmp/kit"),
+            "openai-subscription".into(),
+            "gpt-5.4".into(),
+            "0:0".into(),
+        );
+        app.blocks.push(Block::Agent("hello `x`".into()));
+        let _ = render(&mut app, 9, 24);
+        let rows = &app.transcript_cache[0]
+            .as_ref()
+            .expect("agent block is cached")
+            .rows;
+        app.selection = Some(Selection {
+            anchor: (0, 0),
+            head: (rows.len() - 1, app.transcript_width.saturating_sub(1)),
+        });
+
+        assert_eq!(app.selection_text().as_deref(), Some("hello `x`"));
     }
 
     #[test]
@@ -2041,12 +2106,40 @@ mod tests {
             used: 1_360,
             size: 272_000,
         });
+        app.session_id = Some("s-1770000000000-12345-0".into());
 
         let frame = render(&mut app, 120, 24);
 
+        assert!(frame.contains(concat!("kit v", env!("CARGO_PKG_VERSION"))));
         assert!(frame.contains("openai-subscription / gpt-5.4"));
         assert!(frame.contains("0.5% 1k/272k"));
+        assert!(frame.contains("session s-1770000000000-12345-0"));
+        assert_eq!(frame.lines().nth(1), Some("━".repeat(120).as_str()));
         assert!(!frame.contains("ctx "));
+    }
+
+    #[test]
+    fn header_fitting_uses_terminal_column_width() {
+        let mut app = sample();
+        app.provider = "p".into();
+        app.model = "模型".into();
+        app.session_id = Some("s".into());
+
+        let frame = render(&mut app, 35, 24);
+        let header = frame.lines().next().expect("header row");
+
+        assert!(header.contains("session s"));
+        assert!(!header.contains("p / 模型"));
+    }
+
+    #[test]
+    fn short_terminals_keep_the_prompt_instead_of_the_header_rainbow() {
+        let mut app = sample();
+
+        let frame = render(&mut app, 80, 8);
+
+        assert!(frame.contains("message kit…"));
+        assert_ne!(frame.lines().nth(1), Some("━".repeat(80).as_str()));
     }
 
     #[test]
@@ -2311,6 +2404,8 @@ mod tests {
         );
         let frame = render(&mut app, 90, 24);
         println!("{frame}");
+        assert!(frame.contains("━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
+        assert!(frame.contains("Ask for a change, review, or command."));
         assert!(frame.contains("send"));
         assert!(frame.contains("message kit"));
     }

--- a/src/tui/wrap.rs
+++ b/src/tui/wrap.rs
@@ -20,9 +20,17 @@ pub struct LinkedSpan {
 #[derive(Clone, Debug)]
 pub struct LinkedLine {
     pub spans: Vec<LinkedSpan>,
+    leading_gutter: Option<bool>,
 }
 
 impl LinkedLine {
+    pub fn new(spans: Vec<LinkedSpan>) -> Self {
+        Self {
+            spans,
+            leading_gutter: Some(false),
+        }
+    }
+
     pub fn plain(line: Line<'static>) -> Self {
         Self {
             spans: line
@@ -30,7 +38,13 @@ impl LinkedLine {
                 .into_iter()
                 .map(|span| LinkedSpan { span, url: None })
                 .collect(),
+            leading_gutter: None,
         }
+    }
+
+    pub fn with_leading_gutter(mut self) -> Self {
+        self.leading_gutter = Some(true);
+        self
     }
 
     pub fn line(&self) -> Line<'static> {
@@ -113,7 +127,7 @@ pub fn wrap_linked_tagged<T: Clone>(
 }
 
 fn wrap_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
-    let indent = hanging_indent(line).min(width / 2);
+    let indent = hanging_indent(line, None).min(width / 2);
     let mut lines = Vec::new();
     let mut spans: Vec<Span<'static>> = Vec::new();
     let mut used = 0;
@@ -127,7 +141,7 @@ fn wrap_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
         if blank && spans.is_empty() && !lines.is_empty() {
             continue;
         }
-        if used + chunk_width > width && !spans.is_empty() {
+        if used + chunk_width > width && used > indent {
             lines.push(flush(&mut spans));
             used = 0;
             if blank {
@@ -173,7 +187,7 @@ fn wrap_linked_line(line: &LinkedLine, width: usize) -> Vec<(Vec<LinkedSpan>, St
     if line.width() <= width {
         return vec![(line.spans.clone(), String::new())];
     }
-    let indent = hanging_indent(&line.line()).min(width / 2);
+    let indent = hanging_indent(&line.line(), line.leading_gutter).min(width / 2);
     let mut lines = Vec::new();
     let mut spans = Vec::new();
     let mut separator = String::new();
@@ -186,7 +200,7 @@ fn wrap_linked_line(line: &LinkedLine, width: usize) -> Vec<(Vec<LinkedSpan>, St
             separator.push_str(&chunk);
             continue;
         }
-        if used + chunk_width > width && !spans.is_empty() {
+        if used + chunk_width > width && used > indent {
             let before = std::mem::take(&mut separator);
             let trailing = trim_linked_and_push(&mut lines, &mut spans, before);
             separator.push_str(&trailing);
@@ -290,7 +304,15 @@ fn linked_flush(spans: Vec<LinkedSpan>) -> (Line<'static>, Vec<LinkHit>) {
 
 fn linked_chunks(line: &LinkedLine) -> Vec<(String, Style, Option<String>)> {
     let mut chunks = Vec::new();
-    for linked in &line.spans {
+    for (index, linked) in line.spans.iter().enumerate() {
+        if index == 0 && line.leading_gutter == Some(true) {
+            chunks.push((
+                linked.span.content.to_string(),
+                linked.span.style,
+                linked.url.clone(),
+            ));
+            continue;
+        }
         for (chunk, style) in span_chunks(&linked.span) {
             chunks.push((chunk, style, linked.url.clone()));
         }
@@ -333,19 +355,35 @@ fn span_chunks(span: &Span<'static>) -> Vec<(String, Style)> {
 
 /// Continuation indent: the line's own leading whitespace, plus the width of a
 /// leading gutter span such as `› ` or `✓ ` so wrapped text stays aligned.
-fn hanging_indent(line: &Line<'static>) -> usize {
+fn hanging_indent(line: &Line<'static>, leading_gutter: Option<bool>) -> usize {
     let text: String = line
         .spans
         .iter()
         .map(|span| span.content.as_ref())
         .collect();
-    let leading = text.len() - text.trim_start().len();
-    let gutter = line
-        .spans
-        .first()
-        .filter(|span| span.content.ends_with(' ') && span.content.width() <= 8)
-        .map_or(0, |span| span.content.width());
-    leading.max(gutter)
+    let leading_width = |text: &str| {
+        let end = text.len() - text.trim_start().len();
+        UnicodeWidthStr::width(&text[..end])
+    };
+    let leading = leading_width(&text);
+    let gutter_span = match leading_gutter {
+        Some(true) => line.spans.first(),
+        Some(false) => None,
+        None => line
+            .spans
+            .first()
+            .filter(|span| span.content.ends_with(' ') && span.content.width() <= 8),
+    };
+    let Some(gutter_span) = gutter_span else {
+        return leading;
+    };
+    let gutter = gutter_span.content.width();
+    let content_indent = if gutter_span.content.trim().is_empty() {
+        0
+    } else {
+        leading_width(&text[gutter_span.content.len()..])
+    };
+    leading.max(gutter + content_indent)
 }
 
 #[cfg(test)]
@@ -376,6 +414,38 @@ mod tests {
     fn hangs_continuations_under_the_gutter() {
         let line = Line::from(vec![Span::raw("› "), Span::raw("alpha beta gamma")]);
         assert_eq!(text(&wrap(&[line], 10)), ["› alpha", "  beta", "  gamma"]);
+    }
+
+    #[test]
+    fn preserves_content_indent_after_a_visible_gutter() {
+        let line = Line::from(vec![Span::raw("│ "), Span::raw("  alpha beta")]);
+        assert_eq!(
+            text(&wrap(std::slice::from_ref(&line), 10)),
+            ["│   alpha", "    beta"]
+        );
+
+        let linked = wrap_linked_tagged(&[(LinkedLine::plain(line).with_leading_gutter(), ())], 10);
+        let linked_lines = linked
+            .into_iter()
+            .map(|(line, (), _, _)| line)
+            .collect::<Vec<_>>();
+        assert_eq!(text(&linked_lines), ["│   alpha", "    beta"]);
+    }
+
+    #[test]
+    fn fills_the_first_row_before_splitting_an_oversized_first_token() {
+        let line = Line::from(vec![Span::raw("│ "), Span::raw("  abcdefghijk")]);
+        assert_eq!(
+            text(&wrap(std::slice::from_ref(&line), 10)),
+            ["│   abcdef", "    ghijk"]
+        );
+
+        let linked = wrap_linked_tagged(&[(LinkedLine::plain(line).with_leading_gutter(), ())], 10);
+        let linked_lines = linked
+            .into_iter()
+            .map(|(line, (), _, _)| line)
+            .collect::<Vec<_>>();
+        assert_eq!(text(&linked_lines), ["│   abcdef", "    ghijk"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Refresh Kit's terminal client with terminal-native styling, Speakeasy brand accents, responsive metadata, and copy-safe wrapped Markdown. Clarify that `--root` selects Kit's working directory and project context rather than a filesystem boundary, and bump release metadata to 0.1.100.

## Motivation

The previous TUI probed terminal backgrounds and maintained separate palettes, while "runtime root" wording could imply sandboxing that Kit does not enforce.

## Impact

The TUI now inherits configured terminal colors, uses ANSI functional accents with a true-color brand ramp where supported, and preserves prompt and selection behavior across narrow layouts. CLI diagnostics and customer documentation now consistently describe working-directory semantics.

## Technical details

### Terminal-native presentation

Removes background probing and custom light/dark palettes. Functional styles use terminal defaults and ANSI roles; decorative brand rainbows select true color only when advertised.

### Responsive wrapping and selection

Sizes header fields by display columns, suppresses decorative rows when vertical space is constrained, and carries explicit gutter metadata so wrapped code and styled prose copy exactly.

### Project context terminology

Updates runtime prompts, ACP diagnostics, tool descriptions, CLI help, container metadata, and docs to distinguish project context from filesystem isolation.
