### PR TITLE
feat(tui): render live compose scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.106"
+version = "0.1.107"
 dependencies = [
  "a2a-protocol-client",
  "a2a-protocol-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.1.106"
+version = "0.1.107"
 edition = "2024"
 rust-version = "1.94.0"
 publish = false

--- a/README.md
+++ b/README.md
@@ -427,8 +427,8 @@ The delay must be an integer from 1 through 86,400 seconds.
 Press `Command+B` in the TUI to move the newest running foreground top-level
 compose call into the background. This shortcut requires a terminal that reports
 the Command key through the Kitty keyboard protocol; there is no control-key equivalent. Detached calls
-remain visible and selectable in the TUI runtime graph. Interrupting the originating
-turn does not stop them. The model receives each detached call's ID
+remain visible in the TUI transcript with their annotated Runlet source. Interrupting
+the originating turn does not stop them. The model receives each detached call's ID
 and can cancel it with `close({ call_id: "call_..." })`; the selected running
 background call can also be killed with `Ctrl+K` in the TUI. Completion and
 cancellation are delivered through the normal background-result lifecycle. Detached
@@ -573,14 +573,16 @@ require a Developer ID Application certificate.
 `tui` starts a `kit serve` child and drives it over ACP, so the client sees the
 same protocol any editor would.
 
-While a `compose` call runs, the right-hand pane draws its runtime graph: the
-Runlet program parsed into its call, loop, branch, and boundary structure, with
-each nested shell, edit, subagent, prompt, fork, subagents, close, A2A, and MCP meta-tool dispatch shown live under the node
-that most likely issued it, including concurrent fan-out and failures. Child
-call lifecycle is exact; when the same tool appears in several places, node
-attribution is a stable heuristic. Nested-call
-lifecycle reaches the client on stderr as marked JSON lines, enabled for the
-child process with `KIT_RUNTIME_EVENTS=1`; other ACP hosts never see them.
+While a `compose` call runs, its Runlet source appears directly in the transcript.
+Calls are colored and annotated as idle, running, successful, or failed; bindings
+show whether their value is waiting or resolved; and loops and retry boundaries
+show live iteration and attempt counts. On completion, the source is replaced by
+the compose output. Unless the user explicitly opened or closed it, that output
+collapses automatically when a later tool call or model message arrives. It can
+still be reopened from its card. Nested child lifecycle is exact; when the same tool appears
+in several source locations, source attribution is a stable heuristic. The child
+events reach the TUI on stderr as marked JSON lines, enabled for the child process
+with `KIT_RUNTIME_EVENTS=1`; other ACP hosts never see them.
 
 | Key | Action |
 | --- | --- |
@@ -600,7 +602,7 @@ child process with `KIT_RUNTIME_EVENTS=1`; other ACP hosts never see them.
 | `⌘⌫`, `^u` / `^k` | delete to line start / end |
 | `↑`/`↓` | move between prompt lines, then browse history |
 | `⇧↑`/`⇧↓`, `pgup`/`pgdn`, wheel | scroll the transcript |
-| `^g` / `^l` / `^t` | runtime graph / agent log / reasoning |
+| `^l` / `^t` | agent log / reasoning |
 | click a tool card, `^o` | fold its raw output open or shut |
 
 `⌘` and `⇧⏎` need a terminal that speaks the Kitty keyboard protocol (Ghostty,

--- a/docs/user/compose-and-local-tools.md
+++ b/docs/user/compose-and-local-tools.md
@@ -32,7 +32,7 @@ Retries repeat the body. Do not retry a write unless repeating it is safe or the
 
 Background calls no longer hold their originating turn open, and interrupting that turn does not stop them. When a call detaches, the model receives its tool-call ID and can stop it with `close({ call_id: "call_..." })`. Cancellation is delivered through the same result lifecycle as completion, as a failed result reporting that tool execution was cancelled.
 
-The TUI keeps every running call visible; select a tool card to inspect its runtime graph. Completion or failure is delivered back to the owning session and wakes the session loop directly without inserting synthetic user content. Background work is process- and session-scoped rather than a durable operating-system job, so closing Kit ends its inspectable lifetime.
+The TUI keeps every running call visible. A running compose card shows its Runlet source inline, with live call states, binding resolution, and loop or retry counts. Completion replaces the source with the compose output. Unless the user explicitly opened or closed it, the output collapses when a later tool call or model message arrives and remains available from the tool card. Completion or failure is delivered back to the owning session and wakes the session loop directly without inserting synthetic user content. Background work is process- and session-scoped rather than a durable operating-system job, so closing Kit ends its inspectable lifetime.
 
 ## Ordering, dependencies, and concurrency
 

--- a/docs/user/tui-and-sessions.md
+++ b/docs/user/tui-and-sessions.md
@@ -37,7 +37,7 @@ A session ID must be 1–128 ASCII letters, digits, `-`, or `_`. `kit prompt` us
 | `Up` / `Down` | Move through prompt lines, then prompt history |
 | `Shift+Up` / `Shift+Down`, `PageUp` / `PageDown`, mouse wheel | Scroll the transcript |
 | `Ctrl+Home` / `Ctrl+End` | Jump to transcript top / bottom |
-| `Ctrl+G` / `Ctrl+L` / `Ctrl+T` | Toggle the runtime graph / agent log / reasoning |
+| `Ctrl+L` / `Ctrl+T` | Toggle the agent log / reasoning |
 | `Ctrl+K` | Kill the selected running background tool call; otherwise delete to the end of the editor line |
 | `Ctrl+O`, or click a tool card | Fold or unfold raw tool output |
 | `Ctrl+Y` | Copy the latest agent response as original Markdown |

--- a/src/acp_child.rs
+++ b/src/acp_child.rs
@@ -683,6 +683,20 @@ struct RunConfig {
     context: LaunchContext,
 }
 
+/// Keeps a nested harness's private runtime events out of the parent runtime.
+fn harness_diagnostic(label: &str, line: &str) -> Option<String> {
+    if matches!(
+        crate::events::parse(line),
+        Some(
+            crate::events::RuntimeEvent::ChildStarted { .. }
+                | crate::events::RuntimeEvent::ChildFinished { .. }
+        )
+    ) {
+        return None;
+    }
+    Some(format!("ACP harness {label}: {line}"))
+}
+
 async fn run(
     run_config: RunConfig,
     rx: &mut mpsc::Receiver<Request>,
@@ -728,18 +742,8 @@ async fn run(
     tokio::spawn(async move {
         let mut lines = BufReader::new(stderr).lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            if matches!(
-                crate::events::parse(&line),
-                Some(
-                    crate::events::RuntimeEvent::ChildStarted { .. }
-                        | crate::events::RuntimeEvent::ChildFinished { .. }
-                )
-            ) {
-                // Only nested tool events belong to this process's live script state.
-                // A harness's compaction changes its own transcript, not ours.
+            if let Some(line) = harness_diagnostic(&label, &line) {
                 eprintln!("{line}");
-            } else {
-                eprintln!("ACP harness {label}: {line}");
             }
         }
     });
@@ -1053,6 +1057,27 @@ mod tests {
 
     fn update(value: Value) -> SessionUpdate {
         serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn nested_runtime_events_are_not_forwarded_as_parent_events() {
+        let event = crate::events::RuntimeEvent::ChildStarted {
+            call: "subagent-call:compose:shell".into(),
+            tool: "shell".into(),
+            summary: "inspect".into(),
+            at: 0,
+        };
+        let line = format!(
+            "{}{}",
+            crate::events::EVENT_MARKER,
+            serde_json::to_string(&event).unwrap()
+        );
+
+        assert_eq!(harness_diagnostic("kit", &line), None);
+        assert_eq!(
+            harness_diagnostic("kit", "ordinary diagnostic").as_deref(),
+            Some("ACP harness kit: ordinary diagnostic")
+        );
     }
 
     #[test]

--- a/src/acp_child.rs
+++ b/src/acp_child.rs
@@ -735,7 +735,7 @@ async fn run(
                         | crate::events::RuntimeEvent::ChildFinished { .. }
                 )
             ) {
-                // Only nested tool events belong to this process's runtime graph.
+                // Only nested tool events belong to this process's live script state.
                 // A harness's compaction changes its own transcript, not ours.
                 eprintln!("{line}");
             } else {

--- a/src/events.rs
+++ b/src/events.rs
@@ -4,13 +4,13 @@
 //! ACP reports the model-visible `compose` call, but every interesting thing
 //! Kit does happens *inside* that call: the Runlet program dispatches shell,
 //! edit, subagent, and A2A children concurrently. The terminal client renders
-//! that as a live runtime graph, so it needs the child lifecycle.
+//! that as inline live script state, so it needs the child lifecycle.
 //!
 //! Rather than fork the ACP surface, the events ride on stderr — Kit's
 //! diagnostics channel — as single JSON lines behind a control-character
 //! marker. The terminal client owns the `serve` child process and pipes its
-//! stderr, so marked lines become graph updates and everything else becomes
-//! log output. Emission is opt-in through `KIT_RUNTIME_EVENTS` so ordinary
+//! stderr, so marked lines become script-state updates and everything else
+//! becomes log output. Emission is opt-in through `KIT_RUNTIME_EVENTS` so ordinary
 //! ACP hosts never see the extra chatter.
 
 use std::{

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,4 +1,4 @@
-//! Client state: the transcript, the live runtime graph, and key handling.
+//! Client state: the transcript, live tool activity, and key handling.
 
 use std::{
     cmp::Reverse,
@@ -295,11 +295,15 @@ pub struct ToolCall {
     pub status: ToolCallStatus,
     pub started: Instant,
     pub finished: Option<Instant>,
+    /// Runlet source shown inline while this compose call is running.
+    pub script: String,
     pub plan: Vec<PlanNode>,
     pub children: Vec<Child>,
     /// Raw tool output, kept whole but folded away until asked for.
     pub output: Vec<String>,
     pub expanded: bool,
+    /// The user explicitly chose the output's expanded or collapsed state.
+    pub expansion_explicit: bool,
     /// The call detached from its originating turn.
     pub backgrounded: bool,
 }
@@ -524,9 +528,7 @@ pub struct App {
     pub logs: Vec<String>,
     pub show_logs: bool,
     pub show_thoughts: bool,
-    /// `None` shows the graph while a tool runs; `Some` pins it open or shut.
-    pub graph_pinned: Option<bool>,
-    /// Tool card selected for the runtime graph.
+    /// Tool card selected for output toggling or background cancellation.
     pub focused_call_id: Option<String>,
     pub tick: usize,
     pub scroll: usize,
@@ -791,7 +793,6 @@ impl App {
             logs: Vec::new(),
             show_logs: false,
             show_thoughts: false,
-            graph_pinned: None,
             focused_call_id: None,
             tick: 0,
             scroll: 0,
@@ -816,7 +817,25 @@ impl App {
         self.phase != Phase::Idle
     }
 
+    fn collapse_last_tool_output(&mut self) {
+        let previous = self.blocks.len().checked_sub(1).filter(|&index| {
+            matches!(
+                &self.blocks[index],
+                Block::Tool(call) if call.expanded && !call.expansion_explicit
+            )
+        });
+        if let Some(index) = previous {
+            if let Block::Tool(call) = &mut self.blocks[index] {
+                call.expanded = false;
+            }
+            self.mark_block_dirty(index);
+        }
+    }
+
     fn push_block(&mut self, block: Block) {
+        if !matches!(block, Block::TurnDuration(_)) {
+            self.collapse_last_tool_output();
+        }
         let index = self.blocks.len();
         let thought = matches!(block, Block::Thought { .. });
         let dynamic = Self::block_is_dynamic(&block);
@@ -843,6 +862,14 @@ impl App {
         {
             self.set_focus_index(Some(index));
         }
+    }
+
+    fn call_is_latest_message(&self, id: &str) -> bool {
+        self.call_index(id).is_some_and(|index| {
+            self.blocks[index + 1..]
+                .iter()
+                .all(|block| matches!(block, Block::TurnDuration(_)))
+        })
     }
 
     fn block_is_dynamic(block: &Block) -> bool {
@@ -1039,6 +1066,12 @@ impl App {
                                 status: ToolCallStatus::Completed,
                                 started: Instant::now(),
                                 finished: Some(Instant::now()),
+                                script: call
+                                    .input
+                                    .get("script")
+                                    .and_then(serde_json::Value::as_str)
+                                    .unwrap_or_default()
+                                    .to_string(),
                                 plan: call
                                     .input
                                     .get("script")
@@ -1047,7 +1080,8 @@ impl App {
                                     .unwrap_or_default(),
                                 children: Vec::new(),
                                 output: Vec::new(),
-                                expanded: false,
+                                expanded: call.name == agentkit_tool_compose::COMPOSE_TOOL_NAME,
+                                expansion_explicit: false,
                                 backgrounded: false,
                             })),
                             _ => {}
@@ -1116,13 +1150,6 @@ impl App {
         })
     }
 
-    pub fn show_graph(&self) -> bool {
-        match self.graph_pinned {
-            Some(pinned) => pinned,
-            None => self.focus_call().is_some_and(ToolCall::running),
-        }
-    }
-
     pub fn elapsed(&self) -> u64 {
         self.turn_started.map_or(0, |started| {
             u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
@@ -1154,6 +1181,9 @@ impl App {
         append: bool,
         role: MessageRole,
     ) {
+        if !text.is_empty() || !images.is_empty() {
+            self.collapse_last_tool_output();
+        }
         let mut images = images;
         let existing_index = self.message_blocks.get(&id).copied();
         if !append
@@ -1395,6 +1425,7 @@ impl App {
             } => {
                 self.close_thought();
                 self.prepare_focused_call(id.clone());
+                let expanded = title == agentkit_tool_compose::COMPOSE_TOOL_NAME;
                 self.push_block(Block::Tool(ToolCall {
                     id,
                     title,
@@ -1403,9 +1434,11 @@ impl App {
                     started: Instant::now(),
                     finished: None,
                     plan: script.as_deref().map(parse_plan).unwrap_or_default(),
+                    script: script.unwrap_or_default(),
                     children: Vec::new(),
                     output: Vec::new(),
-                    expanded: false,
+                    expanded,
+                    expansion_explicit: false,
                     backgrounded,
                 }));
             }
@@ -1417,6 +1450,7 @@ impl App {
                 output,
                 backgrounded,
             } => {
+                let expand_compose = self.call_is_latest_message(&id);
                 let completed_background = {
                     let Some(call) = self.call_mut(&id) else {
                         return;
@@ -1424,6 +1458,7 @@ impl App {
                     let was_running = call.running();
                     if let Some(script) = script {
                         call.plan = parse_plan(&script);
+                        call.script = script;
                     }
                     if !output.is_empty() {
                         call.output = output;
@@ -1432,6 +1467,11 @@ impl App {
                     if let Some(status) = status {
                         call.status = status;
                         if !call.running() {
+                            if call.title == agentkit_tool_compose::COMPOSE_TOOL_NAME
+                                && !call.expansion_explicit
+                            {
+                                call.expanded = expand_compose;
+                            }
                             call.finished = Some(Instant::now());
                             call.finish_running_children();
                         }
@@ -1465,10 +1505,17 @@ impl App {
                         backgrounded,
                     });
                 }
+                let expand_compose = self.call_is_latest_message(&id);
                 let Some(call) = self.call_mut(&id) else {
                     return;
                 };
                 if let Some(title) = title {
+                    if title == agentkit_tool_compose::COMPOSE_TOOL_NAME
+                        && call.title != agentkit_tool_compose::COMPOSE_TOOL_NAME
+                        && !call.expansion_explicit
+                    {
+                        call.expanded = true;
+                    }
                     call.title = title;
                 }
                 if let Some(kind) = kind {
@@ -1476,6 +1523,7 @@ impl App {
                 }
                 if let Some(script) = script {
                     call.plan = parse_plan(&script);
+                    call.script = script;
                 }
                 if let Some(output) = output {
                     if append_output {
@@ -1489,6 +1537,11 @@ impl App {
                 if let Some(status) = status {
                     call.status = status;
                     if !call.running() {
+                        if call.title == agentkit_tool_compose::COMPOSE_TOOL_NAME
+                            && !call.expansion_explicit
+                        {
+                            call.expanded = expand_compose;
+                        }
                         call.finished = Some(Instant::now());
                         call.finish_running_children();
                     }
@@ -1668,7 +1721,6 @@ impl App {
         self.compacting = false;
         self.usage = None;
         self.show_logs = false;
-        self.graph_pinned = None;
         self.scroll = usize::MAX;
         self.follow = true;
         self.focused_call_id = None;
@@ -1705,6 +1757,10 @@ impl App {
     pub fn toggle_output(&mut self, id: &str) {
         if let Some(call) = self.call_mut(id) {
             call.expanded = !call.expanded;
+            call.expansion_explicit = true;
+        }
+        if let Some(index) = self.call_index(id) {
+            self.mark_block_dirty(index);
         }
     }
 
@@ -2176,9 +2232,6 @@ impl App {
             KeyCode::Char('f') if alt => self.editor.move_word_right(),
             KeyCode::Char('a') if control => self.editor.move_line_start(),
             KeyCode::Char('e') if control => self.editor.move_line_end(),
-            KeyCode::Char('g') if control => {
-                self.graph_pinned = Some(!self.show_graph());
-            }
             KeyCode::Char('l') if control => self.show_logs = !self.show_logs,
             KeyCode::Char('o') if control => self.toggle_last_output(),
             KeyCode::Char('t') if control => self.toggle_thoughts(),
@@ -2340,7 +2393,6 @@ impl App {
         }
         if let Some(Some(id)) = self.row_calls.get(offset).cloned() {
             self.focus_call_by_id(id.clone());
-            self.graph_pinned = Some(true);
             self.toggle_output(&id);
         }
         Action::None
@@ -3071,8 +3123,6 @@ mod tests {
             script: Some("return 1".into()),
             backgrounded: true,
         });
-        app.graph_pinned = Some(false);
-
         let action = app.handle_key(modified_press(KeyCode::Char('k'), KeyModifiers::CONTROL));
 
         assert!(matches!(
@@ -3341,14 +3391,12 @@ mod tests {
             .push(Block::User("old transcript".to_string().into()));
         app.logs.push("diagnostic".into());
         app.show_logs = true;
-        app.graph_pinned = Some(true);
         app.usage = Some(super::ContextUsage { used: 1, size: 2 });
         app.start_session("fresh".into());
         assert_eq!(app.session_id.as_deref(), Some("fresh"));
         assert!(app.blocks.is_empty());
         assert!(app.usage.is_none());
         assert!(!app.show_logs);
-        assert_eq!(app.graph_pinned, None);
         assert_eq!(app.logs, ["diagnostic"]);
     }
 

--- a/src/tui/plan.rs
+++ b/src/tui/plan.rs
@@ -15,15 +15,23 @@ pub struct PlanNode {
     pub depth: usize,
     pub kind: PlanKind,
     pub label: String,
+    /// Zero-based source line containing this node.
+    #[allow(dead_code)]
+    pub source_line: usize,
+    /// Variable introduced by this node, when it represents a binding.
+    #[allow(dead_code)]
+    pub binding: Option<String>,
     /// Host tool this node dispatches, when it calls one.
     pub tool: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlanKind {
+    Binding,
     Call,
     Loop,
     Fold,
+    After,
     Branch,
     Boundary,
     Return,
@@ -33,9 +41,11 @@ impl PlanKind {
     /// Glyph that marks the node's role in the program.
     pub const fn glyph(self) -> &'static str {
         match self {
+            Self::Binding => "=",
             Self::Call => "◆",
             Self::Loop => "⇉",
             Self::Fold => "∑",
+            Self::After => "→",
             Self::Branch => "◇",
             Self::Boundary => "⟳",
             Self::Return => "▸",
@@ -51,33 +61,45 @@ pub fn parse(script: &str) -> Vec<PlanNode> {
     };
     let mut nodes = Vec::new();
     for statement in &program.statements {
-        statement_nodes(statement, 0, &mut nodes);
+        statement_nodes(statement, 0, script, &mut nodes);
     }
-    if !expression(&program.result, 0, "return ", &mut nodes) {
+    if !expression(&program.result, 0, "return ", None, script, &mut nodes) {
         nodes.push(PlanNode {
             depth: 0,
             kind: PlanKind::Return,
             label: format!("return {}", summary(&program.result)),
+            source_line: source_line(script, program.result.span.start),
+            binding: None,
             tool: None,
         });
     }
     nodes
 }
 
-fn statement_nodes(statement: &Stmt, depth: usize, nodes: &mut Vec<PlanNode>) {
+fn statement_nodes(statement: &Stmt, depth: usize, script: &str, nodes: &mut Vec<PlanNode>) {
     match &statement.kind {
         StmtKind::Binding { name, value } => {
-            expression(value, depth, &format!("{name} = "), nodes);
+            let binding = (name != "_").then_some(name.as_str());
+            if !expression(value, depth, &format!("{name} = "), binding, script, nodes) {
+                nodes.push(PlanNode {
+                    depth,
+                    kind: PlanKind::Binding,
+                    label: format!("{name} = {}", summary(value)),
+                    source_line: source_line(script, statement.span.start),
+                    binding: binding.map(str::to_owned),
+                    tool: None,
+                });
+            }
         }
         StmtKind::Skip { condition } => {
             if let Some(condition) = condition {
-                expression(condition, depth, "", nodes);
+                expression(condition, depth, "", None, script, nodes);
             }
         }
         StmtKind::Assert { condition, message } => {
-            expression(condition, depth, "", nodes);
+            expression(condition, depth, "", None, script, nodes);
             if let Some(message) = message {
-                expression(message, depth, "", nodes);
+                expression(message, depth, "", None, script, nodes);
             }
         }
     }
@@ -85,42 +107,57 @@ fn statement_nodes(statement: &Stmt, depth: usize, nodes: &mut Vec<PlanNode>) {
 
 /// Emits nodes for the runtime-visible parts of `expr`.
 ///
-/// Returns whether anything was emitted: a binding whose value is pure
-/// arithmetic has no graph presence and is left out of the tree entirely.
-fn expression(expr: &Expr, depth: usize, prefix: &str, nodes: &mut Vec<PlanNode>) -> bool {
+/// Returns whether anything was emitted so a pure binding can add its own node.
+fn expression(
+    expr: &Expr,
+    depth: usize,
+    prefix: &str,
+    binding: Option<&str>,
+    script: &str,
+    nodes: &mut Vec<PlanNode>,
+) -> bool {
     match &expr.kind {
         ExprKind::Call { callee, arguments } => {
             let tool = callee_name(callee);
+            if is_intrinsic(&tool) {
+                return arguments.iter().fold(false, |emitted, argument| {
+                    expression(argument, depth, prefix, binding, script, nodes) || emitted
+                });
+            }
             nodes.push(PlanNode {
                 depth,
                 kind: PlanKind::Call,
                 label: format!("{prefix}{tool}({})", arguments_summary(arguments)),
+                source_line: source_line(script, expr.span.start),
+                binding: binding.map(str::to_owned),
                 tool: Some(tool),
             });
             for argument in arguments {
-                expression(argument, depth + 1, "", nodes);
+                expression(argument, depth + 1, "", None, script, nodes);
             }
             true
         }
         ExprKind::For {
-            binding,
+            binding: item_binding,
             collection,
             body,
         } => {
             nodes.push(PlanNode {
                 depth,
                 kind: PlanKind::Loop,
-                label: format!("{prefix}for {binding} in {}", summary(collection)),
+                label: format!("{prefix}for {item_binding} in {}", summary(collection)),
+                source_line: source_line(script, expr.span.start),
+                binding: binding.map(str::to_owned),
                 tool: None,
             });
-            expression(collection, depth + 1, "", nodes);
-            block(body, depth + 1, nodes);
+            expression(collection, depth + 1, "", None, script, nodes);
+            block(body, depth + 1, script, nodes);
             true
         }
         ExprKind::Fold {
             accumulator,
             init,
-            binding,
+            binding: item_binding,
             collection,
             body,
         } => {
@@ -128,14 +165,30 @@ fn expression(expr: &Expr, depth: usize, prefix: &str, nodes: &mut Vec<PlanNode>
                 depth,
                 kind: PlanKind::Fold,
                 label: format!(
-                    "{prefix}fold {accumulator} = {} for {binding} in {}",
+                    "{prefix}fold {accumulator} = {} for {item_binding} in {}",
                     summary(init),
                     summary(collection)
                 ),
+                source_line: source_line(script, expr.span.start),
+                binding: binding.map(str::to_owned),
                 tool: None,
             });
-            expression(collection, depth + 1, "", nodes);
-            block(body, depth + 1, nodes);
+            expression(init, depth + 1, "", None, script, nodes);
+            expression(collection, depth + 1, "", None, script, nodes);
+            block(body, depth + 1, script, nodes);
+            true
+        }
+        ExprKind::After { prerequisite, body } => {
+            nodes.push(PlanNode {
+                depth,
+                kind: PlanKind::After,
+                label: format!("{prefix}after {}", summary(prerequisite)),
+                source_line: source_line(script, expr.span.start),
+                binding: binding.map(str::to_owned),
+                tool: None,
+            });
+            expression(prerequisite, depth + 1, "", None, script, nodes);
+            block(body, depth + 1, script, nodes);
             true
         }
         ExprKind::Boundary {
@@ -148,16 +201,20 @@ fn expression(expr: &Expr, depth: usize, prefix: &str, nodes: &mut Vec<PlanNode>
                 depth,
                 kind: PlanKind::Boundary,
                 label: format!("{prefix}boundary retry {retries}"),
+                source_line: source_line(script, expr.span.start),
+                binding: binding.map(str::to_owned),
                 tool: None,
             });
-            block(body, depth + 1, nodes);
+            block(body, depth + 1, script, nodes);
             let mut fallback = Vec::new();
-            block(catch, depth + 2, &mut fallback);
+            block(catch, depth + 2, script, &mut fallback);
             if !fallback.is_empty() {
                 nodes.push(PlanNode {
                     depth: depth + 1,
                     kind: PlanKind::Branch,
                     label: format!("catch {error_binding}"),
+                    source_line: source_line(script, catch.span.start),
+                    binding: None,
                     tool: None,
                 });
                 nodes.append(&mut fallback);
@@ -173,18 +230,22 @@ fn expression(expr: &Expr, depth: usize, prefix: &str, nodes: &mut Vec<PlanNode>
                 depth,
                 kind: PlanKind::Branch,
                 label: format!("{prefix}if {}", summary(condition)),
+                source_line: source_line(script, expr.span.start),
+                binding: binding.map(str::to_owned),
                 tool: None,
             });
-            expression(condition, depth + 1, "", nodes);
-            block(then_block, depth + 1, nodes);
+            expression(condition, depth + 1, "", None, script, nodes);
+            block(then_block, depth + 1, script, nodes);
             if let Some(else_block) = else_block {
                 let mut alternative = Vec::new();
-                block(else_block, depth + 2, &mut alternative);
+                block(else_block, depth + 2, script, &mut alternative);
                 if !alternative.is_empty() {
                     nodes.push(PlanNode {
                         depth: depth + 1,
                         kind: PlanKind::Branch,
                         label: "else".into(),
+                        source_line: source_line(script, else_block.span.start),
+                        binding: None,
                         tool: None,
                     });
                     nodes.append(&mut alternative);
@@ -199,40 +260,58 @@ fn expression(expr: &Expr, depth: usize, prefix: &str, nodes: &mut Vec<PlanNode>
         } => [then_expr, condition, else_expr]
             .into_iter()
             .fold(false, |emitted, part| {
-                expression(part, depth, prefix, nodes) || emitted
+                expression(part, depth, prefix, binding, script, nodes) || emitted
             }),
         ExprKind::List(items) => items.iter().fold(false, |emitted, item| {
-            expression(item, depth, prefix, nodes) || emitted
+            expression(item, depth, prefix, binding, script, nodes) || emitted
         }),
         ExprKind::Object(entries) => entries.iter().fold(false, |emitted, (key, value)| {
             let key_emitted = match key {
-                ObjectKey::Computed(expr) => expression(expr, depth, prefix, nodes),
+                ObjectKey::Computed(expr) => {
+                    expression(expr, depth, prefix, binding, script, nodes)
+                }
                 ObjectKey::Static(_) => false,
             };
-            expression(value, depth, prefix, nodes) || key_emitted || emitted
+            expression(value, depth, prefix, binding, script, nodes) || key_emitted || emitted
         }),
-        ExprKind::Member { target, .. } => expression(target, depth, prefix, nodes),
-        ExprKind::Index { target, index } => {
-            let target_emitted = expression(target, depth, prefix, nodes);
-            expression(index, depth, prefix, nodes) || target_emitted
+        ExprKind::Member { target, .. } => {
+            expression(target, depth, prefix, binding, script, nodes)
         }
-        ExprKind::Unary { value, .. } => expression(value, depth, prefix, nodes),
+        ExprKind::Index { target, index } => {
+            let target_emitted = expression(target, depth, prefix, binding, script, nodes);
+            expression(index, depth, prefix, binding, script, nodes) || target_emitted
+        }
+        ExprKind::Unary { value, .. } => expression(value, depth, prefix, binding, script, nodes),
         ExprKind::Binary { left, right, .. } => {
-            let left_emitted = expression(left, depth, prefix, nodes);
-            expression(right, depth, prefix, nodes) || left_emitted
+            let left_emitted = expression(left, depth, prefix, binding, script, nodes);
+            expression(right, depth, prefix, binding, script, nodes) || left_emitted
         }
         ExprKind::Fail { arguments } => arguments.iter().fold(false, |emitted, argument| {
-            expression(argument, depth, prefix, nodes) || emitted
+            expression(argument, depth, prefix, binding, script, nodes) || emitted
         }),
         _ => false,
     }
 }
 
-fn block(body: &Block, depth: usize, nodes: &mut Vec<PlanNode>) {
+fn block(body: &Block, depth: usize, script: &str, nodes: &mut Vec<PlanNode>) {
     for statement in &body.statements {
-        statement_nodes(statement, depth, nodes);
+        statement_nodes(statement, depth, script, nodes);
     }
-    expression(&body.result, depth, "", nodes);
+    expression(&body.result, depth, "", None, script, nodes);
+}
+
+fn source_line(script: &str, byte_offset: usize) -> usize {
+    script.as_bytes()[..byte_offset.min(script.len())]
+        .iter()
+        .filter(|&&byte| byte == b'\n')
+        .count()
+}
+
+fn is_intrinsic(name: &str) -> bool {
+    matches!(
+        name.split('.').next(),
+        Some("text" | "regex" | "list" | "json" | "number" | "time")
+    )
 }
 
 fn callee_name(callee: &Expr) -> String {
@@ -327,10 +406,84 @@ mod tests {
     }
 
     #[test]
-    fn leaves_out_bindings_with_no_runtime_work() {
+    fn includes_pure_bindings_with_variable_metadata() {
         let nodes = parse("total = 1 + 2\nreturn total");
-        assert_eq!(nodes.len(), 1);
-        assert_eq!(nodes[0].kind, PlanKind::Return);
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].kind, PlanKind::Binding);
+        assert_eq!(nodes[0].label, "total = 1 … 2");
+        assert_eq!(nodes[0].binding.as_deref(), Some("total"));
+        assert_eq!(nodes[0].source_line, 0);
+        assert_eq!(nodes[1].kind, PlanKind::Return);
+        assert_eq!(nodes[1].binding, None);
+        assert_eq!(nodes[1].source_line, 1);
+    }
+
+    #[test]
+    fn records_source_lines_and_bindings_without_changing_nesting() {
+        let nodes = parse(
+            "first = shell({ command: \"líst\" })\n\
+             items = for item in first.items {\n\
+                 result = boundary retry 1 {\n\
+                     return shell({ command: item })\n\
+                 } catch error {\n\
+                     return log_error({ code: error.code })\n\
+                 }\n\
+                 return result\n\
+             }\n\
+             return items",
+        );
+
+        let metadata: Vec<_> = nodes
+            .iter()
+            .map(|node| {
+                (
+                    node.depth,
+                    node.kind,
+                    node.source_line,
+                    node.binding.as_deref(),
+                    node.tool.as_deref(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            metadata,
+            [
+                (0, PlanKind::Call, 0, Some("first"), Some("shell")),
+                (0, PlanKind::Loop, 1, Some("items"), None),
+                (1, PlanKind::Boundary, 2, Some("result"), None),
+                (2, PlanKind::Call, 3, None, Some("shell")),
+                (2, PlanKind::Branch, 4, None, None),
+                (3, PlanKind::Call, 5, None, Some("log_error")),
+                (0, PlanKind::Return, 9, None, None),
+            ]
+        );
+    }
+
+    #[test]
+    fn includes_after_bodies_fold_initializers_and_pure_intrinsics() {
+        let nodes = parse(
+            "config = json.parse(\"{}\")\n\
+             seed = shell({ command: \"prepare\" })\n\
+             published = after seed {\n\
+                 return edit({ op: \"delete\", path: \"old\" })\n\
+             }\n\
+             total = fold acc = shell({ command: \"init\" }) for item in [] {\n\
+                 return acc\n\
+             }\n\
+             return { config, published, total }",
+        );
+
+        assert_eq!(nodes[0].kind, PlanKind::Binding);
+        assert_eq!(nodes[0].binding.as_deref(), Some("config"));
+        assert!(nodes.iter().any(|node| node.kind == PlanKind::After));
+        assert_eq!(
+            nodes
+                .iter()
+                .filter_map(|node| node.tool.as_deref())
+                .collect::<Vec<_>>(),
+            ["shell", "edit", "shell"]
+        );
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,4 +1,4 @@
-//! Frame drawing: header, transcript, runtime graph, prompt, status.
+//! Frame drawing: header, transcript, prompt, and status.
 
 use std::ops::Range;
 
@@ -32,12 +32,9 @@ use super::{
     markdown,
     plan::PlanKind,
     theme,
-    wrap::{LinkedLine, LinkedSpan, wrap, wrap_linked_tagged},
+    wrap::{LinkedLine, LinkedSpan, wrap_linked_tagged},
 };
 
-/// Width at which the graph moves beside the transcript instead of below it.
-const SIDE_BY_SIDE_WIDTH: u16 = 108;
-const GRAPH_WIDTH: u16 = 46;
 const MAX_PROMPT_ROWS: usize = 10;
 const MAX_PENDING_STEER_ROWS: usize = 3;
 const START_MAX_WIDTH: u16 = 96;
@@ -75,8 +72,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App, images: &mut ImageRuntime) {
         && available_start_prompt_rows >= START_MIN_PROMPT_ROWS
         && app.blocks.is_empty()
         && app.pending_steers.is_empty()
-        && !app.show_logs
-        && !app.show_graph();
+        && !app.show_logs;
 
     if show_start {
         app.prompt_width = start_prompt_width;
@@ -484,21 +480,7 @@ fn draw_start(frame: &mut Frame<'_>, app: &App, width: u16, prompt_rows: u16) {
 }
 
 fn draw_body(frame: &mut Frame<'_>, app: &mut App, images: &mut ImageRuntime, area: Rect) {
-    if !app.show_graph() {
-        draw_transcript(frame, app, images, area);
-        return;
-    }
-    if area.width >= SIDE_BY_SIDE_WIDTH {
-        let [transcript, graph] =
-            Layout::horizontal([Constraint::Min(40), Constraint::Length(GRAPH_WIDTH)]).areas(area);
-        draw_transcript(frame, app, images, transcript);
-        draw_graph(frame, app, graph);
-    } else {
-        let [transcript, graph] =
-            Layout::vertical([Constraint::Min(6), Constraint::Percentage(45)]).areas(area);
-        draw_transcript(frame, app, images, transcript);
-        draw_graph(frame, app, graph);
-    }
+    draw_transcript(frame, app, images, area);
 }
 
 fn draw_transcript(frame: &mut Frame<'_>, app: &mut App, images: &mut ImageRuntime, area: Rect) {
@@ -737,7 +719,6 @@ fn refresh_transcript_cache_with_images(app: &mut App, images: &mut ImageRuntime
     app.transcript_dirty
         .extend(app.transcript_dynamic.iter().copied());
     let dirty = std::mem::take(&mut app.transcript_dirty);
-    let show_graph = !dirty.is_empty() && app.show_graph();
     let mut first_changed_count = app.blocks.len();
     for block_index in dirty {
         #[cfg(test)]
@@ -764,10 +745,7 @@ fn refresh_transcript_cache_with_images(app: &mut App, images: &mut ImageRuntime
             user_block_rows(message, width, images.enabled())
         } else {
             (
-                wrap_linked_tagged(
-                    &transcript_block_lines(app, block_index, show_graph, width),
-                    width,
-                ),
+                wrap_linked_tagged(&transcript_block_lines(app, block_index, width), width),
                 Vec::new(),
             )
         };
@@ -845,7 +823,6 @@ fn user_block_rows(
 fn transcript_block_lines(
     app: &App,
     block_index: usize,
-    show_graph: bool,
     width: usize,
 ) -> Vec<TaggedTranscriptLine> {
     let block = &app.blocks[block_index];
@@ -869,7 +846,6 @@ fn transcript_block_lines(
             uncopyable(plain_lines(tool_lines(
                 app,
                 call,
-                show_graph,
                 app.transcript_call_is_focused(block_index),
             ))),
             Some(call.id.clone()),
@@ -963,13 +939,13 @@ fn thought_lines(
         .collect()
 }
 
-fn tool_lines(app: &App, call: &ToolCall, show_graph: bool, active: bool) -> Vec<Line<'static>> {
+fn tool_lines(app: &App, call: &ToolCall, active: bool) -> Vec<Line<'static>> {
     let mut lines = vec![Line::from(tool_header(app, call, active))];
+    let compose = call.title == agentkit_tool_compose::COMPOSE_TOOL_NAME;
     if call.running() {
-        // The live detail belongs in the graph pane, which is open while a
-        // call runs; repeating it here would just churn the transcript.
-        if !show_graph && let Some(child) = call.children.iter().rev().find(|child| child.running())
-        {
+        if compose && !call.script.is_empty() {
+            lines.extend(live_script_lines(app, call));
+        } else if let Some(child) = call.children.iter().rev().find(|child| child.running()) {
             lines.push(Line::from(vec![
                 Span::styled("   ↳ ", theme::faint()),
                 Span::styled(child.summary.clone(), theme::dim()),
@@ -977,17 +953,218 @@ fn tool_lines(app: &App, call: &ToolCall, show_graph: bool, active: bool) -> Vec
         }
         return lines;
     }
-    for child in call.children.iter().take(6) {
-        lines.push(Line::from(child_spans(app, child, "   ")));
-    }
-    if call.children.len() > 6 {
-        lines.push(Line::from(Span::styled(
-            format!("   … {} more calls", call.children.len() - 6),
-            theme::faint(),
-        )));
+    if !compose {
+        for child in call.children.iter().take(6) {
+            lines.push(Line::from(child_spans(app, child, "   ")));
+        }
+        if call.children.len() > 6 {
+            lines.push(Line::from(Span::styled(
+                format!("   … {} more calls", call.children.len() - 6),
+                theme::faint(),
+            )));
+        }
     }
     lines.extend(output_lines(call));
     lines
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ProgramState {
+    Idle,
+    Resolved,
+    Failed,
+    Running,
+}
+
+fn live_script_lines(app: &App, call: &ToolCall) -> Vec<Line<'static>> {
+    call.script
+        .lines()
+        .enumerate()
+        .map(|(line_index, source)| {
+            let nodes: Vec<usize> = call
+                .plan
+                .iter()
+                .enumerate()
+                .filter_map(|(index, node)| (node.source_line == line_index).then_some(index))
+                .collect();
+            let state = nodes
+                .iter()
+                .map(|&index| program_state(call, index))
+                .max()
+                .unwrap_or(ProgramState::Idle);
+            let (glyph, style) = match state {
+                ProgramState::Running => (
+                    theme::pulse(theme::Pulse::Child, app.tick),
+                    Style::default().fg(theme::running_color()),
+                ),
+                ProgramState::Failed => ("✗", Style::default().fg(theme::error_color())),
+                ProgramState::Resolved => ("✓", Style::default().fg(theme::success_color())),
+                ProgramState::Idle => ("·", theme::faint()),
+            };
+            let annotations: Vec<String> = nodes
+                .iter()
+                .map(|&index| program_annotation(call, index))
+                .filter(|text| !text.is_empty())
+                .collect();
+            let mut spans = vec![
+                Span::styled("   │ ", theme::faint()),
+                Span::styled(format!("{glyph} "), style),
+                Span::styled(source.to_string(), style),
+            ];
+            if !annotations.is_empty() {
+                spans.push(Span::styled("  # ", theme::faint()));
+                spans.push(Span::styled(annotations.join(" · "), style));
+            }
+            Line::from(spans)
+        })
+        .collect()
+}
+
+fn program_state(call: &ToolCall, index: usize) -> ProgramState {
+    let node = &call.plan[index];
+    if node.kind == PlanKind::Binding {
+        return ProgramState::Resolved;
+    }
+    if node.kind == PlanKind::Return {
+        return ProgramState::Idle;
+    }
+    let end = subtree_end(call, index);
+    let children: Vec<&Child> = call
+        .children
+        .iter()
+        .filter(|child| {
+            child
+                .node
+                .is_some_and(|owner| owner >= index && owner < end)
+        })
+        .collect();
+    if children.iter().any(|child| child.running()) {
+        ProgramState::Running
+    } else if children.is_empty() {
+        ProgramState::Idle
+    } else if children.iter().any(|child| child.ok) {
+        ProgramState::Resolved
+    } else {
+        ProgramState::Failed
+    }
+}
+
+fn subtree_end(call: &ToolCall, index: usize) -> usize {
+    let depth = call.plan[index].depth;
+    call.plan
+        .iter()
+        .enumerate()
+        .skip(index + 1)
+        .find_map(|(next, node)| (node.depth <= depth).then_some(next))
+        .unwrap_or(call.plan.len())
+}
+
+fn program_annotation(call: &ToolCall, index: usize) -> String {
+    let node = &call.plan[index];
+    let state = program_state(call, index);
+    let variable = node.binding.as_ref().map(|name| {
+        let status = match state {
+            ProgramState::Resolved => "resolved",
+            ProgramState::Failed => "failed",
+            ProgramState::Idle | ProgramState::Running => "waiting",
+        };
+        format!("{name} {status}")
+    });
+    let detail = match node.kind {
+        PlanKind::Call => {
+            let attached: Vec<&Child> = call
+                .children
+                .iter()
+                .filter(|child| child.node == Some(index))
+                .collect();
+            let status = match state {
+                ProgramState::Idle => "idle",
+                ProgramState::Running => "running",
+                ProgramState::Resolved => "success",
+                ProgramState::Failed => "failure",
+            };
+            let target = node.tool.as_deref().unwrap_or(node.label.as_str());
+            let target = if target.is_empty() {
+                node.kind.glyph()
+            } else {
+                target
+            };
+            if attached.len() <= 1 {
+                Some(format!("{target} {status}"))
+            } else {
+                let running = attached.iter().filter(|child| child.running()).count();
+                let success = attached
+                    .iter()
+                    .filter(|child| !child.running() && child.ok)
+                    .count();
+                let failure = attached
+                    .iter()
+                    .filter(|child| !child.running() && !child.ok)
+                    .count();
+                let states = [
+                    (running, "running"),
+                    (success, "success"),
+                    (failure, "failure"),
+                ]
+                .into_iter()
+                .filter(|(count, _)| *count > 0)
+                .map(|(count, state)| format!("{count} {state}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+                Some(format!("{target}: {states}"))
+            }
+        }
+        PlanKind::Loop | PlanKind::Fold => Some(match direct_execution_count(call, index) {
+            Some(0) => "iteration waiting".into(),
+            Some(count) if state == ProgramState::Running => {
+                format!("iteration {count} running")
+            }
+            Some(count) => format!("{count} {}", plural("iteration", count)),
+            None if state == ProgramState::Idle => "iteration waiting".into(),
+            None => "iterations active".into(),
+        }),
+        PlanKind::Boundary => Some(match direct_execution_count(call, index) {
+            Some(0) => "attempt waiting".into(),
+            Some(attempt) => format!("attempt {attempt}"),
+            None if state == ProgramState::Idle => "attempt waiting".into(),
+            None => "boundary active".into(),
+        }),
+        PlanKind::After => Some(if state == ProgramState::Idle {
+            "dependency waiting".into()
+        } else {
+            "dependency ready".into()
+        }),
+        PlanKind::Branch => Some(if state == ProgramState::Idle {
+            "branch waiting".into()
+        } else {
+            "branch active".into()
+        }),
+        PlanKind::Return => Some("waiting to return".into()),
+        PlanKind::Binding => None,
+    };
+    [variable, detail]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(" · ")
+}
+
+/// Counts a construct only when one direct child call makes dispatch count a
+/// sound proxy. Nested loops/boundaries and branching bodies stay qualitative.
+fn direct_execution_count(call: &ToolCall, index: usize) -> Option<usize> {
+    let end = subtree_end(call, index);
+    let child_depth = call.plan[index].depth + 1;
+    let calls: Vec<usize> = (index + 1..end)
+        .filter(|&child| {
+            call.plan[child].depth == child_depth && call.plan[child].kind == PlanKind::Call
+        })
+        .collect();
+    (calls.len() == 1).then(|| {
+        call.children
+            .iter()
+            .filter(|child| child.node == calls.first().copied())
+            .count()
+    })
 }
 
 /// Raw tool output stays folded: it is machine-shaped, often thousands of
@@ -1008,6 +1185,14 @@ fn output_lines(call: &ToolCall) -> Vec<Line<'static>> {
             Span::styled("  click or ^o to open", theme::faint()),
         ])];
     }
+    expanded_output_lines(call)
+}
+
+fn expanded_output_lines(call: &ToolCall) -> Vec<Line<'static>> {
+    if call.output.is_empty() {
+        return Vec::new();
+    }
+    let count = call.output.len();
     let mut lines = vec![Line::from(vec![
         Span::styled("   ▾ ", theme::dim()),
         Span::styled("output", theme::dim()),
@@ -1143,122 +1328,6 @@ fn working_line(app: &App) -> Line<'static> {
         ),
         Span::styled("   esc interrupts", theme::faint()),
     ])
-}
-
-fn draw_graph(frame: &mut Frame<'_>, app: &App, area: Rect) {
-    let block = Panel::bordered()
-        .border_type(BorderType::Rounded)
-        .border_style(theme::faint())
-        .title(Span::styled(" runtime graph ", theme::accent()));
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-
-    let Some(call) = app.focus_call() else {
-        frame.render_widget(
-            Paragraph::new(Span::styled("no tool calls yet", theme::faint())),
-            inner,
-        );
-        return;
-    };
-    let lines = wrap(&graph_lines(app, call), inner.width.max(1) as usize);
-    let offset = lines.len().saturating_sub(inner.height as usize);
-    frame.render_widget(
-        Paragraph::new(lines.into_iter().skip(offset).collect::<Vec<_>>()),
-        inner,
-    );
-}
-
-fn graph_lines(app: &App, call: &ToolCall) -> Vec<Line<'static>> {
-    let mut lines = vec![Line::from(vec![
-        Span::styled(call.title.clone(), theme::bold(theme::text_color())),
-        Span::styled(
-            format!("  {}", theme::duration(call.elapsed())),
-            theme::dim(),
-        ),
-    ])];
-    let done = call.children.len() - call.running_children();
-    let failed = call.children.iter().filter(|child| !child.ok).count();
-    let program = if call.running() {
-        "running"
-    } else if call.status == ToolCallStatus::Failed {
-        "failed"
-    } else {
-        "complete"
-    };
-    lines.push(Line::from(Span::styled(
-        format!(
-            "{} plan nodes · {done} calls done · {} calls running{} · program {program}",
-            call.plan.len(),
-            call.running_children(),
-            if failed > 0 {
-                format!(" · {failed} calls failed")
-            } else {
-                String::new()
-            }
-        ),
-        theme::faint(),
-    )));
-    lines.push(Line::default());
-
-    if call.plan.is_empty() {
-        if call.children.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "waiting for the program to dispatch…",
-                theme::faint(),
-            )));
-        }
-        for child in call.children.iter().rev().take(20) {
-            lines.push(Line::from(child_spans(app, child, "")));
-        }
-        return lines;
-    }
-
-    for (index, node) in call.plan.iter().enumerate() {
-        let attached: Vec<&Child> = call
-            .children
-            .iter()
-            .filter(|child| child.node == Some(index))
-            .collect();
-        let indent = "  ".repeat(node.depth);
-        let style = node_style(node.kind, &attached);
-        let mut spans = vec![
-            Span::styled(format!("{indent}{} ", node.kind.glyph()), style),
-            Span::styled(node.label.clone(), style),
-        ];
-        if attached.len() > 1 {
-            spans.push(Span::styled(
-                format!("  ×{}", attached.len()),
-                theme::faint(),
-            ));
-        }
-        lines.push(Line::from(spans));
-        for child in attached.iter().rev().take(4) {
-            lines.push(Line::from(child_spans(app, child, &format!("{indent}  "))));
-        }
-        if attached.len() > 4 {
-            lines.push(Line::from(Span::styled(
-                format!("{indent}  … {} earlier", attached.len() - 4),
-                theme::faint(),
-            )));
-        }
-    }
-    lines
-}
-
-fn node_style(kind: PlanKind, attached: &[&Child]) -> Style {
-    if attached.iter().any(|child| child.running()) {
-        return theme::bold(theme::running_color());
-    }
-    if attached.iter().any(|child| !child.ok) {
-        return Style::default().fg(theme::error_color());
-    }
-    if !attached.is_empty() {
-        return Style::default().fg(theme::success_color());
-    }
-    match kind {
-        PlanKind::Call => theme::dim(),
-        _ => theme::faint(),
-    }
 }
 
 fn draw_logs(frame: &mut Frame<'_>, app: &App, area: Rect) {
@@ -1488,7 +1557,7 @@ fn draw_status(frame: &mut Frame<'_>, app: &App, area: Rect) {
             Style::default().fg(theme::warn_color()),
         ));
     }
-    let hints = "⏎ send   ⇧⏎ newline   ^g graph   ^l log   ^c quit ";
+    let hints = "⏎ send   ⇧⏎ newline   ^l log   ^c quit ";
     let used: usize = left.iter().map(|span| span.content.chars().count()).sum();
     let gap = (area.width as usize)
         .saturating_sub(used + hints.chars().count())
@@ -1526,9 +1595,9 @@ mod tests {
     use ratatui_image::picker::Picker;
 
     use super::{
-        MAX_PROMPT_ROWS, ModelDialogRow, draw, graph_lines, model_dialog_rows,
-        model_dialog_viewport, prompt_lines, refresh_transcript_cache,
-        refresh_transcript_cache_with_images, user_block_rows, user_line,
+        MAX_PROMPT_ROWS, ModelDialogRow, draw, model_dialog_rows, model_dialog_viewport,
+        prompt_lines, refresh_transcript_cache, refresh_transcript_cache_with_images,
+        user_block_rows, user_line,
     };
     use crate::{
         events::RuntimeEvent,
@@ -1774,61 +1843,184 @@ mod tests {
     }
 
     #[test]
-    fn draws_the_transcript_beside_a_live_runtime_graph() {
-        let frame = render(&mut sample(), 120, 30);
-        println!("{frame}");
-        assert!(frame.contains("kit"));
-        assert!(frame.contains("› check every source file"));
-        assert!(frame.contains("runtime graph"));
-        assert!(frame.contains("for file in files.lines"));
-        assert!(frame.contains("working"));
-    }
-
-    #[test]
-    fn stacks_the_graph_below_the_transcript_when_narrow() {
-        let frame = render(&mut sample(), 70, 30);
-        println!("{frame}");
-        assert!(frame.contains("runtime graph"));
-    }
-
-    #[test]
-    fn distinguishes_finished_child_calls_from_a_running_program() {
+    fn compose_script_runs_inline_with_live_annotations_at_full_width() {
         let mut app = sample();
-        app.apply(Update::Runtime(RuntimeEvent::ChildFinished {
-            call: "call-1:compose:two".into(),
+
+        let frame = render(&mut app, 120, 40);
+
+        assert!(
+            frame.contains("files = shell({ command: \"ls src\" })"),
+            "{frame}"
+        );
+        assert!(frame.contains("files resolved · shell success"), "{frame}");
+        assert!(
+            frame.contains("checked waiting · iteration 1 running"),
+            "{frame}"
+        );
+        assert!(frame.contains("shell running"), "{frame}");
+        assert!(app.transcript_width > 100, "{}", app.transcript_width);
+    }
+
+    #[test]
+    fn compose_script_annotates_idle_and_failed_calls_and_boundary_attempts() {
+        let script = "value = boundary retry 2 {\n\
+            return shell({ command: \"false\" })\n\
+        } catch err {\n\
+            return fail(\"FAILED\", err.message)\n\
+        }\n\
+        later = docs({ query: \"next\" })\n\
+        return value";
+        let mut app = App::new(
+            PathBuf::from("/Users/dev/projects/kit"),
+            "openai-subscription".into(),
+            "gpt-5.4".into(),
+            "127.0.0.1:7331".into(),
+        );
+        app.apply(Update::ToolStarted {
+            id: "call-1".into(),
+            title: "compose".into(),
+            kind: ToolKind::Other,
+            script: Some(script.into()),
+            backgrounded: false,
+        });
+        app.apply(Update::Runtime(RuntimeEvent::ChildStarted {
+            call: "call-1:compose:failed".into(),
             tool: "shell".into(),
-            ok: true,
-            summary: "checked".into(),
-            millis: 240,
+            summary: "false".into(),
+            at: 0,
+        }));
+        app.apply(Update::Runtime(RuntimeEvent::ChildFinished {
+            call: "call-1:compose:failed".into(),
+            tool: "shell".into(),
+            ok: false,
+            summary: "exit code 1".into(),
+            millis: 10,
         }));
 
-        let summary = graph_lines(&app, app.focus_call().unwrap())[1]
-            .spans
-            .iter()
-            .map(|span| span.content.as_ref())
-            .collect::<String>();
-        assert_eq!(
-            summary,
-            "4 plan nodes · 2 calls done · 0 calls running · program running"
-        );
+        let frame = render(&mut app, 100, 30);
 
+        assert!(frame.contains("value = boundary retry 2 {"), "{frame}");
+        assert!(frame.contains("value failed · attempt 1"), "{frame}");
+        assert!(frame.contains("shell failure"), "{frame}");
+        assert!(frame.contains("later waiting · docs idle"), "{frame}");
+    }
+
+    #[test]
+    fn completed_compose_replaces_the_script_with_output() {
+        let mut app = sample();
         app.apply(Update::ToolUpdated {
             id: "call-1".into(),
             status: Some(agent_client_protocol::schema::v2::ToolCallStatus::Completed),
             script: None,
-            output: Vec::new(),
+            output: vec!["compose result".into()],
             backgrounded: false,
         });
-        let summary = graph_lines(&app, app.focus_call().unwrap())[1]
-            .spans
-            .iter()
-            .map(|span| span.content.as_ref())
-            .collect::<String>();
-        assert!(summary.ends_with("0 calls running · program complete"));
+
+        let frame = render(&mut app, 100, 30);
+
+        assert!(!frame.contains("files = shell"), "{frame}");
+        assert!(frame.contains("compose result"), "{frame}");
+
+        app.apply(Update::AgentMessage {
+            id: "test-agent".into(),
+            text: "Moving on.".into(),
+            append: true,
+        });
+        let continued = render(&mut app, 100, 30);
+        assert!(continued.contains("Moving on."), "{continued}");
+        assert!(continued.contains("1 line of output"), "{continued}");
+        assert!(!continued.contains("compose result"), "{continued}");
     }
 
     #[test]
-    fn only_the_graphs_active_call_shows_the_kill_hint() {
+    fn explicit_output_choice_survives_later_messages_and_tools() {
+        let mut app = sample();
+        app.apply(Update::ToolUpdated {
+            id: "call-1".into(),
+            status: Some(agent_client_protocol::schema::v2::ToolCallStatus::Completed),
+            script: None,
+            output: vec!["compose result".into()],
+            backgrounded: false,
+        });
+
+        app.toggle_last_output();
+        app.apply(Update::AgentMessage {
+            id: "after-compose".into(),
+            text: "Moving on.".into(),
+            append: true,
+        });
+        let compose_expanded = |app: &App| {
+            app.blocks.iter().any(
+                |block| matches!(block, Block::Tool(call) if call.id == "call-1" && call.expanded),
+            )
+        };
+        assert!(!compose_expanded(&app));
+
+        app.toggle_last_output();
+        app.apply(Update::ToolStarted {
+            id: "call-2".into(),
+            title: "shell".into(),
+            kind: ToolKind::Execute,
+            script: None,
+            backgrounded: false,
+        });
+        assert!(compose_expanded(&app));
+    }
+
+    #[test]
+    fn a_new_tool_collapses_the_previous_compose_output() {
+        let mut app = sample();
+        app.apply(Update::ToolUpdated {
+            id: "call-1".into(),
+            status: Some(agent_client_protocol::schema::v2::ToolCallStatus::Completed),
+            script: None,
+            output: vec!["compose result".into()],
+            backgrounded: false,
+        });
+        app.apply(Update::ToolStarted {
+            id: "call-2".into(),
+            title: "shell".into(),
+            kind: ToolKind::Execute,
+            script: None,
+            backgrounded: false,
+        });
+
+        let previous = app.blocks.iter().find_map(|block| match block {
+            Block::Tool(call) if call.id == "call-1" => Some(call),
+            _ => None,
+        });
+        assert!(previous.is_some_and(|call| !call.expanded));
+    }
+
+    #[test]
+    fn non_compose_running_child_summary_remains_inline() {
+        let mut app = App::new(
+            PathBuf::from("/Users/dev/projects/kit"),
+            "openai-subscription".into(),
+            "gpt-5.4".into(),
+            "127.0.0.1:7331".into(),
+        );
+        app.apply(Update::ToolStarted {
+            id: "call-1".into(),
+            title: "shell".into(),
+            kind: ToolKind::Execute,
+            script: None,
+            backgrounded: false,
+        });
+        app.apply(Update::Runtime(RuntimeEvent::ChildStarted {
+            call: "call-1:child".into(),
+            tool: "shell".into(),
+            summary: "cargo check".into(),
+            at: 0,
+        }));
+
+        let frame = render(&mut app, 80, 20);
+
+        assert!(frame.contains("↳ cargo check"), "{frame}");
+    }
+
+    #[test]
+    fn only_the_focused_call_shows_the_kill_hint() {
         let mut app = App::new(
             PathBuf::from("/tmp"),
             "openai-subscription".into(),
@@ -1869,7 +2061,6 @@ mod tests {
         assert!(initial[1].contains("^k kill"));
 
         app.focused_call_id = Some("first".into());
-        app.graph_pinned = Some(false);
         let selected = headers(&app);
         assert!(selected[0].contains("^k kill"));
         assert!(!selected[1].contains("^k kill"));
@@ -2034,6 +2225,10 @@ mod tests {
         use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
         let mut app = sample();
+        if let Some(Block::Tool(call)) = app.blocks.last_mut() {
+            call.title = "shell".into();
+            call.expanded = false;
+        }
         app.apply(Update::ToolUpdated {
             id: "call-1".into(),
             status: Some(agent_client_protocol::schema::v2::ToolCallStatus::Completed),
@@ -2648,7 +2843,7 @@ mod tests {
         ));
         assert!(frame.lines().any(|line| line.trim() == "▔".repeat(86)));
         assert!(frame.contains(" ready"));
-        assert!(frame.contains("⏎ send   ⇧⏎ newline   ^g graph   ^l log   ^c quit"));
+        assert!(frame.contains("⏎ send   ⇧⏎ newline   ^l log   ^c quit"));
         assert!(frame.contains("message kit"));
     }
 }

--- a/src/tui/wrap.rs
+++ b/src/tui/wrap.rs
@@ -71,40 +71,6 @@ pub struct LinkHit {
     pub url: String,
 }
 
-/// Wraps rendered lines to `width` columns.
-pub fn wrap(lines: &[Line<'static>], width: usize) -> Vec<Line<'static>> {
-    let tagged: Vec<(Line<'static>, ())> = lines.iter().map(|line| (line.clone(), ())).collect();
-    wrap_tagged(&tagged, width)
-        .into_iter()
-        .map(|(line, ())| line)
-        .collect()
-}
-
-/// Wraps lines that carry a tag, copying each source line's tag onto every
-/// display row it produces. The client uses this to know which tool call a
-/// clicked row belongs to.
-pub fn wrap_tagged<T: Clone>(
-    lines: &[(Line<'static>, T)],
-    width: usize,
-) -> Vec<(Line<'static>, T)> {
-    if width == 0 {
-        return Vec::new();
-    }
-    let mut wrapped = Vec::with_capacity(lines.len());
-    for (line, tag) in lines {
-        if line.width() <= width {
-            wrapped.push((line.clone(), tag.clone()));
-        } else {
-            wrapped.extend(
-                wrap_line(line, width)
-                    .into_iter()
-                    .map(|line| (line, tag.clone())),
-            );
-        }
-    }
-    wrapped
-}
-
 /// Wraps lines whose spans carry exact link identity, retaining that identity
 /// in the hit ranges for every display row produced. The final tuple field is
 /// source whitespace removed before that row, so copy can restore word wraps
@@ -124,61 +90,6 @@ pub fn wrap_linked_tagged<T: Clone>(
         }
     }
     wrapped
-}
-
-fn wrap_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
-    let indent = hanging_indent(line, None).min(width / 2);
-    let mut lines = Vec::new();
-    let mut spans: Vec<Span<'static>> = Vec::new();
-    let mut used = 0;
-
-    for (chunk, style) in chunks(line) {
-        let chunk_width = chunk.width();
-        let blank = chunk.trim().is_empty();
-        // Keep source indentation on the first display row. Whitespace at a
-        // wrap point is discarded, but its continuation indent is restored
-        // when the next word arrives.
-        if blank && spans.is_empty() && !lines.is_empty() {
-            continue;
-        }
-        if used + chunk_width > width && used > indent {
-            lines.push(flush(&mut spans));
-            used = 0;
-            if blank {
-                continue;
-            }
-            if indent > 0 {
-                spans.push(Span::raw(" ".repeat(indent)));
-                used = indent;
-            }
-        }
-        if spans.is_empty() && !lines.is_empty() && !blank && indent > 0 {
-            spans.push(Span::raw(" ".repeat(indent)));
-            used = indent;
-        }
-        if used + chunk_width <= width {
-            used += chunk_width;
-            spans.push(Span::styled(chunk, style));
-            continue;
-        }
-        // A single token longer than the line: break it at the margin.
-        for character in chunk.chars() {
-            let character_width = character.to_string().width();
-            if used + character_width > width {
-                lines.push(flush(&mut spans));
-                used = indent;
-                if indent > 0 {
-                    spans.push(Span::raw(" ".repeat(indent)));
-                }
-            }
-            used += character_width;
-            spans.push(Span::styled(character.to_string(), style));
-        }
-    }
-    if !spans.is_empty() {
-        lines.push(flush(&mut spans));
-    }
-    lines
 }
 
 /// Takes the pending spans as a line, without the trailing space that the
@@ -320,21 +231,6 @@ fn linked_chunks(line: &LinkedLine) -> Vec<(String, Style, Option<String>)> {
     chunks
 }
 
-fn flush(spans: &mut Vec<Span<'static>>) -> Line<'static> {
-    while spans
-        .last()
-        .is_some_and(|span| span.content.trim().is_empty())
-    {
-        spans.pop();
-    }
-    Line::from(std::mem::take(spans))
-}
-
-/// Splits a line into styled words and whitespace runs.
-fn chunks(line: &Line<'static>) -> Vec<(String, Style)> {
-    line.spans.iter().flat_map(span_chunks).collect()
-}
-
 fn span_chunks(span: &Span<'static>) -> Vec<(String, Style)> {
     let mut chunks = Vec::new();
     let mut current = String::new();
@@ -390,7 +286,34 @@ fn hanging_indent(line: &Line<'static>, leading_gutter: Option<bool>) -> usize {
 mod tests {
     use ratatui::text::{Line, Span};
 
-    use super::{LinkedLine, wrap, wrap_linked_tagged};
+    use super::{LinkedLine, wrap_linked_tagged};
+
+    fn wrap(lines: &[Line<'static>], width: usize) -> Vec<Line<'static>> {
+        let linked = lines
+            .iter()
+            .cloned()
+            .map(|line| {
+                let has_gutter = line.spans.len() > 1
+                    && line
+                        .spans
+                        .first()
+                        .is_some_and(|span| !span.content.trim().is_empty());
+                let line = LinkedLine::plain(line);
+                (
+                    if has_gutter {
+                        line.with_leading_gutter()
+                    } else {
+                        line
+                    },
+                    (),
+                )
+            })
+            .collect::<Vec<_>>();
+        wrap_linked_tagged(&linked, width)
+            .into_iter()
+            .map(|(line, (), _, _)| line)
+            .collect()
+    }
 
     fn text(lines: &[Line<'static>]) -> Vec<String> {
         lines


### PR DESCRIPTION
## Summary

Replaces the compose runtime graph with an inline view of the Runlet source while a program executes. Script lines show live call, binding, loop, boundary, branch, and dependency state; once execution completes, the source is replaced by the compose output. Nested ACP harness activity is isolated so subagent-internal calls do not pollute the parent compose view.

## Motivation

A running compose call previously appeared as an opaque transcript row while its execution detail lived in a separate, space-consuming sidebar. Rendering the source in place keeps the execution context and its progress together.

## Impact

The transcript now uses the full terminal width and the runtime graph and `Ctrl+G` toggle are removed. Compose output opens on completion, then collapses when later model or tool activity arrives unless the user explicitly chose an expansion state. Parent compose progress now reflects only its own direct runtime calls. Kit's patch version moves to `0.1.105`.

## Technical details

### Live source state

The TUI maps parsed Runlet nodes back to source lines and layers nested child lifecycle events onto them. Simple loop and retry shapes show numeric iteration or attempt progress; complex nested shapes stay qualitative rather than displaying misleading counts. Pure intrinsics, `after` bodies, and fold initializers are represented without treating intrinsic calls as host tools.

### Harness event isolation

ACP harness stderr keeps ordinary diagnostics prefixed for logging but drops private child lifecycle events at the nested harness boundary. This preserves the parent runtime's existing out-of-order event handling without attributing a subagent's compose work to the visible parent call.

### Output expansion

Expansion state distinguishes automatic behavior from an explicit user choice. Completed compose outputs default open, automatic outputs fold as the transcript advances, and click or `Ctrl+O` choices remain pinned.

https://github.com/user-attachments/assets/0aed1aea-4b0d-4391-8a11-70264bae648b
