### PR TITLE
feat(sessions): list and resume past sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.105"
+version = "0.1.106"
 dependencies = [
  "a2a-protocol-client",
  "a2a-protocol-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.1.105"
+version = "0.1.106"
 edition = "2024"
 rust-version = "1.94.0"
 publish = false

--- a/README.md
+++ b/README.md
@@ -99,11 +99,14 @@ remain resumable and are copied to the global location on resume. When reported
 context use reaches 80% of the model's window, Kit automatically checkpoints older
 history while preserving bootstrap instructions and a tool-safe recent tail; the
 replacement is persisted for resume.
-The session id is shown in the header. Resume it with:
+The session id is shown in the header. List workspace sessions or resume one with:
 
 ```sh
+cargo run -- sessions --root /path/to/project
 cargo run -- tui --root /path/to/project --resume <session-id>
 ```
+
+`kit sessions` prints the shared newest-first session catalog with ID, updated time, title, and preview.
 
 A per-session filesystem lock prevents two live Kit processes from mutating the
 same transcript. If a crashed process left its lock file behind, add `--force`;
@@ -583,6 +586,7 @@ child process with `KIT_RUNTIME_EVENTS=1`; other ACP hosts never see them.
 | --- | --- |
 | `⏎` | send |
 | `/new` | start a fresh persisted session (`/new prompt` sends its first prompt) |
+| `/sessions` | choose a workspace session and resume it |
 | `/compact` | compact context now (`/compact prompt` starts the next turn with `prompt`) |
 | `/effort` | choose `default`, `low`, `medium`, or `high`; Tab toggles saving the default |
 | `/model` | open the searchable provider-grouped model picker |
@@ -607,7 +611,7 @@ no credentials — the client exits with that agent's own last diagnostic rather
 than waiting on a handshake that will never finish.
 
 `/new` clears the visible transcript but leaves the prior persisted session
-intact and resumable. `/model` switches the main agent and compactor in the same
+intact and resumable. `/sessions` opens the newest-first workspace catalog; Enter resumes the selected session through the same path as `/resume <session-id>`. `/model` switches the main agent and compactor in the same
 live ACP session at the next safe turn boundary; it does not rewrite transcript
 history or restart the child process. The picker groups models by provider and
 ranks fuzzy matches as you type. Press `tab` before confirming to also replace the `provider`

--- a/docs/user/tui-and-sessions.md
+++ b/docs/user/tui-and-sessions.md
@@ -10,11 +10,14 @@ Start an interactive session at a project root with the installed binary:
 kit tui --root /path/to/project
 ```
 
-Resume the ID shown in the header:
+List sessions for the workspace, then resume the ID shown in the header or catalog:
 
 ```sh
+kit sessions --root /path/to/project
 kit tui --root /path/to/project --resume <session-id>
 ```
+
+The catalog requires an existing directory and is workspace-filtered and newest-first. It reports each durable ID and updated time. The title comes from the earliest retained useful user text so compaction does not rename a session; the preview describes the current retained history. Display metadata removes terminal controls and Unicode default-ignorable formatting characters.
 
 A session ID must be 1–128 ASCII letters, digits, `-`, or `_`. `kit prompt` uses the same durable sessions: it prints `session_id: <id>` after its answer, and that ID can be continued by either `kit prompt --resume <session-id>` or `kit tui --resume <session-id>`.
 
@@ -72,12 +75,13 @@ At an idle, non-empty editor, `Ctrl+C` clears the prompt instead of unexpectedly
 
 ## Manage sessions and compact from the TUI
 
-The TUI handles `/new`, `/resume`, `/close`, `/model`, and `/effort` as exact local slash-command tokens. It also discovers agent commands through ACP and highlights them without interpreting them locally:
+The TUI handles `/new`, `/resume`, `/sessions`, `/close`, `/model`, and `/effort` as exact local slash-command tokens. It also discovers agent commands through ACP and highlights them without interpreting them locally:
 
 ```text
 /new
 /new Start by reviewing the tests
 /resume <session-id>
+/sessions
 /close
 /compact
 /compact Continue with the migration
@@ -86,7 +90,7 @@ The TUI handles `/new`, `/resume`, `/close`, `/model`, and `/effort` as exact lo
 /effort high
 ```
 
-These local commands are available only while the session is idle. `/new` closes the current session and starts a fresh persisted session. It clears the visible transcript but does not delete or alter the previous session, which remains resumable by its ID. Text following `/new` becomes the new session's first prompt. `/resume <session-id>` closes the current session, resumes the requested durable session, and replays its transcript. `/close` closes the current session and exits the TUI.
+These local commands are available only while the session is idle. `/new` closes the current session and starts a fresh persisted session. It clears the visible transcript but does not delete or alter the previous session, which remains resumable by its ID. Text following `/new` becomes the new session's first prompt. `/resume <session-id>` closes the current session, resumes the requested durable session, and replays its transcript; selecting the already-active ID is a no-op. `/sessions` opens a visible newest-first selector for the same workspace; Up and Down move, Enter uses the existing resume flow, and Esc closes the dialog. `/close` closes the current session and exits the TUI.
 
 `/model` opens the model selector. `/effort` opens the advertised ACP reasoning-effort selector; `/effort default|low|medium|high` selects directly. In either dialog, Tab toggles saving the selection to `~/.kit/config.toml`, Enter selects, and Esc closes. Saving `default` removes top-level `reasoning_effort`; other values update it without replacing unrelated TOML. A new or resumed process starts from the resolved CLI/TOML default unless the selection was saved.
 
@@ -97,10 +101,12 @@ The ACP server advertises `compact` for every new session. The TUI submits `/com
 Kit stores durable JSONL transcripts, locks, and session-associated fatal error logs in:
 
 ```text
-~/.kit/sessions/<session-id>.jsonl
-~/.kit/sessions/<session-id>.lock
+~/.kit/sessions/w-<workspace-hash>/<session-id>.jsonl
+~/.kit/sessions/w-<workspace-hash>/<session-id>.lock
 ~/.kit/errors/<session-id>/<event-id>.json
 ```
+
+The workspace hash is the BLAKE3 digest of the canonical workspace-root path. It keeps identical session IDs in different workspaces in separate storage directories.
 
 Fatal error records use their own versioned JSON schema and are not transcript content. Schema v2 adds optional structured transport diagnostics; schema v1 records remain readable. Transport diagnostics contain only bounded, allowlisted request/stream stage, retry, attempt, the provider's strictly validated `x-request-id` value, reqwest classification, and typed Hyper, HTTP/2, and I/O fields. Unknown or truncated source chains are identified without storing source text. Kit never stores raw error display/debug text, arbitrary headers, prompts, tool arguments, response bodies, credentials, URLs, or peer-controlled HTTP/2 debug text in these records. Files are written atomically with owner-only permissions on Unix, and Kit retains the newest 50 records per session. Cancellation is not a fatal error and does not create a record. When persistence succeeds, local prompt and ACP terminal errors include the log path; A2A records stay server-local.
 
@@ -108,13 +114,13 @@ Fatal error records use their own versioned JSON schema and are not transcript c
 
 Transcript records are versioned and have consecutive generations. Transcript schema v3 records the canonical workspace root so ACP discovery and resume cannot expose a session to another project; schema v1 and v2 records remain readable and gain that binding when they are next resumed. Normal items are appended and synced to disk before they are accepted into the in-memory conversation. Operations such as compaction append a replacement record; older records remain in the JSONL file, but readers treat the latest valid replacement as the canonical transcript.
 
-Older sessions under `<root>/.kit/sessions` remain readable. The first resume validates and copies a legacy transcript into `~/.kit/sessions`; a live legacy lock produces `legacy session is actively locked by another Kit instance ...; stop it before resuming with this Kit version`. When both locations contain the ID, the global transcript is preferred.
+Older sessions stored directly under `~/.kit/sessions` or under `<root>/.kit/sessions` remain readable. On resume, Kit compares workspace-hashed, workspace-bound global, and project-local candidates and selects the history that descends from the others; equivalent histories prefer the workspace-hashed copy, while divergent histories fail instead of choosing silently. An old global transcript without workspace metadata is a fallback only for an explicit resume when no workspace-hashed or project-local candidate has that ID. The first successful resume copies the authoritative history into the workspace-hashed directory and leaves redirects in applicable legacy files. A live legacy lock produces `legacy session is actively locked by another Kit instance ...; stop it before resuming with this Kit version`.
 
 ### ACP session loading
 
-ACP v1 clients restore a closed durable session with `session/load`. The v1 endpoint advertises only the protocol's top-level `loadSession` capability; it does not advertise `session/resume` or `session/list`. ACP v2 clients use `session/list` and `session/resume` instead. Both versions use the exact durable session ID and return the same model and reasoning configuration options as `session/new`.
+ACP v1 clients restore a closed durable session with `session/load` and discover sessions with the optional `session/list` capability. ACP v2 clients use `session/list` and `session/resume`. Both list variants use the same newest-first catalog, optional exact-cwd filter, and opaque `offset:<n>` pagination cursors, and return titles and RFC 3339 updated times. Both versions use the exact durable session ID and return the same model and reasoning configuration options as `session/new`.
 
-Session discovery and restoration are isolated to the server's canonical workspace root. A requested workspace must match that root, and additional directories are not accepted. Legacy transcripts under a project-local `.kit/sessions` directory follow the same migration and root checks as CLI resume; they do not make a same-named session visible from another workspace.
+Session discovery and restoration are isolated to the server's canonical workspace root. A requested workspace must match that root, and additional directories are not accepted. Legacy transcripts under a project-local `.kit/sessions` directory follow the same migration and root checks as CLI resume; they do not make a same-named session visible from another workspace. Old global transcripts without workspace metadata are excluded from discovery in every workspace, but an explicit resume by ID remains supported and binds the transcript to that workspace. An individually malformed or concurrently incomplete transcript is omitted from catalog results without preventing valid sessions from being listed; explicit resume remains strict and reports its error.
 
 An arbitrary ACP load or resume never applies the server process's configured `--force` setting. The one exception is the initial resume requested by `kit tui --resume <id> --force`: only that matching configured session may use the explicit stale-lock override. If another live Kit instance owns the session lock, restoration fails instead of taking over the session. A missing or invalid ID also fails normally. After the session closes and releases its lock, an ACP client can restore it again.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,6 +405,12 @@ enum Command {
         #[command(flatten)]
         credentials: CredentialArgs,
     },
+    /// List durable sessions for a workspace, newest first.
+    Sessions {
+        /// Working directory and project context (defaults to config or `.`).
+        #[arg(long)]
+        root: Option<PathBuf>,
+    },
     /// Serve ACP on stdio with A2A, remote ACP, or both over HTTP.
     Serve {
         /// Working directory and project context (defaults to config or `.`).
@@ -532,6 +538,21 @@ fn initial_config(home: &Path) -> String {
     format!(
         "model = \"gpt-5.6-sol\"\nmcp_config = {mcp_config}\ncredential_store = \"file\"\ncredential_dir = {credential_dir}\n\n[plugins]\n"
     )
+}
+
+fn format_sessions(entries: &[kit::session::CatalogEntry]) -> String {
+    let mut output = String::from("UPDATED\tID\tTITLE\tPREVIEW\n");
+    for entry in entries {
+        output.push_str(&entry.updated_at_rfc3339());
+        output.push('\t');
+        output.push_str(&entry.id);
+        output.push('\t');
+        output.push_str(entry.title.as_deref().unwrap_or("-"));
+        output.push('\t');
+        output.push_str(entry.preview.as_deref().unwrap_or("-"));
+        output.push('\n');
+    }
+    output
 }
 
 fn write_if_missing(path: &Path, contents: &[u8]) -> io::Result<()> {
@@ -750,6 +771,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
     let config = Config::load_default()?;
+    if let Command::Sessions { root } = &cli.command {
+        let root = config.root(root.clone());
+        print!("{}", format_sessions(&kit::session::catalog(&root)?));
+        return Ok(());
+    }
     let openrouter_api_key =
         resolve_openrouter_api_key(cli.openrouter.openrouter_api_key.clone(), |name| {
             env::var(name).ok()
@@ -773,6 +799,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Command::Init => unreachable!("init returns before loading runtime config"),
         Command::Auth { .. } => unreachable!("auth commands return before loading runtime config"),
+        Command::Sessions { .. } => unreachable!("sessions returns before starting a runtime"),
         Command::Serve {
             root,
             model,
@@ -1014,9 +1041,10 @@ mod tests {
     use kit::tools::CredentialStorage;
 
     use super::{
-        AuthAction, AuthProvider, Cli, Config, CredentialArgs, CredentialStoreKind, McpArgs,
-        OTEL_CAPTURE_MESSAGE_CONTENT_ENV, ReasoningEffortArg, init_config,
-        resolve_openrouter_api_key, supervise_serve_with_trigger, validate_auth_storage,
+        AuthAction, AuthProvider, Cli, Command, Config, CredentialArgs, CredentialStoreKind,
+        McpArgs, OTEL_CAPTURE_MESSAGE_CONTENT_ENV, ReasoningEffortArg, format_sessions,
+        init_config, resolve_openrouter_api_key, supervise_serve_with_trigger,
+        validate_auth_storage,
     };
 
     #[test]
@@ -1378,6 +1406,27 @@ future_option = true
         )
         .unwrap();
         assert!(Config::load(&path).is_err());
+    }
+
+    #[test]
+    fn sessions_command_accepts_a_workspace_root_and_formats_catalog_rows() {
+        let cli = Cli::try_parse_from(["kit", "sessions", "--root", "/tmp/project"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Sessions { root: Some(root) }
+                if root.as_path() == std::path::Path::new("/tmp/project")
+        ));
+
+        let output = format_sessions(&[kit::session::CatalogEntry {
+            id: "session-1".into(),
+            title: Some("Fix tests".into()),
+            preview: Some("Fix tests in the catalog".into()),
+            updated_at: 0,
+        }]);
+        assert_eq!(
+            output,
+            "UPDATED\tID\tTITLE\tPREVIEW\n1970-01-01T00:00:00.000Z\tsession-1\tFix tests\tFix tests in the catalog\n"
+        );
     }
 
     #[test]

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -16,14 +16,14 @@ use agentkit_acp::{
     AudioContent, AutoDenyResolver, AvailableCommand, AvailableCommandsUpdate,
     BlobResourceContents, CancelNotification, CloseSessionRequest, CloseSessionResponse,
     ContentBlock, ContentChunk, EmbeddedResource, EmbeddedResourceResource, ImageContent,
-    InitializeRequest, InitializeResponse, LoadSessionRequest, LoadSessionResponse,
-    NewSessionRequest, NewSessionResponse, Notice, NoticeSeverity, PromptCapabilities,
-    PromptRequest, PromptResponse, ResourceLink, SessionAdditionalDirectoriesCapabilities,
-    SessionCapabilities, SessionCloseCapabilities, SessionConfigOption,
-    SessionConfigOptionCategory, SessionConfigSelectGroup, SessionConfigSelectOption,
-    SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
-    SetSessionConfigOptionResponse, StopReason, TextContent, TextResourceContents, ToolCallStatus,
-    ToolCallUpdateFields,
+    InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
+    LoadSessionRequest, LoadSessionResponse, NewSessionRequest, NewSessionResponse, Notice,
+    NoticeSeverity, PromptCapabilities, PromptRequest, PromptResponse, ResourceLink,
+    SessionAdditionalDirectoriesCapabilities, SessionCapabilities, SessionCloseCapabilities,
+    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectGroup,
+    SessionConfigSelectOption, SessionInfo, SessionListCapabilities, SessionNotification,
+    SessionUpdate, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, StopReason,
+    TextContent, TextResourceContents, ToolCallStatus, ToolCallUpdateFields,
 };
 use agentkit_core::{
     CancellationController, DataRef, FinishReason, Item, ItemKind, MediaPart, MetadataMap,
@@ -52,6 +52,7 @@ use crate::{
 
 const MODEL_CONFIG_ID: &str = "model";
 const REASONING_EFFORT_CONFIG_ID: &str = "reasoning_effort";
+const SESSION_LIST_PAGE_SIZE: usize = 100;
 
 fn available_commands_update(session_id: agentkit_acp::SessionId) -> SessionNotification {
     SessionNotification::new(
@@ -315,6 +316,21 @@ pub(crate) struct TurnStateNotification {
 
 fn sdk_error(error: AcpRuntimeError) -> agent_client_protocol::Error {
     agent_client_protocol::util::internal_error(error.to_string())
+}
+
+#[derive(Debug)]
+enum ListSessionsError {
+    InvalidCursor,
+    Runtime(AcpRuntimeError),
+}
+
+fn list_sessions_error(error: ListSessionsError) -> agent_client_protocol::Error {
+    match error {
+        ListSessionsError::InvalidCursor => {
+            agent_client_protocol::Error::invalid_params().data("invalid session list cursor")
+        }
+        ListSessionsError::Runtime(error) => sdk_error(error),
+    }
 }
 
 enum Command {
@@ -696,6 +712,50 @@ impl Server {
         } = attached;
         let _ = activation.send(());
         Ok(NewSessionResponse::new(session_id).config_options(Some(config_options)))
+    }
+
+    async fn list_sessions(
+        &self,
+        request: ListSessionsRequest,
+    ) -> Result<ListSessionsResponse, ListSessionsError> {
+        let cwd = self.runtime.root().to_path_buf();
+        let offset = request
+            .cursor
+            .as_deref()
+            .map(parse_session_list_cursor)
+            .transpose()?
+            .unwrap_or(0);
+        if request
+            .cwd
+            .as_ref()
+            .is_some_and(|requested| requested != &cwd)
+        {
+            return Ok(ListSessionsResponse::new(Vec::new()));
+        }
+        let root = self.runtime.root().to_path_buf();
+        let catalog = tokio::task::spawn_blocking(move || crate::session::catalog(&root))
+            .await
+            .map_err(|error| {
+                ListSessionsError::Runtime(AcpRuntimeError::Loop(format!(
+                    "session catalog worker failed: {error}"
+                )))
+            })?
+            .map_err(|error| ListSessionsError::Runtime(AcpRuntimeError::Loop(error)))?;
+        if offset > catalog.len() {
+            return Err(ListSessionsError::InvalidCursor);
+        }
+        let end = catalog.len().min(offset + SESSION_LIST_PAGE_SIZE);
+        let sessions = catalog[offset..end]
+            .iter()
+            .map(|entry| {
+                SessionInfo::new(entry.id.clone(), cwd.clone())
+                    .title(entry.title.clone())
+                    .updated_at(entry.updated_at_rfc3339())
+            })
+            .collect();
+        let mut response = ListSessionsResponse::new(sessions);
+        response.next_cursor = (end < catalog.len()).then(|| format!("offset:{end}"));
+        Ok(response)
     }
 
     async fn load_session(
@@ -1627,6 +1687,24 @@ fn component(
         .on_receive_request(
             {
                 let state = Arc::clone(&state);
+                async move |request: ListSessionsRequest, responder, cx| {
+                    let state = Arc::clone(&state);
+                    cx.spawn(async move {
+                        responder.respond_with_result(
+                            state
+                                .list_sessions(request)
+                                .await
+                                .map_err(list_sessions_error),
+                        )
+                    })?;
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let state = Arc::clone(&state);
                 async move |request: PromptRequest, responder, cx| {
                     let state = Arc::clone(&state);
                     cx.spawn(async move {
@@ -1707,6 +1785,13 @@ fn component(
         ))
 }
 
+fn parse_session_list_cursor(cursor: &str) -> Result<usize, ListSessionsError> {
+    cursor
+        .strip_prefix("offset:")
+        .and_then(|value| value.parse().ok())
+        .ok_or(ListSessionsError::InvalidCursor)
+}
+
 fn capabilities() -> agentkit_acp::AgentCapabilities {
     agentkit_acp::AgentCapabilities::new()
         .load_session(true)
@@ -1718,6 +1803,7 @@ fn capabilities() -> agentkit_acp::AgentCapabilities {
         )
         .session_capabilities(
             SessionCapabilities::new()
+                .list(SessionListCapabilities::new())
                 .additional_directories(SessionAdditionalDirectoriesCapabilities::new())
                 .close(SessionCloseCapabilities::new()),
         )
@@ -3357,8 +3443,19 @@ pub(super) mod tests {
         }
     }
 
+    #[test]
+    fn session_list_cursors_parse_offsets_and_reject_malformed_values() {
+        assert_eq!(parse_session_list_cursor("offset:100").unwrap(), 100);
+        assert!(parse_session_list_cursor("100").is_err());
+        assert!(parse_session_list_cursor("offset:nope").is_err());
+        assert_eq!(
+            list_sessions_error(ListSessionsError::InvalidCursor).code,
+            agent_client_protocol::ErrorCode::InvalidParams
+        );
+    }
+
     #[tokio::test]
-    async fn kit_server_advertises_only_supported_session_restoration() {
+    async fn kit_server_advertises_supported_session_discovery_and_restoration() {
         let root = tempfile::tempdir().unwrap();
         let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
         let (client_transport, agent_transport) = Channel::duplex();
@@ -3374,9 +3471,25 @@ pub(super) mod tests {
                 assert_eq!(initialized.protocol_version, ProtocolVersion::V1);
                 assert!(initialized.agent_capabilities.load_session);
                 let sessions = &initialized.agent_capabilities.session_capabilities;
-                assert!(sessions.list.is_none());
+                assert!(sessions.list.is_some());
                 assert!(sessions.resume.is_none());
                 assert!(sessions.fork.is_none());
+
+                let listed = connection
+                    .send_request(ListSessionsRequest::new().cwd(root.path().to_path_buf()))
+                    .block_task()
+                    .await?;
+                assert!(listed.sessions.is_empty());
+                let error = connection
+                    .send_request(
+                        ListSessionsRequest::new()
+                            .cwd(root.path().join("other"))
+                            .cursor("invalid"),
+                    )
+                    .block_task()
+                    .await
+                    .expect_err("malformed list cursor must fail");
+                assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
 
                 connection
                     .send_request(agentkit_acp::ForkSessionRequest::new(

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Arc, Mutex, Weak,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -62,6 +62,21 @@ fn complete_new_session<E>(
 
 fn sdk_error(error: AcpRuntimeError) -> agent_client_protocol::Error {
     agent_client_protocol::util::internal_error(error.to_string())
+}
+
+#[derive(Debug)]
+enum ListSessionsError {
+    InvalidCursor,
+    Runtime(AcpRuntimeError),
+}
+
+fn list_sessions_error(error: ListSessionsError) -> agent_client_protocol::Error {
+    match error {
+        ListSessionsError::InvalidCursor => {
+            agent_client_protocol::Error::invalid_params().data("invalid session list cursor")
+        }
+        ListSessionsError::Runtime(error) => sdk_error(error),
+    }
 }
 
 fn map_loop_error(session_id: &wire::SessionId, error: &LoopError) -> AcpRuntimeError {
@@ -536,11 +551,17 @@ impl Server {
         ))
     }
 
-    fn list_sessions(
+    async fn list_sessions(
         &self,
         request: wire::ListSessionsRequest,
-    ) -> Result<wire::ListSessionsResponse, AcpRuntimeError> {
+    ) -> Result<wire::ListSessionsResponse, ListSessionsError> {
         let cwd = self.runtime.root().to_path_buf();
+        let offset = request
+            .cursor
+            .as_ref()
+            .map(|cursor| parse_cursor(cursor.as_ref()))
+            .transpose()?
+            .unwrap_or(0);
         if request
             .cwd
             .as_ref()
@@ -548,24 +569,25 @@ impl Server {
         {
             return Ok(wire::ListSessionsResponse::new(Vec::new()));
         }
-        let offset = request
-            .cursor
-            .as_ref()
-            .map(|cursor| parse_cursor(cursor.as_ref()))
-            .transpose()?
-            .unwrap_or(0);
-        let ids = crate::session::list_ids(self.runtime.root()).map_err(AcpRuntimeError::Loop)?;
-        if offset > ids.len() {
-            return Err(AcpRuntimeError::Unsupported(
-                "invalid session list cursor".into(),
-            ));
+        let root = self.runtime.root().to_path_buf();
+        let catalog = tokio::task::spawn_blocking(move || crate::session::catalog(&root))
+            .await
+            .map_err(|error| {
+                ListSessionsError::Runtime(AcpRuntimeError::Loop(format!(
+                    "session catalog worker failed: {error}"
+                )))
+            })?
+            .map_err(|error| ListSessionsError::Runtime(AcpRuntimeError::Loop(error)))?;
+        if offset > catalog.len() {
+            return Err(ListSessionsError::InvalidCursor);
         }
-        let end = ids.len().min(offset + PAGE_SIZE);
-        let sessions = ids[offset..end]
+        let end = catalog.len().min(offset + PAGE_SIZE);
+        let sessions = catalog[offset..end]
             .iter()
-            .map(|id| wire::SessionInfo::new(wire::SessionId::new(id.as_str()), cwd.clone()))
+            .map(|entry| catalog_session_info(entry, &cwd))
             .collect();
-        let next = (end < ids.len()).then(|| wire::SessionListCursor::new(format!("offset:{end}")));
+        let next =
+            (end < catalog.len()).then(|| wire::SessionListCursor::new(format!("offset:{end}")));
         Ok(wire::ListSessionsResponse::new(sessions).next_cursor(next))
     }
 
@@ -1465,11 +1487,17 @@ fn set_v2_config(
     ))
 }
 
-fn parse_cursor(cursor: &str) -> Result<usize, AcpRuntimeError> {
+fn catalog_session_info(entry: &crate::session::CatalogEntry, cwd: &Path) -> wire::SessionInfo {
+    wire::SessionInfo::new(wire::SessionId::new(entry.id.clone()), cwd.to_path_buf())
+        .title(entry.title.clone())
+        .updated_at(entry.updated_at_rfc3339())
+}
+
+fn parse_cursor(cursor: &str) -> Result<usize, ListSessionsError> {
     cursor
         .strip_prefix("offset:")
         .and_then(|value| value.parse().ok())
-        .ok_or_else(|| AcpRuntimeError::Unsupported("invalid session list cursor".into()))
+        .ok_or(ListSessionsError::InvalidCursor)
 }
 
 fn transcript_replay(
@@ -1687,8 +1715,17 @@ pub(crate) fn component(
         .on_receive_request(
             {
                 let state = Arc::clone(&state);
-                async move |request: wire::ListSessionsRequest, responder, _cx| {
-                    responder.respond_with_result(state.list_sessions(request).map_err(sdk_error))
+                async move |request: wire::ListSessionsRequest, responder, cx| {
+                    let state = Arc::clone(&state);
+                    cx.spawn(async move {
+                        responder.respond_with_result(
+                            state
+                                .list_sessions(request)
+                                .await
+                                .map_err(list_sessions_error),
+                        )
+                    })?;
+                    Ok(())
                 }
             },
             agent_client_protocol::on_receive_request!(),
@@ -3177,9 +3214,46 @@ mod tests {
     }
 
     #[test]
-    fn cursors_are_stable_and_reject_malformed_values() {
+    fn catalog_entries_enrich_v2_session_info() {
+        let info = catalog_session_info(
+            &crate::session::CatalogEntry {
+                id: "saved".into(),
+                title: Some("Saved session".into()),
+                preview: Some("Saved session preview".into()),
+                updated_at: 0,
+            },
+            &PathBuf::from("/workspace"),
+        );
+        let encoded = serde_json::to_value(info).unwrap();
+        assert_eq!(encoded["sessionId"], "saved");
+        assert_eq!(encoded["cwd"], "/workspace");
+        assert_eq!(encoded["title"], "Saved session");
+        assert_eq!(encoded["updatedAt"], "1970-01-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn cursors_parse_offsets_and_reject_malformed_values() {
         assert_eq!(parse_cursor("offset:100").unwrap(), 100);
         assert!(parse_cursor("100").is_err());
         assert!(parse_cursor("offset:nope").is_err());
+        assert_eq!(
+            list_sessions_error(ListSessionsError::InvalidCursor).code,
+            agent_client_protocol::ErrorCode::InvalidParams
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_cursor_is_rejected_before_cwd_filtering() {
+        let root = tempfile::tempdir().unwrap();
+        let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
+        let server = Server::new(runtime, SessionRegistry::new());
+        let request = wire::ListSessionsRequest::new()
+            .cwd(root.path().join("other"))
+            .cursor(wire::SessionListCursor::new("invalid"));
+
+        assert!(matches!(
+            server.list_sessions(request).await,
+            Err(ListSessionsError::InvalidCursor)
+        ));
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -12,7 +12,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use agentkit_core::{Item, Timestamp};
+use agentkit_core::{Item, ItemKind, Part, Timestamp};
 use agentkit_loop::{TranscriptEvent, TranscriptObserver};
 use serde::{Deserialize, Serialize};
 
@@ -20,6 +20,7 @@ pub const SCHEMA_VERSION: u32 = 3;
 const REDIRECT_SCHEMA_VERSION: u32 = 4;
 const PREVIOUS_SCHEMA_VERSION: u32 = 2;
 const LEGACY_SCHEMA_VERSION: u32 = 1;
+const MAX_RFC3339_MILLIS: u64 = 253_402_300_799_999;
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -41,6 +42,24 @@ struct Record {
 pub struct OpenSession {
     pub transcript: Vec<Item>,
     pub observer: SessionObserver,
+}
+
+/// Read-only metadata for one durable session in a workspace.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CatalogEntry {
+    pub id: String,
+    pub title: Option<String>,
+    pub preview: Option<String>,
+    /// Last activity as milliseconds since the Unix epoch.
+    pub updated_at: u64,
+}
+
+impl CatalogEntry {
+    /// Formats the last activity as an RFC 3339 UTC timestamp.
+    #[must_use]
+    pub fn updated_at_rfc3339(&self) -> String {
+        timestamp_rfc3339(self.updated_at)
+    }
 }
 
 #[derive(Clone)]
@@ -251,7 +270,17 @@ fn open_with_initial_timestamps_in(
     if resume {
         let authority =
             authority.ok_or_else(|| format!("session {session_id:?} does not exist"))?;
-        establish_scoped_authority(&path, session_id, &workspace_root, &authority.items)?;
+        let title_seed = authority
+            .historical_items
+            .iter()
+            .find_map(|items| first_user_item_index(items).map(|index| items[..=index].to_vec()));
+        establish_scoped_authority(
+            &path,
+            session_id,
+            &workspace_root,
+            &authority.items,
+            title_seed.as_deref(),
+        )?;
         for legacy in authority.legacy_histories {
             redirect_legacy_transcript(&legacy, &path, session_id, &workspace_root)?;
         }
@@ -760,8 +789,17 @@ fn transcript_workspace_bytes(
                 index + 1
             ));
         }
-        if record.workspace_root.is_some() {
-            workspace = record.workspace_root;
+        if let Some(record_workspace) = record.workspace_root {
+            if workspace
+                .as_ref()
+                .is_some_and(|workspace| workspace != &record_workspace)
+            {
+                return Err(format!(
+                    "conflicting workspace roots in transcript {}",
+                    path.display()
+                ));
+            }
+            workspace = Some(record_workspace);
         }
     }
     Ok(workspace)
@@ -780,9 +818,192 @@ fn ensure_workspace(path: &Path, session_id: &str, root: &Path) -> Result<(), St
     Ok(())
 }
 
-/// Lists durable transcript ids bound to one workspace without taking mutation locks.
-pub(crate) fn list_ids(root: &Path) -> Result<Vec<String>, String> {
-    list_ids_for_workspace(root, &default_directory()?)
+/// Lists durable sessions bound to one workspace, newest first, without taking mutation locks.
+pub fn catalog(root: &Path) -> Result<Vec<CatalogEntry>, String> {
+    catalog_for_workspace(root, &default_directory()?)
+}
+
+fn catalog_for_workspace(
+    root: &Path,
+    global_directory: &Path,
+) -> Result<Vec<CatalogEntry>, String> {
+    let root = root.canonicalize().map_err(|error| {
+        format!(
+            "could not resolve workspace root {}: {error}",
+            root.display()
+        )
+    })?;
+    if !root.is_dir() {
+        return Err(format!(
+            "workspace root {} is not a directory",
+            root.display()
+        ));
+    }
+    let ids = list_ids_for_workspace(&root, global_directory)?;
+    let mut entries = Vec::with_capacity(ids.len());
+    for id in ids {
+        // Discovery is best-effort per transcript: a damaged file or one caught
+        // mid-append must not hide every other session in the workspace.
+        let Ok(Some(authority)) = select_authority_with(global_directory, &root, &id, false) else {
+            continue;
+        };
+        let (title, preview) = catalog_text(&authority.historical_items, &authority.items);
+        let item_updated = authority
+            .items
+            .iter()
+            .filter_map(|item| {
+                item.created_at
+                    .map(|timestamp| timestamp.0)
+                    .filter(|timestamp| *timestamp <= MAX_RFC3339_MILLIS)
+            })
+            .max()
+            .unwrap_or(0);
+        let file_updated = fs::metadata(&authority.path)
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
+            .unwrap_or(0);
+        entries.push(CatalogEntry {
+            id,
+            title,
+            preview,
+            updated_at: item_updated.max(file_updated),
+        });
+    }
+    entries.sort_by(|left, right| {
+        right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then_with(|| right.id.cmp(&left.id))
+    });
+    Ok(entries)
+}
+
+fn catalog_text(
+    historical_items: &[Vec<Item>],
+    current_items: &[Item],
+) -> (Option<String>, Option<String>) {
+    let title = historical_items
+        .iter()
+        .map(Vec::as_slice)
+        .chain(std::iter::once(current_items))
+        .find_map(first_user_text)
+        .and_then(|text| {
+            text.lines()
+                .map(normalize_catalog_text)
+                .find(|line| !line.is_empty())
+        })
+        .map(|line| truncate_catalog_text(&line, 80));
+    let preview = first_user_text(current_items)
+        .map(normalize_catalog_text)
+        .filter(|text| !text.is_empty())
+        .map(|text| truncate_catalog_text(&text, 160));
+    (title, preview)
+}
+
+fn first_user_item_index(items: &[Item]) -> Option<usize> {
+    items.iter().position(|item| {
+        item.kind == ItemKind::User
+            && item.parts.iter().any(|part| {
+                matches!(
+                    part,
+                    Part::Text(text) if !normalize_catalog_text(&text.text).is_empty()
+                )
+            })
+    })
+}
+
+fn first_user_item(items: &[Item]) -> Option<&Item> {
+    first_user_item_index(items).map(|index| &items[index])
+}
+
+fn first_user_text(items: &[Item]) -> Option<&str> {
+    first_user_item(items)?
+        .parts
+        .iter()
+        .find_map(|part| match part {
+            Part::Text(text) if !normalize_catalog_text(&text.text).is_empty() => {
+                Some(text.text.as_str())
+            }
+            _ => None,
+        })
+}
+
+fn normalize_catalog_text(text: &str) -> String {
+    text.chars()
+        .filter(|character| {
+            (!character.is_control() || character.is_whitespace())
+                && !is_default_ignorable(*character)
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn is_default_ignorable(character: char) -> bool {
+    matches!(
+        character as u32,
+        0x00ad
+            | 0x034f
+            | 0x061c
+            | 0x115f..=0x1160
+            | 0x17b4..=0x17b5
+            | 0x180b..=0x180f
+            | 0x200b..=0x200f
+            | 0x202a..=0x202e
+            | 0x2060..=0x206f
+            | 0x3164
+            | 0xfe00..=0xfe0f
+            | 0xfeff
+            | 0xffa0
+            | 0xfff0..=0xfff8
+            | 0x1bca0..=0x1bca3
+            | 0x1d173..=0x1d17a
+            | 0xe0000..=0xe0fff
+    )
+}
+
+fn truncate_catalog_text(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+    let mut value = text
+        .chars()
+        .take(limit.saturating_sub(1))
+        .collect::<String>();
+    value.push('…');
+    value
+}
+
+fn timestamp_rfc3339(milliseconds: u64) -> String {
+    let milliseconds = milliseconds.min(MAX_RFC3339_MILLIS);
+    let seconds = milliseconds / 1_000;
+    let millis = milliseconds % 1_000;
+    let days = i64::try_from(seconds / 86_400).unwrap_or(i64::MAX);
+    let day_seconds = seconds % 86_400;
+    let (year, month, day) = civil_date(days);
+    let hour = day_seconds / 3_600;
+    let minute = day_seconds % 3_600 / 60;
+    let second = day_seconds % 60;
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
+}
+
+// Gregorian civil date from days since 1970-01-01.
+fn civil_date(days: i64) -> (i64, i64, i64) {
+    let days = days + 719_468;
+    let era = if days >= 0 { days } else { days - 146_096 } / 146_097;
+    let day_of_era = days - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    (year, month, day)
 }
 
 fn list_ids_for_workspace(root: &Path, global_directory: &Path) -> Result<Vec<String>, String> {
@@ -790,25 +1011,18 @@ fn list_ids_for_workspace(root: &Path, global_directory: &Path) -> Result<Vec<St
     let scoped_directory = workspace_storage_directory(global_directory, &root);
     let legacy_directory = workspace_directory(&root);
     let mut ids = Vec::new();
-    for id in list_ids_in(&scoped_directory)? {
-        let path = transcript_path(&scoped_directory, &id);
-        read_records(&path, &id)?;
-        ensure_workspace(&path, &id, &root)?;
-        ids.push(id);
-    }
+    ids.extend(list_ids_in(&scoped_directory)?);
     for id in list_ids_in(global_directory)? {
         let path = transcript_path(global_directory, &id);
-        read_records(&path, &id)?;
-        let stored_workspace = transcript_workspace(&path, &id)?;
-        if stored_workspace.as_deref() == Some(root.as_path()) || stored_workspace.is_none() {
+        if matches!(
+            transcript_workspace(&path, &id),
+            Ok(Some(stored)) if stored == root
+        ) {
             ids.push(id);
         }
     }
-    for id in list_ids_in(&legacy_directory)? {
-        let path = transcript_path(&legacy_directory, &id);
-        read_records(&path, &id)?;
-        ids.push(id);
-    }
+    // Its location scopes this pre-global-layout directory to the workspace.
+    ids.extend(list_ids_in(&legacy_directory)?);
     ids.sort();
     ids.dedup();
     Ok(ids)
@@ -841,12 +1055,14 @@ pub(crate) fn list_ids_in(directory: &Path) -> Result<Vec<String>, String> {
     };
     let mut ids = Vec::new();
     for entry in entries {
-        let entry = entry.map_err(|error| format!("could not read session entry: {error}"))?;
+        let Ok(entry) = entry else {
+            continue;
+        };
         let path = entry.path();
-        if !entry
-            .file_type()
-            .map_err(|error| format!("could not inspect {}: {error}", path.display()))?
-            .is_file()
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file()
             || path.extension().and_then(|value| value.to_str()) != Some("jsonl")
         {
             continue;
@@ -864,6 +1080,8 @@ pub(crate) fn list_ids_in(directory: &Path) -> Result<Vec<String>, String> {
 
 struct Authority {
     items: Vec<Item>,
+    historical_items: Vec<Vec<Item>>,
+    path: PathBuf,
     legacy_histories: Vec<PathBuf>,
 }
 
@@ -884,11 +1102,21 @@ fn select_authority(
     root: &Path,
     session_id: &str,
 ) -> Result<Option<Authority>, String> {
+    select_authority_with(directory, root, session_id, true)
+}
+
+fn select_authority_with(
+    directory: &Path,
+    root: &Path,
+    session_id: &str,
+    include_unbound_global: bool,
+) -> Result<Option<Authority>, String> {
     let scoped = transcript_path(&workspace_storage_directory(directory, root), session_id);
     let global = transcript_path(directory, session_id);
     let local = legacy_transcript(root, session_id);
     let mut histories = Vec::new();
     let mut legacy_histories = Vec::new();
+    let mut unbound_global = None;
 
     for (path, is_global, is_legacy) in [
         (&scoped, false, false),
@@ -902,9 +1130,13 @@ fn select_authority(
             continue;
         }
         let workspace = transcript_workspace(path, session_id)?;
-        if is_global && workspace.as_deref().is_some_and(|stored| stored != root) {
+        if is_global
+            && (workspace.as_deref().is_some_and(|stored| stored != root)
+                || workspace.is_none() && !include_unbound_global)
+        {
             continue;
         }
+        let is_unbound_global = is_global && workspace.is_none();
         if !is_global && workspace.as_deref().is_some_and(|stored| stored != root) {
             return Err(format!(
                 "session {session_id:?} belongs to workspace {}, not {}",
@@ -914,12 +1146,17 @@ fn select_authority(
         }
         match read_records_direct(path, session_id)? {
             StoredTranscript::History(history) => {
-                histories.push(HistoryCandidate {
+                let candidate = HistoryCandidate {
                     path: path.clone(),
                     history,
-                });
-                if is_legacy {
-                    legacy_histories.push(path.clone());
+                };
+                if is_unbound_global {
+                    unbound_global = Some(candidate);
+                } else {
+                    histories.push(candidate);
+                    if is_legacy {
+                        legacy_histories.push(path.clone());
+                    }
                 }
             }
             StoredTranscript::Redirect(target) => {
@@ -942,6 +1179,13 @@ fn select_authority(
                 });
             }
         }
+    }
+
+    if histories.is_empty()
+        && let Some(candidate) = unbound_global
+    {
+        legacy_histories.push(candidate.path.clone());
+        histories.push(candidate);
     }
 
     let mut authority: Option<HistoryCandidate> = None;
@@ -968,6 +1212,8 @@ fn select_authority(
     }
     Ok(authority.map(|candidate| Authority {
         items: candidate.history.items,
+        historical_items: candidate.history.states,
+        path: candidate.path,
         legacy_histories,
     }))
 }
@@ -1170,11 +1416,12 @@ fn establish_scoped_authority(
     session_id: &str,
     root: &Path,
     items: &[Item],
+    title_seed: Option<&[Item]>,
 ) -> Result<(), String> {
     let exists = path
         .try_exists()
         .map_err(|error| format!("could not inspect {}: {error}", path.display()))?;
-    let generation = if exists {
+    let (mut generation, existing_items) = if exists {
         match read_records_direct(path, session_id)? {
             StoredTranscript::History(history)
                 if history.items == items
@@ -1182,10 +1429,13 @@ fn establish_scoped_authority(
             {
                 return Ok(());
             }
-            StoredTranscript::History(history) => history
-                .generation
-                .checked_add(1)
-                .ok_or_else(|| "session generation overflowed".to_string())?,
+            StoredTranscript::History(history) => (
+                history
+                    .generation
+                    .checked_add(1)
+                    .ok_or_else(|| "session generation overflowed".to_string())?,
+                Some(history.items),
+            ),
             StoredTranscript::Redirect(_) => {
                 return Err(format!(
                     "scoped transcript {} is a redirect",
@@ -1194,8 +1444,30 @@ fn establish_scoped_authority(
             }
         }
     } else {
-        1
+        (1, None)
     };
+    let title_seed =
+        title_seed.filter(|seed| *seed != items && existing_items.as_deref() != Some(*seed));
+    let mut create = !exists;
+    if let Some(title_seed) = title_seed {
+        write_migration_record(
+            path,
+            &Record {
+                schema_version: SCHEMA_VERSION,
+                session_id: session_id.into(),
+                generation,
+                workspace_root: Some(root.to_path_buf()),
+                item: None,
+                replacement: Some(title_seed.to_vec()),
+                redirect: None,
+            },
+            create,
+        )?;
+        generation = generation
+            .checked_add(1)
+            .ok_or_else(|| "session generation overflowed".to_string())?;
+        create = false;
+    }
     write_migration_record(
         path,
         &Record {
@@ -1207,7 +1479,7 @@ fn establish_scoped_authority(
             replacement: Some(items.to_vec()),
             redirect: None,
         },
-        !exists,
+        create,
     )
 }
 
@@ -2057,7 +2329,7 @@ mod tests {
             PREVIOUS_SCHEMA_VERSION,
             "abc",
             &["first", "newer"],
-            None,
+            Some(canonical_workspace(&project_root(root.path()))),
         );
 
         let opened = open(root.path(), "abc", true, false, Vec::new()).unwrap();
@@ -2082,7 +2354,7 @@ mod tests {
             PREVIOUS_SCHEMA_VERSION,
             "abc",
             &["before-one", "before-two"],
-            None,
+            Some(canonical_workspace(&project_root(root.path()))),
         );
         let scoped = transcript_path(root.path(), "abc");
         write_history(
@@ -2150,7 +2422,13 @@ mod tests {
     fn torn_redirect_is_truncated_and_retried() {
         let root = tempfile::tempdir().unwrap();
         let global = super::transcript_path(&session_directory(root.path()), "abc");
-        let expected = write_history(&global, PREVIOUS_SCHEMA_VERSION, "abc", &["shared"], None);
+        let expected = write_history(
+            &global,
+            PREVIOUS_SCHEMA_VERSION,
+            "abc",
+            &["shared"],
+            Some(canonical_workspace(&project_root(root.path()))),
+        );
         let scoped = transcript_path(root.path(), "abc");
         write_history(
             &scoped,
@@ -2353,6 +2631,419 @@ mod tests {
         fs::create_dir(directory.path().join("nested.jsonl")).unwrap();
 
         assert_eq!(list_ids_in(directory.path()).unwrap(), ["alpha", "zeta"]);
+        let not_directory = directory.path().join("plain-file");
+        fs::write(&not_directory, "not a directory").unwrap();
+        assert!(
+            list_ids_in(&not_directory)
+                .unwrap_err()
+                .contains("could not list session directory")
+        );
+    }
+
+    #[test]
+    fn catalog_text_omits_terminal_controls_and_skips_control_only_parts() {
+        let items = vec![
+            Item::text(ItemKind::User, "\u{1b}\u{7}"),
+            Item::text(ItemKind::User, "Safe\u{1b}[31m title\u{7}"),
+        ];
+
+        let (title, preview) = catalog_text(&[], &items);
+        assert_eq!(title.as_deref(), Some("Safe[31m title"));
+        assert_eq!(preview.as_deref(), Some("Safe[31m title"));
+        assert!(
+            title
+                .iter()
+                .chain(&preview)
+                .all(|text| !text.chars().any(char::is_control))
+        );
+    }
+
+    #[test]
+    fn catalog_is_workspace_filtered_newest_first_and_extracts_display_text() {
+        let storage = tempfile::tempdir().unwrap();
+        let roots = tempfile::tempdir().unwrap();
+        let first = roots.path().join("first");
+        let second = roots.path().join("second");
+        fs::create_dir_all(&first).unwrap();
+        fs::create_dir_all(&second).unwrap();
+        let now = Timestamp::now().0;
+
+        let older = open_in(
+            &first,
+            storage.path(),
+            "older",
+            false,
+            false,
+            vec![Item::text(ItemKind::System, "system")],
+        )
+        .unwrap();
+        write(
+            &older.observer,
+            &Item::text(ItemKind::User, "  First title  \nwith a useful preview  ")
+                .with_created_at(Timestamp(now + 1_000)),
+        );
+        let newer = open_in(
+            &first,
+            storage.path(),
+            "newer",
+            false,
+            false,
+            vec![Item::text(ItemKind::System, "system")],
+        )
+        .unwrap();
+        write(
+            &newer.observer,
+            &Item::text(ItemKind::User, "Newest session").with_created_at(Timestamp(now + 2_000)),
+        );
+        let other = open_in(
+            &second,
+            storage.path(),
+            "other",
+            false,
+            false,
+            vec![Item::text(ItemKind::User, "Other workspace")],
+        )
+        .unwrap();
+
+        let entries = catalog_for_workspace(&first, storage.path()).unwrap();
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            ["newer", "older"]
+        );
+        assert_eq!(entries[1].title.as_deref(), Some("First title"));
+        assert_eq!(
+            entries[1].preview.as_deref(),
+            Some("First title with a useful preview")
+        );
+        assert!(entries[0].updated_at > entries[1].updated_at);
+        drop((older, newer, other));
+    }
+
+    #[test]
+    fn catalog_timestamps_are_rfc3339() {
+        assert_eq!(timestamp_rfc3339(0), "1970-01-01T00:00:00.000Z");
+        assert_eq!(
+            timestamp_rfc3339(1_709_164_800_123),
+            "2024-02-29T00:00:00.123Z"
+        );
+        assert_eq!(timestamp_rfc3339(u64::MAX), "9999-12-31T23:59:59.999Z");
+    }
+
+    #[test]
+    fn catalog_strips_bidi_and_default_ignorable_characters() {
+        let items = vec![Item::text(
+            ItemKind::User,
+            "safe\u{202e}txt\u{2066} zero\u{200b}width\u{ad} \
+             bom\u{feff} tag\u{e0021} variation\u{fe0f}",
+        )];
+
+        let (title, preview) = catalog_text(&[], &items);
+        assert_eq!(
+            title.as_deref(),
+            Some("safetxt zerowidth bom tag variation")
+        );
+        assert_eq!(title, preview);
+    }
+
+    #[test]
+    fn catalog_title_survives_transcript_replacement() {
+        let storage = tempfile::tempdir().unwrap();
+        let roots = tempfile::tempdir().unwrap();
+        let root = roots.path().join("project");
+        fs::create_dir(&root).unwrap();
+        let opened = open_in(
+            &root,
+            storage.path(),
+            "compacted",
+            false,
+            false,
+            vec![Item::text(ItemKind::System, "system")],
+        )
+        .unwrap();
+        write(
+            &opened.observer,
+            &Item::text(ItemKind::User, "Original title"),
+        );
+        opened
+            .observer
+            .replace(&[
+                Item::text(ItemKind::System, "summary"),
+                Item::text(ItemKind::User, "Newer retained prompt"),
+            ])
+            .unwrap();
+
+        let entries = catalog_for_workspace(&root, storage.path()).unwrap();
+        assert_eq!(entries[0].title.as_deref(), Some("Original title"));
+        assert_eq!(entries[0].preview.as_deref(), Some("Newer retained prompt"));
+    }
+
+    #[test]
+    fn compacted_legacy_migration_preserves_earliest_user_title() {
+        let storage = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let id = "legacy-compacted";
+        let original_system = Record {
+            schema_version: SCHEMA_VERSION,
+            session_id: id.into(),
+            generation: 1,
+            workspace_root: None,
+            item: Some(Item::text(ItemKind::System, "system")),
+            replacement: None,
+            redirect: None,
+        };
+        let original_user = Record {
+            schema_version: SCHEMA_VERSION,
+            session_id: id.into(),
+            generation: 2,
+            workspace_root: None,
+            item: Some(Item::text(ItemKind::User, "Original title")),
+            replacement: None,
+            redirect: None,
+        };
+        let current = vec![
+            Item::text(ItemKind::System, "summary"),
+            Item::text(ItemKind::User, "Newer retained prompt"),
+        ];
+        let replacement = Record {
+            schema_version: SCHEMA_VERSION,
+            session_id: id.into(),
+            generation: 3,
+            workspace_root: None,
+            item: None,
+            replacement: Some(current.clone()),
+            redirect: None,
+        };
+        let legacy = super::transcript_path(storage.path(), id);
+        fs::write(
+            &legacy,
+            format!(
+                "{}\n{}\n{}\n",
+                serde_json::to_string(&original_system).unwrap(),
+                serde_json::to_string(&original_user).unwrap(),
+                serde_json::to_string(&replacement).unwrap()
+            ),
+        )
+        .unwrap();
+
+        let resumed = open_in(root.path(), storage.path(), id, true, false, Vec::new()).unwrap();
+        assert_eq!(resumed.transcript, current);
+        drop(resumed);
+        assert!(matches!(
+            read_records_direct(&legacy, id).unwrap(),
+            StoredTranscript::Redirect(_)
+        ));
+        let entries = catalog_for_workspace(root.path(), storage.path()).unwrap();
+        assert_eq!(entries[0].title.as_deref(), Some("Original title"));
+        assert_eq!(entries[0].preview.as_deref(), Some("Newer retained prompt"));
+    }
+
+    #[test]
+    fn catalog_skips_damaged_and_partially_appended_transcripts() {
+        let storage = tempfile::tempdir().unwrap();
+        let roots = tempfile::tempdir().unwrap();
+        let root = roots.path().join("project");
+        fs::create_dir(&root).unwrap();
+        let valid = open_in(
+            &root,
+            storage.path(),
+            "valid",
+            false,
+            false,
+            vec![Item::text(ItemKind::User, "Valid session")],
+        )
+        .unwrap();
+        let directory = workspace_storage_directory(storage.path(), &canonical_workspace(&root));
+        fs::write(directory.join("malformed.jsonl"), b"not json\n").unwrap();
+        fs::write(directory.join("partial.jsonl"), b"{\"schema_version\":3").unwrap();
+
+        let entries = catalog_for_workspace(&root, storage.path()).unwrap();
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            ["valid"]
+        );
+        drop(valid);
+    }
+
+    #[test]
+    fn catalog_rejects_missing_and_non_directory_roots() {
+        let storage = tempfile::tempdir().unwrap();
+        let roots = tempfile::tempdir().unwrap();
+        let missing = roots.path().join("missing");
+        assert!(catalog_for_workspace(&missing, storage.path()).is_err());
+
+        let file = roots.path().join("file");
+        fs::write(&file, b"not a directory").unwrap();
+        assert!(catalog_for_workspace(&file, storage.path()).is_err());
+    }
+
+    #[test]
+    fn unbound_global_is_hidden_until_explicit_resume_binds_it() {
+        let storage = tempfile::tempdir().unwrap();
+        let roots = tempfile::tempdir().unwrap();
+        let first = roots.path().join("first");
+        let second = roots.path().join("second");
+        fs::create_dir(&first).unwrap();
+        fs::create_dir(&second).unwrap();
+        let record = Record {
+            schema_version: SCHEMA_VERSION,
+            session_id: "legacy".into(),
+            generation: 1,
+            workspace_root: None,
+            item: Some(Item::text(ItemKind::User, "private prompt")),
+            replacement: None,
+            redirect: None,
+        };
+        fs::write(
+            super::transcript_path(storage.path(), "legacy"),
+            format!("{}\n", serde_json::to_string(&record).unwrap()),
+        )
+        .unwrap();
+
+        assert!(
+            catalog_for_workspace(&first, storage.path())
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            catalog_for_workspace(&second, storage.path())
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            item_text(&load_in(&first, storage.path(), "legacy").unwrap()[0]),
+            "private prompt"
+        );
+        let resumed = open_in(&first, storage.path(), "legacy", true, false, Vec::new()).unwrap();
+        drop(resumed);
+        assert_eq!(
+            catalog_for_workspace(&first, storage.path()).unwrap()[0].id,
+            "legacy"
+        );
+        assert!(
+            catalog_for_workspace(&second, storage.path())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn catalog_rejects_conflicting_workspace_metadata_without_hiding_valid_sessions() {
+        let storage = tempfile::tempdir().unwrap();
+        let roots = tempfile::tempdir().unwrap();
+        let first = roots.path().join("first");
+        let second = roots.path().join("second");
+        fs::create_dir(&first).unwrap();
+        fs::create_dir(&second).unwrap();
+        let first = canonical_workspace(&first);
+        let second = canonical_workspace(&second);
+        let records = [
+            Record {
+                schema_version: SCHEMA_VERSION,
+                session_id: "conflict".into(),
+                generation: 1,
+                workspace_root: Some(first.clone()),
+                item: Some(Item::text(ItemKind::User, "first private prompt")),
+                replacement: None,
+                redirect: None,
+            },
+            Record {
+                schema_version: SCHEMA_VERSION,
+                session_id: "conflict".into(),
+                generation: 2,
+                workspace_root: Some(second.clone()),
+                item: Some(Item::text(ItemKind::User, "second private prompt")),
+                replacement: None,
+                redirect: None,
+            },
+        ];
+        let transcript = records
+            .iter()
+            .map(|record| serde_json::to_string(record).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        fs::write(
+            super::transcript_path(storage.path(), "conflict"),
+            transcript,
+        )
+        .unwrap();
+        let valid = open_in(
+            &first,
+            storage.path(),
+            "valid",
+            false,
+            false,
+            vec![Item::text(ItemKind::User, "valid")],
+        )
+        .unwrap();
+
+        assert_eq!(
+            catalog_for_workspace(&first, storage.path()).unwrap()[0].id,
+            "valid"
+        );
+        assert!(
+            catalog_for_workspace(&second, storage.path())
+                .unwrap()
+                .is_empty()
+        );
+        drop(valid);
+    }
+
+    #[test]
+    fn load_and_resume_ignore_unbound_global_on_a_scoped_id_collision() {
+        let storage = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let id = "collision";
+        let global = Record {
+            schema_version: SCHEMA_VERSION,
+            session_id: id.into(),
+            generation: 1,
+            workspace_root: None,
+            item: Some(Item::text(ItemKind::User, "private global prompt")),
+            replacement: None,
+            redirect: None,
+        };
+        fs::write(
+            super::transcript_path(storage.path(), id),
+            format!("{}\n", serde_json::to_string(&global).unwrap()),
+        )
+        .unwrap();
+        let scoped_directory =
+            workspace_storage_directory(storage.path(), &canonical_workspace(root.path()));
+        fs::create_dir_all(&scoped_directory).unwrap();
+        let scoped = Record {
+            workspace_root: Some(canonical_workspace(root.path())),
+            item: Some(Item::text(ItemKind::User, "visible scoped prompt")),
+            ..global
+        };
+        fs::write(
+            super::transcript_path(&scoped_directory, id),
+            format!("{}\n", serde_json::to_string(&scoped).unwrap()),
+        )
+        .unwrap();
+
+        let entries = catalog_for_workspace(root.path(), storage.path()).unwrap();
+        assert_eq!(entries[0].title.as_deref(), Some("visible scoped prompt"));
+        assert_eq!(
+            item_text(&load_in(root.path(), storage.path(), id).unwrap()[0]),
+            "visible scoped prompt"
+        );
+        let resumed = open_in(root.path(), storage.path(), id, true, false, Vec::new()).unwrap();
+        assert_eq!(item_text(&resumed.transcript[0]), "visible scoped prompt");
+        drop(resumed);
+
+        let StoredTranscript::History(history) =
+            read_records_direct(&super::transcript_path(storage.path(), id), id).unwrap()
+        else {
+            panic!("unbound global collision was redirected");
+        };
+        assert_eq!(item_text(&history.items[0]), "private global prompt");
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -42,6 +42,8 @@ use super::{
 pub enum Update {
     /// The actual dynamically allocated A2A listen address.
     A2aAddress(String),
+    /// Result of listing sessions without blocking the terminal event loop.
+    SessionCatalog(Result<Vec<crate::session::CatalogEntry>, String>),
     /// A steer was accepted but has not been delivered into the transcript yet.
     SteerAccepted { id: String, text: String },
     /// A user message delivered or replayed by the agent.
@@ -203,6 +205,10 @@ pub struct EffortDialog {
     pub save_defaults: bool,
 }
 
+pub struct SessionDialog {
+    pub selected: usize,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AttachmentKind {
     Image,
@@ -238,6 +244,7 @@ pub enum Action {
         inject: bool,
     },
     New(Option<String>),
+    ListSessions,
     Resume(String),
     Close,
     SelectModel {
@@ -482,6 +489,8 @@ pub struct App {
     pub reasoning_effort: String,
     pub effort_choices: Vec<EffortChoice>,
     pub effort_dialog: Option<EffortDialog>,
+    pub session_choices: Vec<crate::session::CatalogEntry>,
+    pub session_dialog: Option<SessionDialog>,
     pub available_commands: Vec<String>,
     pub a2a: String,
     pub session_id: Option<String>,
@@ -750,6 +759,8 @@ impl App {
             reasoning_effort: "default".into(),
             effort_choices: Vec::new(),
             effort_dialog: None,
+            session_choices: Vec::new(),
+            session_dialog: None,
             available_commands: Vec::new(),
             a2a,
             session_id: None,
@@ -1328,6 +1339,16 @@ impl App {
     pub fn apply(&mut self, update: Update) {
         match update {
             Update::A2aAddress(address) => self.a2a = address,
+            Update::SessionCatalog(result) => match result {
+                Ok(entries) if entries.is_empty() => {
+                    self.toast("no sessions found for this workspace");
+                }
+                Ok(entries) => {
+                    self.session_choices = entries;
+                    self.session_dialog = Some(SessionDialog { selected: 0 });
+                }
+                Err(error) => self.toast(format!("could not list sessions: {error}")),
+            },
             Update::AvailableCommands {
                 session_id,
                 commands,
@@ -1928,10 +1949,43 @@ impl App {
         Action::None
     }
 
+    fn handle_session_key(&mut self, key: KeyEvent) -> Action {
+        match key.code {
+            KeyCode::Esc => self.session_dialog = None,
+            KeyCode::Up => {
+                if let Some(dialog) = &mut self.session_dialog {
+                    dialog.selected = dialog.selected.saturating_sub(1);
+                }
+            }
+            KeyCode::Down => {
+                if let Some(dialog) = &mut self.session_dialog {
+                    dialog.selected =
+                        (dialog.selected + 1).min(self.session_choices.len().saturating_sub(1));
+                }
+            }
+            KeyCode::Enter => {
+                let selected = self
+                    .session_dialog
+                    .as_ref()
+                    .map_or(0, |dialog| dialog.selected);
+                if let Some(entry) = self.session_choices.get(selected) {
+                    let id = entry.id.clone();
+                    self.session_dialog = None;
+                    return Action::Resume(id);
+                }
+            }
+            _ => {}
+        }
+        Action::None
+    }
+
     /// Applies a key press, returning work for the event loop.
     pub fn handle_key(&mut self, key: KeyEvent) -> Action {
         if key.kind != KeyEventKind::Press {
             return Action::None;
+        }
+        if self.session_dialog.is_some() {
+            return self.handle_session_key(key);
         }
         if self.model_dialog.is_some() {
             return self.handle_model_key(key);
@@ -2040,6 +2094,7 @@ impl App {
                         self.toast("usage: /resume <session-id>");
                         Action::None
                     }
+                    Parsed::Sessions => Action::ListSessions,
                     Parsed::Close => Action::Close,
                     Parsed::Model { query: Some(query) } => match self.closest_model(query) {
                         Some(choice) => Action::SelectModel {
@@ -3498,6 +3553,54 @@ mod tests {
             model_choice("anthropic", "claude-3-7-sonnet"),
             model_choice("openrouter", "anthropic/claude-sonnet-4"),
         ]
+    }
+
+    #[test]
+    fn sessions_command_defers_catalog_work_to_the_event_loop() {
+        let mut app = app();
+        app.editor.insert_str("/sessions");
+        assert!(matches!(
+            app.handle_key(press(KeyCode::Enter)),
+            Action::ListSessions
+        ));
+        assert!(app.session_dialog.is_none());
+    }
+
+    #[test]
+    fn session_catalog_update_opens_the_dialog() {
+        let mut app = app();
+        app.apply(Update::SessionCatalog(Ok(vec![
+            crate::session::CatalogEntry {
+                id: "saved".into(),
+                title: Some("Saved".into()),
+                preview: None,
+                updated_at: 0,
+            },
+        ])));
+        assert_eq!(app.session_choices[0].id, "saved");
+        assert!(app.session_dialog.is_some());
+    }
+
+    #[test]
+    fn session_dialog_selects_a_catalog_entry_for_existing_resume_flow() {
+        let mut app = app();
+        app.session_choices = ["newer", "older"]
+            .into_iter()
+            .map(|id| crate::session::CatalogEntry {
+                id: id.into(),
+                title: Some(format!("{id} title")),
+                preview: None,
+                updated_at: 0,
+            })
+            .collect();
+        app.session_dialog = Some(super::SessionDialog { selected: 0 });
+
+        assert!(matches!(app.handle_key(press(KeyCode::Down)), Action::None));
+        assert!(matches!(
+            app.handle_key(press(KeyCode::Enter)),
+            Action::Resume(id) if id == "older"
+        ));
+        assert!(app.session_dialog.is_none());
     }
 
     #[test]

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -9,6 +9,7 @@ use std::ops::Range;
 enum Kind {
     New,
     Resume,
+    Sessions,
     Close,
     Model,
     Effort,
@@ -31,6 +32,10 @@ const LOCAL_COMMANDS: &[Spec] = &[
         kind: Kind::Resume,
     },
     Spec {
+        token: "/sessions",
+        kind: Kind::Sessions,
+    },
+    Spec {
         token: "/close",
         kind: Kind::Close,
     },
@@ -48,6 +53,7 @@ const LOCAL_COMMANDS: &[Spec] = &[
 pub enum Parsed<'a> {
     New { prompt: Option<&'a str> },
     Resume { session_id: Option<&'a str> },
+    Sessions,
     Close,
     Model { query: Option<&'a str> },
     Effort { value: Option<&'a str> },
@@ -79,6 +85,7 @@ pub fn parse(input: &str) -> Parsed<'_> {
     match spec.kind {
         Kind::New => Parsed::New { prompt },
         Kind::Resume => Parsed::Resume { session_id: prompt },
+        Kind::Sessions => Parsed::Sessions,
         Kind::Close => Parsed::Close,
         Kind::Model => Parsed::Model { query: prompt },
         Kind::Effort => Parsed::Effort { value: prompt },
@@ -111,6 +118,7 @@ mod tests {
                 session_id: Some("session-1")
             }
         );
+        assert_eq!(parse("/sessions"), Parsed::Sessions);
         assert_eq!(parse("/close"), Parsed::Close);
         assert_eq!(parse("/model"), Parsed::Model { query: None });
         assert_eq!(parse("/effort"), Parsed::Effort { value: None });
@@ -147,6 +155,7 @@ mod tests {
             assert_eq!(known_token(input, &[]), None);
         }
         assert_eq!(known_token("/new prompt", &[]), Some(0..4));
+        assert_eq!(known_token("/sessions", &[]), Some(0..9));
         assert_eq!(known_token("/model sonnet", &[]), Some(0..6));
         assert_eq!(known_token("/effort high", &[]), Some(0..7));
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -75,6 +75,52 @@ const MAX_TOTAL_ATTACHMENT_BYTES: u64 = 20 * 1024 * 1024;
 /// Output lines kept per tool call; the fold shows the count either way.
 const MAX_OUTPUT_LINES: usize = 5_000;
 
+#[derive(Clone)]
+struct ActiveSessionRoute {
+    id: String,
+    generation: u64,
+}
+
+struct QueuedUpdate {
+    generation: Option<u64>,
+    update: Update,
+}
+
+impl QueuedUpdate {
+    fn global(update: Update) -> Self {
+        Self {
+            generation: None,
+            update,
+        }
+    }
+
+    fn for_session(generation: u64, update: Update) -> Self {
+        Self {
+            generation: Some(generation),
+            update,
+        }
+    }
+}
+
+fn transition_route(route: &Arc<Mutex<ActiveSessionRoute>>, id: String) {
+    if let Ok(mut route) = route.lock() {
+        route.id = id;
+        route.generation = route.generation.wrapping_add(1);
+    }
+}
+
+fn accept_queued_update(
+    route: &Arc<Mutex<ActiveSessionRoute>>,
+    queued: QueuedUpdate,
+) -> Option<Update> {
+    let accepted = queued.generation.is_none_or(|generation| {
+        route
+            .lock()
+            .is_ok_and(|route| route.generation == generation)
+    });
+    accepted.then_some(queued.update)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, agent_client_protocol::JsonRpcRequest)]
 #[request(method = "kit/background/cancel", response = CancelBackgroundResponse)]
 struct CancelBackgroundRequest {
@@ -295,7 +341,10 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
     let persisted_session_id = resume_session_id
         .clone()
         .unwrap_or_else(crate::session::new_id);
-    let active_persisted_id = Arc::new(Mutex::new(persisted_session_id.clone()));
+    let active_persisted_id = Arc::new(Mutex::new(ActiveSessionRoute {
+        id: persisted_session_id.clone(),
+        generation: 0,
+    }));
     let mut command = crate::acp_child::serve_command(
         root,
         model,
@@ -360,15 +409,15 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                     Update::Log(line)
                 }
             };
-            if diagnostics.send(update).is_err() {
+            if diagnostics.send(QueuedUpdate::global(update)).is_err() {
                 return;
             }
         }
         // Stderr closing means the agent process is gone; stop any spinner
         // waiting on a turn that can no longer finish.
-        let _ = diagnostics.send(Update::ProcessExited(
+        let _ = diagnostics.send(QueuedUpdate::global(Update::ProcessExited(
             "the agent process exited — press ctrl+c to leave".into(),
-        ));
+        )));
     });
 
     // The child is watched from its own task, which also owns it: aborting that
@@ -396,12 +445,19 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
         .v2()
         .on_receive_notification(
             async move |notification: UpdateSessionNotification, _cx| {
-                let current = notification_session.lock().ok().map(|id| id.clone());
-                for update in current
-                    .as_deref()
-                    .map_or_else(Vec::new, |current| translate_for_session(notification, current))
-                {
-                    let _ = notifications.send(update);
+                let current = notification_session.lock().ok().map(|route| route.clone());
+                for update in current.as_ref().map_or_else(Vec::new, |route| {
+                    translate_for_session(notification, &route.id)
+                }) {
+                    let queued = if matches!(update, Update::AvailableCommands { .. }) {
+                        QueuedUpdate::global(update)
+                    } else {
+                        QueuedUpdate::for_session(
+                            current.as_ref().map_or(0, |route| route.generation),
+                            update,
+                        )
+                    };
+                    let _ = notifications.send(queued);
                 }
                 Ok(())
             },
@@ -485,7 +541,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
             refresh_config_state(&mut app, Some(&config_options));
             app.can_steer = can_steer;
             if let Ok(mut active) = transition_session.lock() {
-                *active = active_session_id.clone();
+                active.id = active_session_id.clone();
             }
             app.start_session(active_session_id);
             let mut events = EventStream::new();
@@ -580,9 +636,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     let persisted_id = durable_session_id(&session_id).map_err(|error| {
                                         agent_client_protocol::Error::into_internal_error(std::io::Error::other(error))
                                     })?;
-                                    if let Ok(mut active) = transition_session.lock() {
-                                        *active = persisted_id.clone();
-                                    }
+                                    transition_route(&transition_session, persisted_id.clone());
                                     images.clear();
                                     app.start_session(persisted_id);
                                     refresh_config_state(&mut app, Some(&session.config_options));
@@ -599,22 +653,51 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                         }
                                     }
                                 }
+                                Action::ListSessions => {
+                                    let Ok(route) = transition_session.lock() else {
+                                        app.note("could not start session catalog scan");
+                                        continue;
+                                    };
+                                    let generation = route.generation;
+                                    drop(route);
+                                    let root = root.clone();
+                                    let updates = updates_tx.clone();
+                                    tokio::spawn(async move {
+                                        let result = tokio::task::spawn_blocking(move || {
+                                            crate::session::catalog(&root)
+                                        })
+                                        .await
+                                        .map_err(|error| {
+                                            format!("session catalog worker failed: {error}")
+                                        })
+                                        .and_then(|result| result);
+                                        let _ = updates.send(QueuedUpdate::for_session(
+                                            generation,
+                                            Update::SessionCatalog(result),
+                                        ));
+                                    });
+                                }
                                 Action::Resume(requested_id) => {
                                     if let Err(error) = crate::session::validate_id(&requested_id) {
                                         app.note(format!("invalid session id: {error}"));
                                         continue;
                                     }
+                                    let Some(previous_persisted_id) =
+                                        previous_session_for_resume(&session_id, &requested_id)
+                                            .map_err(|error| {
+                                                agent_client_protocol::Error::into_internal_error(
+                                                    std::io::Error::other(error),
+                                                )
+                                            })?
+                                    else {
+                                        app.note(format!("session {requested_id} is already active"));
+                                        continue;
+                                    };
                                     if let Err(error) = crate::session::load(&root, &requested_id) {
                                         app.note(format!("could not resume session: {error}"));
                                         continue;
                                     }
                                     let previous_session_id = session_id.clone();
-                                    let previous_persisted_id = durable_session_id(&session_id)
-                                        .map_err(|error| {
-                                            agent_client_protocol::Error::into_internal_error(
-                                                std::io::Error::other(error),
-                                            )
-                                        })?;
                                     if let Err(error) = connection
                                         .send_request(CloseSessionRequest::new(session_id.clone()))
                                         .block_task()
@@ -627,9 +710,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                         continue;
                                     }
                                     session_id = wire::SessionId::new(requested_id.clone());
-                                    if let Ok(mut active) = transition_session.lock() {
-                                        *active = requested_id.clone();
-                                    }
+                                    transition_route(&transition_session, requested_id.clone());
                                     images.clear();
                                     app.start_session(requested_id.clone());
                                     match request_resume(&connection, session_id.clone(), root.clone()).await {
@@ -639,9 +720,10 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                         ),
                                         Err(error) => {
                                             session_id = previous_session_id;
-                                            if let Ok(mut active) = transition_session.lock() {
-                                                *active = previous_persisted_id.clone();
-                                            }
+                                            transition_route(
+                                                &transition_session,
+                                                previous_persisted_id.clone(),
+                                            );
                                             images.clear();
                                             app.start_session(previous_persisted_id);
                                             let restored = request_resume(
@@ -779,11 +861,16 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                         },
                         update = updates_rx.recv() => match update {
                             Some(update) => {
-                                if let Update::ConfigOptions(options) = &update {
-                                    refresh_config_state(&mut app, Some(options));
+                                if let Some(update) = accept_queued_update(&transition_session, update) {
+                                    if let Update::ConfigOptions(options) = &update {
+                                        refresh_config_state(&mut app, Some(options));
+                                    }
+                                    app.apply(update);
                                 }
-                                app.apply(update);
                                 while let Ok(update) = updates_rx.try_recv() {
+                                    let Some(update) = accept_queued_update(&transition_session, update) else {
+                                        continue;
+                                    };
                                     if let Update::ConfigOptions(options) = &update {
                                         refresh_config_state(&mut app, Some(options));
                                     }
@@ -827,7 +914,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
     // If the server failed before acknowledging CloseSession, reclaim only a
     // lock that is now provably stale; a live owner's OS lock is never stolen.
     if let Ok(active) = active_persisted_id.lock() {
-        let _ = crate::session::remove_stale_lock(&cleanup_root, &active);
+        let _ = crate::session::remove_stale_lock(&cleanup_root, &active.id);
     }
 
     result?;
@@ -1240,6 +1327,14 @@ fn durable_session_id(session_id: &wire::SessionId) -> Result<String, String> {
     Ok(session_id)
 }
 
+fn previous_session_for_resume(
+    current: &wire::SessionId,
+    requested: &str,
+) -> Result<Option<String>, String> {
+    let current = durable_session_id(current)?;
+    Ok((current != requested).then_some(current))
+}
+
 /// Maps one ACP session notification onto client updates.
 fn translate(notification: UpdateSessionNotification) -> (String, Vec<Update>) {
     let session_id = notification.session_id.to_string();
@@ -1581,7 +1676,10 @@ fn readable(text: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{
+        path::PathBuf,
+        sync::{Arc, Mutex},
+    };
 
     use agent_client_protocol::schema::v2::{
         AgentMessage, AgentThought, AvailableCommand, AvailableCommandsUpdate, ContentBlock,
@@ -1594,10 +1692,12 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        MAX_ATTACHMENTS, ModelChoice, attachments_from_paste, current_model_choice,
-        detach_from_controlling_terminal, durable_session_id, effort_state, handle, message_of,
-        osc52, prompt_blocks, readable, refresh_config_state, save_effort_default_to,
-        save_model_defaults_to, translate, translate_for_session, user_message_of, wire,
+        ActiveSessionRoute, MAX_ATTACHMENTS, ModelChoice, QueuedUpdate, accept_queued_update,
+        attachments_from_paste, current_model_choice, detach_from_controlling_terminal,
+        durable_session_id, effort_state, handle, message_of, osc52, previous_session_for_resume,
+        prompt_blocks, readable, refresh_config_state, save_effort_default_to,
+        save_model_defaults_to, transition_route, translate, translate_for_session,
+        user_message_of, wire,
     };
     use crate::tui::app::{App, SubmittedPrompt, Update};
 
@@ -1614,6 +1714,52 @@ mod tests {
         assert_eq!(unsafe { libc::getsid(pid) }, pid);
         child.kill().await.unwrap();
         child.wait().await.unwrap();
+    }
+
+    #[test]
+    fn resuming_the_active_session_is_a_noop() {
+        let current = wire::SessionId::new("current");
+        assert_eq!(
+            previous_session_for_resume(&current, "current").unwrap(),
+            None
+        );
+        assert_eq!(
+            previous_session_for_resume(&current, "other")
+                .unwrap()
+                .as_deref(),
+            Some("current")
+        );
+    }
+
+    #[test]
+    fn queued_updates_from_previous_session_generations_are_dropped() {
+        let route = Arc::new(Mutex::new(ActiveSessionRoute {
+            id: "first".into(),
+            generation: 0,
+        }));
+        let old = QueuedUpdate::for_session(0, Update::Log("old".into()));
+
+        transition_route(&route, "second".into());
+        assert!(accept_queued_update(&route, old).is_none());
+        transition_route(&route, "first".into());
+        assert!(
+            accept_queued_update(
+                &route,
+                QueuedUpdate::for_session(0, Update::Log("older attachment".into())),
+            )
+            .is_none()
+        );
+        assert!(
+            accept_queued_update(
+                &route,
+                QueuedUpdate::for_session(2, Update::Log("current".into())),
+            )
+            .is_some()
+        );
+        assert!(
+            accept_queued_update(&route, QueuedUpdate::global(Update::Log("global".into())))
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -113,7 +113,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App, images: &mut ImageRuntime) {
         draw_prompt(frame, app, prompt);
         draw_status(frame, app, status);
     }
-    if app.model_dialog.is_some() {
+    if app.session_dialog.is_some() {
+        draw_session_dialog(frame, app);
+    } else if app.model_dialog.is_some() {
         draw_model_dialog(frame, app);
     } else if app.effort_dialog.is_some() {
         draw_effort_dialog(frame, app);
@@ -174,6 +176,72 @@ fn visible_query_tail(query: &str, width: usize) -> &str {
         tail = &tail[index..];
     }
     tail
+}
+
+fn draw_session_dialog(frame: &mut Frame<'_>, app: &App) {
+    let outer = frame.area();
+    let width = if outer.width > 20 {
+        outer.width.saturating_sub(4).min(88)
+    } else {
+        outer.width
+    };
+    let height = outer
+        .height
+        .min((app.session_choices.len() as u16).saturating_add(3).min(22));
+    let area = Rect::new(
+        outer.x + outer.width.saturating_sub(width) / 2,
+        outer.y + outer.height.saturating_sub(height) / 2,
+        width,
+        height,
+    );
+    let selected = app
+        .session_dialog
+        .as_ref()
+        .map_or(0, |dialog| dialog.selected);
+    let panel = Panel::bordered().title(" sessions ");
+    let inner = panel.inner(area);
+    let footer_rows = u16::from(inner.height > 1);
+    let [list, footer] =
+        Layout::vertical([Constraint::Min(0), Constraint::Length(footer_rows)]).areas(inner);
+    let visible = list.height as usize;
+    let start = selected
+        .saturating_sub(visible / 2)
+        .min(app.session_choices.len().saturating_sub(visible));
+    let lines = app.session_choices[start..]
+        .iter()
+        .take(visible)
+        .enumerate()
+        .map(|(offset, entry)| {
+            let is_selected = start + offset == selected;
+            let label = entry
+                .title
+                .as_deref()
+                .or(entry.preview.as_deref())
+                .unwrap_or("untitled");
+            let updated = entry.updated_at_rfc3339();
+            Line::from(Span::styled(
+                format!(
+                    "{}{} · {} · {}",
+                    if is_selected { "› " } else { "  " },
+                    &updated[..10],
+                    entry.id,
+                    label
+                ),
+                if is_selected {
+                    theme::accent()
+                } else {
+                    theme::text()
+                },
+            ))
+        })
+        .collect::<Vec<_>>();
+    frame.render_widget(Clear, area);
+    frame.render_widget(panel, area);
+    frame.render_widget(Paragraph::new(lines), list);
+    frame.render_widget(
+        Paragraph::new(Span::styled("enter resume · esc close", theme::dim())),
+        footer,
+    );
 }
 
 fn draw_effort_dialog(frame: &mut Frame<'_>, app: &App) {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,27 @@
+use std::{fs, process::Command};
+
+#[test]
+fn sessions_rejects_missing_and_non_directory_roots() {
+    let home = tempfile::tempdir().unwrap();
+    let missing = home.path().join("missing");
+    let output = Command::new(env!("CARGO_BIN_EXE_kit"))
+        .env("HOME", home.path())
+        .args(["sessions", "--root"])
+        .arg(&missing)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("could not resolve workspace root"));
+
+    let file = home.path().join("workspace-file");
+    fs::write(&file, b"not a directory").unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_kit"))
+        .env("HOME", home.path())
+        .args(["sessions", "--root"])
+        .arg(&file)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("is not a directory"));
+}


### PR DESCRIPTION
## Summary

Adds a workspace-scoped catalog of durable sessions and exposes it through `kit sessions`, the TUI `/sessions` picker, and ACP v1/v2 `session/list`. Session listings are newest-first and include stable titles, current previews where supported, and updated timestamps.

## Motivation

Persisted sessions were resumable only when the caller already knew the session ID. This makes past sessions discoverable from Kit's local interfaces and from protocol clients.

## Impact

Users can list and resume prior sessions without copying IDs from earlier output. ACP v1 clients can use the advertised optional list capability, while ACP v2 clients use the standard session listing method. Unbound legacy transcripts remain resumable by a known ID but are excluded from discovery until they are bound to a workspace.

## Technical details

### Catalog isolation and compatibility

The shared catalog resolves scoped, global, and legacy transcript authorities without changing the persistent schema. It preserves stable titles through compaction and migration, skips malformed individual entries, sanitizes display metadata, and prevents metadata from leaking across workspaces.

### Non-blocking protocol and TUI discovery

ACP handlers and the TUI run filesystem discovery off their async event paths. TUI updates and catalog responses carry attachment generations so stale events cannot cross session transitions.

### ACP behavior

ACP v1 advertises `sessionCapabilities.list` and implements exact `cwd` filtering plus opaque cursor pagination. ACP v2 reuses the same catalog. Both versions report malformed cursors as invalid parameters.