### PR TITLE
chore(deps): update audited Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "a2a-protocol-client"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f8b474cb3b55ee934183355b04963e72b127ee70ff3770e1c16b6270995f15b"
+checksum = "02930993bf289383cd0939aef809a6b1a09e680dcc2ea40dbe4d364db56437c3"
 dependencies = [
  "a2a-protocol-types",
  "base64 0.22.1",
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "a2a-protocol-server"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9a36a28020dd5c82c85bc850bb1b6dd4e73f0a7527c4c59488902b3cd8de34"
+checksum = "ef7fd6f1c3f8f8d57eb32acf7ccaac1bad7db361ca9d5a3f84b4d84f362dbed3"
 dependencies = [
  "a2a-protocol-types",
  "bytes",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "a2a-protocol-types"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97bfde40ff2d073fafc3c17bcadf11c99284f807c1cb1fbb21c802d3e4eb2ddf"
+checksum = "ceb66392420388f11dcc604ee556d868baf567a1578c0fe18a55814b27f8944e"
 dependencies = [
  "serde",
  "serde_json",
@@ -1581,12 +1581,12 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
  "zlib-rs",
 ]
 
@@ -1624,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fee0259ffdc3d7bd64438b6b08437884d4df5700f9cb8a23b079c3958ae578"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
 dependencies = [
  "num",
  "num-bigint",
@@ -1827,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1964,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2415,9 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.50.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b6bb4e22283b09119c671e57ac6a185e9a0c70c31585e56b729b626d877753"
+checksum = "0ee5867390f14ee43278d8d05d3af5f5314eeccb4684e6049033f2ba4ae3d4ae"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2444,18 +2444,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.50.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497fbf3b1ca53b1e23a253f636e88e7a2031387388b8140199a0f240fcadf647"
+checksum = "1a7bbc0f53dcb425cf3bae539be26b406b7053e6995e34e4b04477091e600044"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.50.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84ca3f39446973a810fc90fc2645ada8c24284f6deb009c78b776813973887d"
+checksum = "0d3e24abcd5f7eff512eb6bb915ac67772f2e7142ae5b5ac67b4ac75bd417d46"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.104"
+version = "0.1.105"
 dependencies = [
  "a2a-protocol-client",
  "a2a-protocol-server",
@@ -2708,6 +2708,16 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3113,7 +3123,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3556,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.50.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0a32a2a2c2d7dd0ee54705b5fd641be73037271928f68e9b0e7205b71c9d30"
+checksum = "b6326ce79629af4702ac033666390011ccc70fe82ffedd62824d061f133bd10b"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -4944,9 +4954,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "kit"
-version = "0.1.104"
+version = "0.1.105"
 edition = "2024"
 rust-version = "1.94.0"
 publish = false
 
 [dependencies]
-a2a-protocol-client = "=0.9.0"
-a2a-protocol-server = { version = "=0.9.0", default-features = false }
-a2a-protocol-types = "=0.9.0"
+a2a-protocol-client = "=0.10.0"
+a2a-protocol-server = { version = "=0.10.0", default-features = false }
+a2a-protocol-types = "=0.10.0"
 agent-client-protocol = { version = "=2.0.0", features = ["unstable_session_fork", "unstable_session_inject"] }
 agent-client-protocol-schema = { git = "https://github.com/danielkov/agent-client-protocol", rev = "6e7e044f9464c4fd652d90699a09e9edc8b3bbad", features = ["unstable_session_notices"] }
 agent-client-protocol-http = { version = "=2.0.0", default-features = false, features = ["server"] }
@@ -34,17 +34,17 @@ blake3 = "=1.8.7"
 bytes = "=1.12.1"
 clap = { version = "=4.6.6", features = ["derive"] }
 crossterm = { version = "=0.29.0", features = ["event-stream"] }
-flate2 = "=1.1.9"
+flate2 = "=1.1.10"
 futures-util = "=0.3.34"
 getrandom = "=0.4.3"
-h2 = "=0.4.17"
+h2 = "=0.4.19"
 httpdate = "=1.0.3"
-hyper = "=1.11.0"
+hyper = "=1.11.1"
 hyper-util = { version = "=0.1.20", features = ["server", "http1", "http2", "tokio"] }
 image = { version = "=0.25.10", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
 jsonwebtoken = { version = "=11.0.0", default-features = false, features = ["aws_lc_rs"] }
 keyring = { version = "=4.1.6", default-features = false, features = ["v1"] }
-jsonschema = { version = "=0.50.1", default-features = false }
+jsonschema = { version = "=0.52.0", default-features = false, features = ["idna"] }
 opentelemetry = { version = "=0.32.0", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "=0.32.0", default-features = false, features = ["grpc-tonic", "tls-webpki-roots", "trace"] }
 opentelemetry_sdk = { version = "=0.32.1", default-features = false, features = ["trace"] }
@@ -68,7 +68,7 @@ tracing-opentelemetry = { version = "=0.33.0", default-features = false }
 tracing-subscriber = { version = "=0.3.23", default-features = false, features = ["registry", "std"] }
 unicode-width = "=0.2.2"
 url = "=2.5.8"
-uuid = { version = "=1.25.0", features = ["v5"] }
+uuid = { version = "=1.26.0", features = ["v5"] }
 zip = { version = "=8.6.0", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 zeroize = { version = "=1.9.0", features = ["derive"] }
 


### PR DESCRIPTION
## Summary

Updates the pinned A2A protocol, compression, HTTP/2, HTTP, JSON Schema, and UUID dependencies to their latest compatible audited releases. Regenerates the lockfile and bumps Kit to 0.1.105.

## Motivation

Adopts upstream maintenance, correctness, and resource-hardening fixes while retaining exact dependency pins. The selected releases were reviewed for crates.io publisher continuity, archive integrity, and unexpected build or runtime hooks before inclusion.

## Impact

No Kit API changes are intended. A2A receives timeout and graceful-shutdown improvements, HTTP/2 receives small-frame resource hardening, and the compression and HTTP stacks receive correctness fixes. JSON Schema keeps internationalized email and hostname validation enabled explicitly through the `idna` feature after it became optional in 0.52.0.

## Technical details

### Dependency provenance

The updated archives match crates.io checksums and their declared upstream source. No ownership discontinuities, new unexpected build scripts, executable payloads, process spawning, or unsafe-code expansions were found.

### Pinned transitive dependencies

`generic-array`, `matchit`, `thiserror`, and `thiserror-impl` remain at their existing versions because current upstream dependencies impose exact or upper-bound constraints.