### PR TITLE
fix(tui): restore start screen for new sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.101"
+version = "0.1.102"
 dependencies = [
  "a2a-protocol-client",
  "a2a-protocol-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.1.101"
+version = "0.1.102"
 edition = "2024"
 rust-version = "1.94.0"
 publish = false

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1646,6 +1646,8 @@ impl App {
         self.pending_steers.clear();
         self.compacting = false;
         self.usage = None;
+        self.show_logs = false;
+        self.graph_pinned = None;
         self.scroll = usize::MAX;
         self.follow = true;
         self.focused_call_id = None;
@@ -3278,16 +3280,20 @@ mod tests {
     }
 
     #[test]
-    fn switching_sessions_clears_only_transcript_derived_state() {
+    fn switching_sessions_restores_the_initial_view_but_retains_diagnostics() {
         let mut app = app();
         app.blocks
             .push(Block::User("old transcript".to_string().into()));
         app.logs.push("diagnostic".into());
+        app.show_logs = true;
+        app.graph_pinned = Some(true);
         app.usage = Some(super::ContextUsage { used: 1, size: 2 });
         app.start_session("fresh".into());
         assert_eq!(app.session_id.as_deref(), Some("fresh"));
         assert!(app.blocks.is_empty());
         assert!(app.usage.is_none());
+        assert!(!app.show_logs);
+        assert_eq!(app.graph_pinned, None);
         assert_eq!(app.logs, ["diagnostic"]);
     }
 


### PR DESCRIPTION
## Summary

Reset transient log and runtime graph visibility when the TUI switches sessions so an empty session created by `/new` renders the branded start screen. Preserve collected diagnostics for later inspection and bump the patch version to 0.1.102.

## Motivation

A graph pinned open in the previous session remained visible after `/new`, leaving the fresh session as an empty transcript beside a graph with no tool calls instead of returning to the initial prompt screen.

## Impact

Session transitions now close the log panel and return graph visibility to its automatic state. Transcript state continues to reset, while diagnostic log contents remain available if the panel is reopened.