### PR TITLE
fix(tui): resume sessions with stale locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.107"
+version = "0.1.108"
 dependencies = [
  "a2a-protocol-client",
  "a2a-protocol-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.1.107"
+version = "0.1.108"
 edition = "2024"
 rust-version = "1.94.0"
 publish = false

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -693,7 +693,13 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                         app.note(format!("session {requested_id} is already active"));
                                         continue;
                                     };
-                                    if let Err(error) = crate::session::load(&root, &requested_id) {
+                                    // Session switching has no `--force` flag. Reclaim only a
+                                    // lock that the OS proves no live Kit process still holds.
+                                    if let Err(error) = crate::session::load(&root, &requested_id)
+                                        .and_then(|_| {
+                                            crate::session::remove_stale_lock(&root, &requested_id)
+                                        })
+                                    {
                                         app.note(format!("could not resume session: {error}"));
                                         continue;
                                     }


### PR DESCRIPTION
## Summary

Allow TUI session switches to recover abandoned session lock files before sending the ACP resume request. Locks held by live Kit processes remain protected.

## Motivation

`/resume` and the `/sessions` picker had no way to supply `--force`, so a session left behind by a terminated process failed to resume and surfaced only a generic internal error.

## Technical details

### Lock safety

The TUI validates and loads the requested session, then uses the existing stale-lock cleanup path before closing the current session. Cleanup acquires the OS lock before removing the lock file, so it cannot take ownership from a live Kit process; failures leave the current session active.
