### PR TITLE
fix(subagents): harden roster lifecycle and rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "kit"
-version = "0.1.109"
+version = "0.1.110"
 dependencies = [
  "a2a-protocol-client",
  "a2a-protocol-server",
@@ -2581,6 +2581,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry 0.33.0",
  "tracing-subscriber",
+ "unicode-segmentation",
  "unicode-width",
  "url",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kit"
-version = "0.1.109"
+version = "0.1.110"
 edition = "2024"
 rust-version = "1.94.0"
 publish = false
@@ -66,6 +66,7 @@ tower = { version = "=0.5.3", features = ["util"] }
 tracing = "=0.1.44"
 tracing-opentelemetry = { version = "=0.33.0", default-features = false }
 tracing-subscriber = { version = "=0.3.23", default-features = false, features = ["registry", "std"] }
+unicode-segmentation = "=1.13.3"
 unicode-width = "=0.2.2"
 url = "=2.5.8"
 uuid = { version = "=1.26.0", features = ["v5"] }

--- a/fixtures/mock-acp.py
+++ b/fixtures/mock-acp.py
@@ -6,10 +6,29 @@ import threading
 import time
 
 write_lock = threading.Lock()
+log_lock = threading.Lock()
+state_lock = threading.Lock()
 next_session = 1
 supports_fork = "--no-fork" not in sys.argv
 supports_models = "--models" in sys.argv
+fail_first_close = "--fail-first-close" in sys.argv
+failed_close = False
 selected_models = {}
+
+
+def option(name):
+    prefix = name + "="
+    return next((arg[len(prefix):] for arg in sys.argv if arg.startswith(prefix)), None)
+
+
+request_log = option("--request-log")
+new_release = option("--new-release")
+fork_release = option("--fork-release")
+prompt_release = option("--prompt-release")
+prompt_release_text = option("--prompt-release-text")
+close_release = option("--close-release")
+close_release_session = option("--close-release-session")
+fail_close_session = option("--fail-close-session")
 model_ids = ["mock/default", "mock/requested"]
 
 if "--fail-start" in sys.argv:
@@ -26,11 +45,58 @@ def respond(request_id, result):
     send({"jsonrpc": "2.0", "id": request_id, "result": result})
 
 
+def log_request(request):
+    if request_log is None:
+        return
+    params = request.get("params", {})
+    entry = {"method": request.get("method")}
+    if "sessionId" in params:
+        entry["sessionId"] = params["sessionId"]
+    if request.get("method") == "session/prompt":
+        entry["text"] = params["prompt"][0]["text"]
+    with log_lock:
+        with open(request_log, "a", encoding="utf-8") as log:
+            log.write(json.dumps(entry, separators=(",", ":")) + "\n")
+            log.flush()
+
+
+def fork(request):
+    global next_session
+    if "--fail-fork" in sys.argv:
+        send({
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "error": {"code": -32000, "message": "fork failed"},
+        })
+        return
+    if not supports_fork:
+        send({
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "error": {"code": -32601, "message": "Method not found"},
+        })
+        return
+    source_id = request["params"]["sessionId"]
+    with state_lock:
+        session_id = f"branch-{next_session}"
+        next_session += 1
+        selected_models[session_id] = selected_models.get(source_id, model_ids[0])
+    while fork_release is not None and not os.path.exists(fork_release):
+        time.sleep(0.01)
+    respond(request["id"], {"sessionId": session_id})
+
+
 def prompt(request):
     params = request["params"]
     session_id = params["sessionId"]
     text = params["prompt"][0]["text"]
-    time.sleep(0.40)
+    should_gate = prompt_release is not None and (
+        prompt_release_text is None or prompt_release_text == text
+    )
+    while should_gate and not os.path.exists(prompt_release):
+        time.sleep(0.01)
+    if prompt_release is None:
+        time.sleep(0.40)
     if "MOCK_SELECTED_MODEL" in text:
         text = selected_models.get(session_id, model_ids[0])
     if "MOCK_STRUCTURED_OUTPUT" in text:
@@ -94,9 +160,36 @@ def prompt(request):
         os._exit(0)
 
 
+def close(request):
+    global failed_close
+    if "--slow-close" in sys.argv:
+        time.sleep(0.40)
+    session_id = request["params"]["sessionId"]
+    should_gate = close_release is not None and (
+        close_release_session is None or close_release_session == session_id
+    )
+    while should_gate and not os.path.exists(close_release):
+        time.sleep(0.01)
+    with state_lock:
+        should_fail = (fail_close_session == session_id and not failed_close) or (
+            fail_first_close and not failed_close
+        )
+        if should_fail:
+            failed_close = True
+    if should_fail:
+        send({
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "error": {"code": -32000, "message": "close failed"},
+        })
+    else:
+        respond(request["id"], {})
+
+
 for line in sys.stdin:
     request = json.loads(line)
     method = request.get("method")
+    log_request(request)
     if method == "initialize":
         respond(request["id"], {
             "protocolVersion": 1,
@@ -107,6 +200,8 @@ for line in sys.stdin:
             },
         })
     elif method == "session/new":
+        while new_release is not None and not os.path.exists(new_release):
+            time.sleep(0.01)
         selected_models["base"] = model_ids[0]
         result = {"sessionId": "base"}
         if supports_models:
@@ -122,25 +217,7 @@ for line in sys.stdin:
             }]
         respond(request["id"], result)
     elif method == "session/fork":
-        if "--fail-fork" in sys.argv:
-            send({
-                "jsonrpc": "2.0",
-                "id": request["id"],
-                "error": {"code": -32000, "message": "fork failed"},
-            })
-            continue
-        if not supports_fork:
-            send({
-                "jsonrpc": "2.0",
-                "id": request["id"],
-                "error": {"code": -32601, "message": "Method not found"},
-            })
-            continue
-        session_id = f"branch-{next_session}"
-        next_session += 1
-        source_id = request["params"]["sessionId"]
-        selected_models[session_id] = selected_models.get(source_id, model_ids[0])
-        respond(request["id"], {"sessionId": session_id})
+        threading.Thread(target=fork, args=(request,), daemon=True).start()
     elif method == "session/prompt":
         threading.Thread(target=prompt, args=(request,), daemon=True).start()
     elif method == "session/set_config_option":
@@ -158,6 +235,4 @@ for line in sys.stdin:
     elif method == "session/cancel":
         pass
     elif method == "session/close":
-        if "--slow-close" in sys.argv:
-            time.sleep(0.40)
-        respond(request["id"], {})
+        threading.Thread(target=close, args=(request,), daemon=True).start()

--- a/src/acp_child.rs
+++ b/src/acp_child.rs
@@ -275,8 +275,7 @@ impl AcpHarnesses {
             command
                 .arg("--subagent-parent-id")
                 .arg(parent_id)
-                .arg("--subagent-parent-name")
-                .arg(parent_name);
+                .arg(format!("--subagent-parent-name={parent_name}"));
         }
         if resume {
             command.arg("--resume");
@@ -2000,10 +1999,18 @@ mod tests {
                 args.windows(2)
                     .any(|pair| pair == ["--subagent-parent-id", "s-parent"])
             );
-            assert!(
-                args.windows(2)
-                    .any(|pair| pair == ["--subagent-parent-name", "偵察 🦀"])
-            );
+            assert!(args.contains(&"--subagent-parent-name=偵察 🦀".into()));
+        }
+
+        #[test]
+        fn kit_child_parent_name_is_safe_when_it_starts_with_a_hyphen() {
+            let config = config(Some("s-parent"), Some("--reviewer"));
+            let command = config
+                .harnesses
+                .spawn(BUILTIN_HARNESS, &config, Some(("session", false)), 1)
+                .unwrap();
+
+            assert!(args(&command).contains(&"--subagent-parent-name=--reviewer".into()));
         }
 
         #[test]

--- a/src/tools/subagent.rs
+++ b/src/tools/subagent.rs
@@ -10,7 +10,7 @@ use agentkit_tools_core::{
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tokio::sync::{Mutex as AsyncMutex, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Mutex as AsyncMutex, OwnedSemaphorePermit, Semaphore, oneshot};
 
 const MAX_LIVE_SUBAGENTS: usize = 120;
 const MAX_DISPLAY_NAME_LEN: usize = 32;
@@ -27,12 +27,15 @@ fn normalize_display_name(candidate: &str) -> Option<String> {
     }
 }
 
-fn allocate_display_name(used: &mut HashSet<String>, preferred: Option<&str>) -> String {
+fn allocate_display_name(
+    used: &mut HashSet<String>,
+    preferred: Option<&str>,
+) -> Result<String, ChildError> {
     if let Some(name) = preferred.and_then(normalize_display_name) {
         if reserve_name(used, &name) {
-            return name;
+            return Ok(name);
         }
-        for number in 2usize.. {
+        for number in 2..=MAX_LIVE_SUBAGENTS + 1 {
             let suffix = format!(" {number}");
             let Some(max_base_len) = MAX_DISPLAY_NAME_LEN.checked_sub(suffix.len()) else {
                 break;
@@ -40,18 +43,23 @@ fn allocate_display_name(used: &mut HashSet<String>, preferred: Option<&str>) ->
             let base = name[..name.len().min(max_base_len)].trim_end();
             let candidate = format!("{base}{suffix}");
             if reserve_name(used, &candidate) {
-                return candidate;
+                return Ok(candidate);
             }
         }
     }
 
-    for number in 1usize.. {
+    // At most MAX_LIVE_SUBAGENTS names can be reserved, so one of these
+    // MAX_LIVE_SUBAGENTS + 1 generated names must be available. Keep the
+    // search bounded and report invariant violations instead of looping.
+    for number in 1..=MAX_LIVE_SUBAGENTS + 1 {
         let name = format!("Agent {number}");
         if reserve_name(used, &name) {
-            return name;
+            return Ok(name);
         }
     }
-    unreachable!("generated subagent name space is inexhaustible")
+    Err(ChildError::Failed(
+        "could not allocate a unique subagent display name".into(),
+    ))
 }
 
 fn reserve_name(used: &mut HashSet<String>, name: &str) -> bool {
@@ -92,23 +100,11 @@ pub struct Subagents {
     sessions: Arc<Mutex<HashMap<String, SessionEntry>>>,
     capacity: Arc<Semaphore>,
     event_sink: EventSink,
-    #[cfg(test)]
-    failed_removals: Arc<Mutex<Vec<FailedRemoval>>>,
-    #[cfg(test)]
-    runtime_events: Arc<Mutex<Vec<events::RuntimeEvent>>>,
 }
 
 struct SessionEntry {
     name: String,
     state: Arc<AsyncMutex<State>>,
-}
-
-#[cfg(test)]
-#[derive(Clone, Debug)]
-struct FailedRemoval {
-    status: SubagentStatus,
-    outcome: Option<GenerationOutcome>,
-    finished_at_unix_ms: Option<u64>,
 }
 
 struct State {
@@ -127,7 +123,8 @@ struct State {
     model: Option<String>,
     kit: bool,
     child: Option<ChildSession>,
-    _permit: OwnedSemaphorePermit,
+    forking: Option<String>,
+    permit: Option<OwnedSemaphorePermit>,
 }
 
 impl State {
@@ -236,6 +233,29 @@ struct CreateOptions {
     model: Option<String>,
 }
 
+struct ForkSuccess {
+    value: SubagentValue,
+    acknowledge: oneshot::Sender<()>,
+}
+
+struct ForkOperation {
+    source_id: String,
+    source_state: Arc<AsyncMutex<State>>,
+    source_child: ChildSession,
+    id: String,
+    prompt: String,
+    name: Option<String>,
+    harness: String,
+    model: Option<String>,
+    kit: bool,
+    generation: u64,
+    depth: usize,
+    cancellation: TurnCancellation,
+    contract: Option<Arc<OutputContract>>,
+    permit: OwnedSemaphorePermit,
+    native_fork: bool,
+}
+
 impl Subagents {
     pub(crate) fn new(config: ChildConfig, max_depth: usize) -> Self {
         Self {
@@ -247,10 +267,6 @@ impl Subagents {
                 events::emit(event);
                 Ok(())
             }),
-            #[cfg(test)]
-            failed_removals: Arc::default(),
-            #[cfg(test)]
-            runtime_events: Arc::default(),
         }
     }
 
@@ -272,51 +288,7 @@ impl Subagents {
             *parent_id = self.config.parent_id.clone();
             *parent_name = self.config.parent_name.clone();
         }
-        #[cfg(test)]
-        if let Ok(mut emitted) = self.runtime_events.lock() {
-            emitted.push(event.clone());
-        }
         let _ = (self.event_sink)(&event);
-    }
-
-    #[cfg(test)]
-    fn runtime_events_for_test(&self) -> Vec<events::RuntimeEvent> {
-        self.runtime_events.lock().unwrap().clone()
-    }
-
-    #[cfg(test)]
-    fn with_event_sink_for_test(mut self, event_sink: EventSink) -> Self {
-        self.event_sink = event_sink;
-        self
-    }
-
-    #[cfg(test)]
-    async fn insert_starting_for_test(&self) -> String {
-        let now = events::now_millis();
-        let state = self
-            .insert_starting(
-                session::new_id(),
-                State {
-                    name: String::new(),
-                    status: SubagentStatus::Starting,
-                    task: "test".into(),
-                    generation: 1,
-                    handle_generation: 1,
-                    outcome: None,
-                    created_at_unix_ms: now,
-                    generation_started_at_unix_ms: now,
-                    generation_finished_at_unix_ms: None,
-                    output: Value::Null,
-                    updates: None,
-                    harness: crate::acp_child::BUILTIN_HARNESS.into(),
-                    model: None,
-                    kit: true,
-                    child: None,
-                    _permit: self.reserve().unwrap(),
-                },
-            )
-            .unwrap();
-        state.lock().await.name.clone()
     }
 
     fn harness_references(&self) -> Vec<String> {
@@ -370,7 +342,8 @@ impl Subagents {
                 model: model.clone(),
                 kit,
                 child: None,
-                _permit: permit,
+                forking: None,
+                permit: Some(permit),
             },
         )?;
         let persisted = kit.then(|| (id.clone(), false));
@@ -378,6 +351,10 @@ impl Subagents {
             .config
             .clone()
             .with_parent_context(id.clone(), state.lock().await.name.clone());
+        {
+            let locked = state.lock().await;
+            self.check_active(&locked)?;
+        }
         let child = match ChildSession::start(
             child_config,
             harness,
@@ -396,6 +373,18 @@ impl Subagents {
         };
         {
             let mut locked = state.lock().await;
+            if let Err(error) = self.check_active(&locked) {
+                drop(locked);
+                let error = self
+                    .reject_uninstalled_child_owned(
+                        id.clone(),
+                        Arc::clone(&state),
+                        child.clone(),
+                        error,
+                    )
+                    .await;
+                return Err(error);
+            }
             locked.status = SubagentStatus::Working;
             locked.child = Some(child.clone());
             self.emit_event(locked.runtime_event(id.clone()));
@@ -446,6 +435,11 @@ impl Subagents {
             () = cancellation.cancelled() => return Err(ChildError::Cancelled),
         };
         self.check_ready(&locked)?;
+        if locked.forking.is_some() {
+            return Err(ChildError::Failed(
+                "subagent session is being forked".into(),
+            ));
+        }
         self.check_generation(&prior, locked.handle_generation)?;
         let generation = locked
             .generation
@@ -495,15 +489,17 @@ impl Subagents {
                     self.fail_removed_and_remove(&prior.id, &state).await;
                 } else {
                     let mut locked = state.lock().await;
-                    locked.status = SubagentStatus::Idle;
-                    locked.outcome = Some(GenerationOutcome::Failed);
-                    locked.generation_finished_at_unix_ms = Some(events::now_millis());
-                    // A failed call returns no replacement handle, so preserve the
-                    // accepted handle generation for a retry while keeping lifecycle
-                    // generations monotonic.
-                    let event = locked.runtime_event(prior.id.clone());
-                    drop(locked);
-                    self.emit_event(event);
+                    if locked.status != SubagentStatus::Removed {
+                        locked.status = SubagentStatus::Idle;
+                        locked.outcome = Some(GenerationOutcome::Failed);
+                        locked.generation_finished_at_unix_ms = Some(events::now_millis());
+                        // A failed call returns no replacement handle, so preserve the
+                        // accepted handle generation for a retry while keeping lifecycle
+                        // generations monotonic.
+                        let event = locked.runtime_event(prior.id.clone());
+                        drop(locked);
+                        self.emit_event(event);
+                    }
                 }
                 Err(error)
             }
@@ -517,39 +513,115 @@ impl Subagents {
         name: Option<String>,
         depth: usize,
         cancellation: TurnCancellation,
-        contract: Option<&OutputContract>,
+        contract: Option<Arc<OutputContract>>,
     ) -> Result<SubagentValue, ChildError> {
         self.check_depth(depth)?;
         let permit = self.reserve()?;
         let source_state = self.lookup(&prior)?;
-        let source = tokio::select! {
+        let mut source = tokio::select! {
             source = source_state.lock() => source,
             () = cancellation.cancelled() => return Err(ChildError::Cancelled),
         };
         self.check_ready(&source)?;
+        if source.forking.is_some() {
+            return Err(ChildError::Failed(
+                "subagent session is being forked".into(),
+            ));
+        }
         self.check_generation(&prior, source.handle_generation)?;
+
         let id = session::new_id();
-        let harness = source.harness.clone();
-        let model = source.model.clone();
-        let kit = source.kit;
         let source_child = source
             .child
             .clone()
             .ok_or_else(|| ChildError::Failed("subagent session is still starting".into()))?;
         let native_fork = source_child.supports_native_fork();
-        if !native_fork && kit {
-            session::clone_completed(&self.config.root, &prior.id, &id)
-                .map_err(ChildError::Failed)?;
-        } else if !native_fork {
+        if !native_fork && !source.kit {
             return Err(ChildError::Failed(format!(
-                "ACP harness {harness:?} does not advertise session/fork; transcript fallback is only available for Kit"
+                "ACP harness {:?} does not advertise session/fork; transcript fallback is only available for Kit",
+                source.harness
             )));
         }
         let generation = source
             .generation
             .checked_add(1)
             .ok_or_else(|| ChildError::Failed("subagent generation overflow".into()))?;
+        source.forking = Some(id.clone());
+        let operation = ForkOperation {
+            source_id: prior.id,
+            source_state: Arc::clone(&source_state),
+            source_child,
+            id: id.clone(),
+            prompt,
+            name,
+            harness: source.harness.clone(),
+            model: source.model.clone(),
+            kit: source.kit,
+            generation,
+            depth,
+            cancellation,
+            contract,
+            permit,
+            native_fork,
+        };
         drop(source);
+
+        let (reply, response) = oneshot::channel();
+        let manager = self.clone();
+        tokio::spawn(async move {
+            let source_state = Arc::clone(&operation.source_state);
+            let reservation = operation.id.clone();
+            let result = manager.run_fork(operation, &reply).await;
+            manager.finish_forking(&source_state, &reservation).await;
+            match result {
+                Ok(value) => manager.handoff_fork_success(reply, value).await,
+                Err(error) => {
+                    let _ = reply.send(Err(error));
+                }
+            }
+        });
+        match response.await.map_err(|_| {
+            ChildError::Failed("subagent fork task stopped before returning a result".into())
+        })? {
+            Ok(success) => {
+                success.acknowledge.send(()).map_err(|_| {
+                    ChildError::Failed(
+                        "subagent fork task stopped before transferring ownership".into(),
+                    )
+                })?;
+                Ok(success.value)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn run_fork(
+        &self,
+        operation: ForkOperation,
+        reply: &oneshot::Sender<Result<ForkSuccess, ChildError>>,
+    ) -> Result<SubagentValue, ChildError> {
+        let ForkOperation {
+            source_id,
+            source_state,
+            source_child,
+            id,
+            prompt,
+            name,
+            harness,
+            model,
+            kit,
+            generation,
+            depth,
+            cancellation,
+            contract,
+            permit,
+            native_fork,
+        } = operation;
+
+        if reply.is_closed() {
+            return Err(ChildError::Cancelled);
+        }
+
         let now = events::now_millis();
         let state = self.insert_starting(
             id.clone(),
@@ -569,21 +641,48 @@ impl Subagents {
                 model: model.clone(),
                 kit,
                 child: None,
-                _permit: permit,
+                forking: None,
+                permit: None,
             },
         )?;
+        let branch_name = state.lock().await.name.clone();
+        if reply.is_closed() {
+            self.fail_removed_and_remove(&id, &state).await;
+            return Err(ChildError::Cancelled);
+        }
+
+        if !native_fork {
+            let root = self.config.root.clone();
+            let source_id = source_id.clone();
+            let branch_id = id.clone();
+            let cloned = tokio::task::spawn_blocking(move || {
+                session::clone_completed(&root, &source_id, &branch_id)
+            })
+            .await
+            .map_err(|error| ChildError::Failed(format!("transcript clone task failed: {error}")))
+            .and_then(|result| result.map_err(ChildError::Failed));
+            if let Err(error) = cloned {
+                self.fail_removed_and_remove(&id, &state).await;
+                return Err(error);
+            }
+        }
+        if reply.is_closed() {
+            self.fail_removed_and_remove(&id, &state).await;
+            return Err(ChildError::Cancelled);
+        }
+
         let child_config = self
             .config
             .clone()
-            .with_parent_context(id.clone(), state.lock().await.name.clone());
+            .with_parent_context(id.clone(), branch_name);
         let child_result = if native_fork {
             source_child.fork(model.as_deref(), &cancellation).await
         } else {
             ChildSession::start(
                 child_config,
-                harness,
+                harness.clone(),
                 Some((id.clone(), true)),
-                model,
+                model.clone(),
                 depth + 1,
                 cancellation.clone(),
             )
@@ -596,26 +695,68 @@ impl Subagents {
                 return Err(error);
             }
         };
+
+        if let Err(error) = self
+            .revalidate_fork_source(&source_id, &source_state, &id)
+            .await
+        {
+            self.fail_removed_and_remove(&id, &state).await;
+            return Err(self
+                .cleanup_uninstalled_child(child, Some(permit), error)
+                .await);
+        }
+        self.finish_forking(&source_state, &id).await;
+        if reply.is_closed() {
+            self.fail_removed_and_remove(&id, &state).await;
+            return Err(self
+                .cleanup_uninstalled_child(child, Some(permit), ChildError::Cancelled)
+                .await);
+        }
         {
             let mut locked = state.lock().await;
-            locked.status = SubagentStatus::Working;
+            if let Err(error) = self.check_active(&locked) {
+                drop(locked);
+                return Err(self
+                    .cleanup_uninstalled_child(child, Some(permit), error)
+                    .await);
+            }
             locked.child = Some(child.clone());
+            locked.permit = Some(permit);
+            locked.status = SubagentStatus::Working;
             self.emit_event(locked.runtime_event(id.clone()));
         }
         self.monitor_child_exit(id.clone(), &state, &child);
+
+        if reply.is_closed() {
+            return Err(self
+                .cleanup_installed_child(&id, &state, &child, ChildError::Cancelled)
+                .await);
+        }
         let output = match child
-            .prompt(structured_prompt(prompt, contract), cancellation)
+            .prompt(structured_prompt(prompt, contract.as_deref()), cancellation)
             .await
         {
             Ok(output) => output,
             Err(error) => {
-                self.fail_removed_and_remove(&id, &state).await;
-                let _ = child.close().await;
-                return Err(error);
+                return Err(self
+                    .cleanup_installed_child(&id, &state, &child, error)
+                    .await);
             }
         };
-        let (output, updates) = turn_output(output, contract);
+        let (output, updates) = turn_output(output, contract.as_deref());
         let mut locked = state.lock().await;
+        if reply.is_closed() {
+            drop(locked);
+            return Err(self
+                .cleanup_installed_child(&id, &state, &child, ChildError::Cancelled)
+                .await);
+        }
+        if let Err(error) = self.check_active(&locked) {
+            drop(locked);
+            return Err(self
+                .cleanup_installed_child(&id, &state, &child, error)
+                .await);
+        }
         locked.status = SubagentStatus::Idle;
         locked.outcome = Some(GenerationOutcome::Success);
         locked.generation_finished_at_unix_ms = Some(events::now_millis());
@@ -632,29 +773,6 @@ impl Subagents {
             generation,
             updates,
         })
-    }
-
-    #[cfg(test)]
-    async fn clone_for_fork(
-        &self,
-        prior: &SubagentValue,
-        cancellation: &TurnCancellation,
-        directory: &std::path::Path,
-    ) -> Result<String, ChildError> {
-        let source = self.lookup(prior)?;
-        let source = tokio::select! {
-            source = source.lock() => source,
-            () = cancellation.cancelled() => return Err(ChildError::Cancelled),
-        };
-        self.check_ready(&source)?;
-        self.check_generation(prior, source.handle_generation)?;
-        let id = session::new_id();
-        session::clone_completed_in(&self.config.root, directory, &prior.id, &id)
-            .map_err(ChildError::Failed)?;
-        // This is the stable snapshot boundary. Returning drops the source
-        // guard before child startup or the branch prompt can begin.
-        drop(source);
-        Ok(id)
     }
 
     async fn list(
@@ -709,36 +827,22 @@ impl Subagents {
             () = cancellation.cancelled() => return Err(ChildError::Cancelled),
         };
         self.check_active(&locked)?;
-        let previous_status = locked.status;
         locked.status = SubagentStatus::Removed;
+        locked.forking = None;
         let child = locked.child.take();
         let event = locked.runtime_event(id.to_string());
         drop(locked);
+        self.remove_if_same(id, &state);
+        self.emit_event(event);
 
-        let result = match &child {
-            Some(child) => child.close().await,
-            None => Ok(()),
+        let Some(child) = child else {
+            return Ok(());
         };
-        match result {
-            Ok(()) => {
-                self.remove_if_same(id, &state);
-                self.emit_event(event);
-                Ok(())
-            }
+        match child.close().await {
+            Ok(()) => Ok(()),
+            Err(error) if child_error_is_terminal(&error, &child) => Err(error),
             Err(error) => {
-                let terminal = child
-                    .as_ref()
-                    .is_none_or(|child| child_error_is_terminal(&error, child));
-                if terminal || previous_status != SubagentStatus::Idle {
-                    self.remove_if_same(id, &state);
-                    self.emit_event(event);
-                } else {
-                    let mut locked = state.lock().await;
-                    if locked.status == SubagentStatus::Removed {
-                        locked.status = previous_status;
-                        locked.child = child;
-                    }
-                }
+                self.retain_permit_until_process_exit(&state, &child).await;
                 Err(error)
             }
         }
@@ -767,7 +871,7 @@ impl Subagents {
             .map(|entry| entry.name.to_lowercase())
             .collect::<HashSet<_>>();
         let preferred = std::mem::take(&mut state.name);
-        let name = allocate_display_name(&mut used, Some(&preferred));
+        let name = allocate_display_name(&mut used, Some(&preferred))?;
         state.name.clone_from(&name);
         let event = state.runtime_event(id.clone());
         let state = Arc::new(AsyncMutex::new(state));
@@ -799,6 +903,7 @@ impl Subagents {
                         state.outcome = Some(GenerationOutcome::Failed);
                     }
                     state.status = SubagentStatus::Removed;
+                    state.forking = None;
                     state
                         .generation_finished_at_unix_ms
                         .get_or_insert_with(events::now_millis);
@@ -816,6 +921,160 @@ impl Subagents {
                 "live subagent session limit ({MAX_LIVE_SUBAGENTS}) reached"
             ))
         })
+    }
+
+    async fn handoff_fork_success(
+        &self,
+        reply: oneshot::Sender<Result<ForkSuccess, ChildError>>,
+        value: SubagentValue,
+    ) {
+        let cleanup = value.clone();
+        let (acknowledge, acknowledged) = oneshot::channel();
+        let sent = reply.send(Ok(ForkSuccess { value, acknowledge })).is_ok();
+        if !sent || acknowledged.await.is_err() {
+            self.cleanup_abandoned_fork(&cleanup).await;
+        }
+    }
+
+    async fn cleanup_abandoned_fork(&self, value: &SubagentValue) {
+        let Ok(state) = self.lookup(value) else {
+            return;
+        };
+        let child = state.lock().await.child.clone();
+        if let Some(child) = child {
+            let _ = self
+                .cleanup_installed_child(&value.id, &state, &child, ChildError::Cancelled)
+                .await;
+        } else {
+            self.fail_removed_and_remove(&value.id, &state).await;
+        }
+    }
+
+    async fn revalidate_fork_source(
+        &self,
+        id: &str,
+        state: &Arc<AsyncMutex<State>>,
+        reservation: &str,
+    ) -> Result<(), ChildError> {
+        let registered = self
+            .sessions
+            .lock()
+            .map_err(|_| ChildError::Failed("subagent registry lock was poisoned".into()))?
+            .get(id)
+            .is_some_and(|entry| Arc::ptr_eq(&entry.state, state));
+        if !registered {
+            return Err(ChildError::Failed("subagent session is retired".into()));
+        }
+        let locked = state.lock().await;
+        self.check_active(&locked)?;
+        if locked.forking.as_deref() != Some(reservation) {
+            return Err(ChildError::Failed(
+                "subagent fork reservation is no longer active".into(),
+            ));
+        }
+        if locked.child.as_ref().is_none_or(ChildSession::is_closed) {
+            return Err(ChildError::TerminalFailed(
+                "nested agent process is no longer running".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn cleanup_uninstalled_child(
+        &self,
+        child: ChildSession,
+        permit: Option<OwnedSemaphorePermit>,
+        error: ChildError,
+    ) -> ChildError {
+        match child.close().await {
+            Ok(()) => error,
+            Err(cleanup) if child_error_is_terminal(&cleanup, &child) => error,
+            Err(cleanup) => {
+                Self::watch_permit_until_process_exit(permit, &child);
+                ChildError::Failed(format!(
+                    "{error}; failed to clean up retired subagent session: {cleanup}"
+                ))
+            }
+        }
+    }
+
+    async fn cleanup_installed_child(
+        &self,
+        id: &str,
+        state: &Arc<AsyncMutex<State>>,
+        child: &ChildSession,
+        error: ChildError,
+    ) -> ChildError {
+        let mut locked = state.lock().await;
+        let event = if locked.status == SubagentStatus::Removed {
+            None
+        } else {
+            locked.status = SubagentStatus::Removed;
+            locked.forking = None;
+            locked.outcome = Some(GenerationOutcome::Failed);
+            locked.generation_finished_at_unix_ms = Some(events::now_millis());
+            Some(locked.runtime_event(id.to_string()))
+        };
+        drop(locked);
+        self.remove_if_same(id, state);
+        if let Some(event) = event {
+            self.emit_event(event);
+        }
+
+        match child.close().await {
+            Ok(()) => error,
+            Err(cleanup) if child_error_is_terminal(&cleanup, child) => error,
+            Err(cleanup) => {
+                self.retain_permit_until_process_exit(state, child).await;
+                ChildError::Failed(format!(
+                    "{error}; failed to clean up retired subagent session: {cleanup}"
+                ))
+            }
+        }
+    }
+
+    async fn reject_uninstalled_child_owned(
+        &self,
+        id: String,
+        state: Arc<AsyncMutex<State>>,
+        child: ChildSession,
+        error: ChildError,
+    ) -> ChildError {
+        let manager = self.clone();
+        match tokio::spawn(async move {
+            manager
+                .cleanup_installed_child(&id, &state, &child, error)
+                .await
+        })
+        .await
+        {
+            Ok(error) => error,
+            Err(error) => {
+                ChildError::Failed(format!("retired subagent cleanup task failed: {error}"))
+            }
+        }
+    }
+
+    async fn retain_permit_until_process_exit(
+        &self,
+        state: &Arc<AsyncMutex<State>>,
+        child: &ChildSession,
+    ) {
+        let permit = state.lock().await.permit.take();
+        Self::watch_permit_until_process_exit(permit, child);
+    }
+
+    fn watch_permit_until_process_exit(permit: Option<OwnedSemaphorePermit>, child: &ChildSession) {
+        let Some(permit) = permit else {
+            return;
+        };
+        let mut closed = child.closed_signal();
+        tokio::spawn(async move {
+            if !*closed.borrow() {
+                let _ = closed.changed().await;
+            }
+            drop(permit);
+        });
     }
 
     fn monitor_child_exit(&self, id: String, state: &Arc<AsyncMutex<State>>, child: &ChildSession) {
@@ -841,41 +1100,39 @@ impl Subagents {
             locked.outcome = Some(GenerationOutcome::Failed);
         }
         locked.status = SubagentStatus::Removed;
+        locked.forking = None;
         locked
             .generation_finished_at_unix_ms
             .get_or_insert_with(events::now_millis);
         let event = locked.runtime_event(id.clone());
         drop(locked);
         self.remove_if_same(&id, &state);
-        drop(state);
         self.emit_event(event);
     }
 
     async fn fail_removed_and_remove(&self, id: &str, state: &Arc<AsyncMutex<State>>) {
         let mut locked = state.lock().await;
-        if locked.status == SubagentStatus::Removed {
-            return;
-        }
-        locked.status = SubagentStatus::Removed;
-        locked.outcome = Some(GenerationOutcome::Failed);
-        locked.generation_finished_at_unix_ms = Some(events::now_millis());
-        #[cfg(test)]
-        if let Ok(mut transitions) = self.failed_removals.lock() {
-            transitions.push(FailedRemoval {
-                status: locked.status,
-                outcome: locked.outcome,
-                finished_at_unix_ms: locked.generation_finished_at_unix_ms,
-            });
-        }
-        let event = locked.runtime_event(id.to_string());
+        let event = if locked.status == SubagentStatus::Removed {
+            None
+        } else {
+            locked.status = SubagentStatus::Removed;
+            locked.forking = None;
+            locked.outcome = Some(GenerationOutcome::Failed);
+            locked.generation_finished_at_unix_ms = Some(events::now_millis());
+            Some(locked.runtime_event(id.to_string()))
+        };
         drop(locked);
         self.remove_if_same(id, state);
-        self.emit_event(event);
+        if let Some(event) = event {
+            self.emit_event(event);
+        }
     }
 
-    #[cfg(test)]
-    fn failed_removals_for_test(&self) -> Vec<FailedRemoval> {
-        self.failed_removals.lock().unwrap().clone()
+    async fn finish_forking(&self, state: &Arc<AsyncMutex<State>>, reservation: &str) {
+        let mut locked = state.lock().await;
+        if locked.forking.as_deref() == Some(reservation) {
+            locked.forking = None;
+        }
     }
 
     fn remove_if_same(&self, id: &str, expected: &Arc<AsyncMutex<State>>) {
@@ -990,11 +1247,6 @@ impl CloseInput {
     }
 }
 
-#[cfg(test)]
-fn listing_id(value: &SubagentListing) -> &str {
-    &value.id
-}
-
 fn value_schema() -> serde_json::Value {
     json!({"type":"object","properties":{"id":{"type":"string"},"name":{"type":"string"},"output":{},"generation":{"type":"integer","minimum":1},"updates":{"type":"object","properties":{"items":{"type":"array","items":{"type":"object"}},"truncated":{"type":"boolean"}},"required":["items","truncated"],"additionalProperties":false}},"required":["id","output","generation"],"additionalProperties":false})
 }
@@ -1005,7 +1257,7 @@ fn continuation_schema() -> serde_json::Value {
     json!({"type":"object","properties":{"subagent":value_schema(),"prompt":{"type":"string"},"output_schema":{"oneOf":[{"type":"object"},{"type":"boolean"}]}},"required":["subagent","prompt"],"additionalProperties":false})
 }
 fn display_name_schema() -> serde_json::Value {
-    json!({"type":"string","description":"Prefer a concise role-oriented display name based on the task, such as `Round 2 Implementer` or `Reviewer`. Valid names are 1-32 bytes of printable ASCII. Kit falls back to `Agent N` when omitted or invalid."})
+    json!({"type":"string","description":"Provide a concise role-oriented display name that is unique among live sibling subagents. Valid names are 1-32 bytes of printable ASCII. Kit allocates a unique fallback when the name is omitted or invalid."})
 }
 fn id_schema() -> serde_json::Value {
     json!({"type":"object","properties":{"id":{"type":"string"}},"required":["id"],"additionalProperties":false})
@@ -1274,7 +1526,7 @@ impl Tool for ForkTool {
                     input.name,
                     self.depth,
                     cancellation(context),
-                    contract.as_ref(),
+                    contract.map(Arc::new),
                 )
                 .await,
         )
@@ -1282,1205 +1534,5 @@ impl Tool for ForkTool {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::path::Path;
-
-    use agentkit_core::{Item, ItemKind};
-
-    use super::*;
-
-    #[test]
-    fn preferred_name_is_trimmed_and_reserved() {
-        let mut used = HashSet::new();
-
-        assert_eq!(
-            allocate_display_name(&mut used, Some("  Round 2 Implementer  ")),
-            "Round 2 Implementer"
-        );
-        assert!(used.contains("round 2 implementer"));
-    }
-
-    #[test]
-    fn preferred_name_collisions_receive_case_insensitive_numeric_suffixes() {
-        let mut used = HashSet::from(["round 2 reviewer".into(), "round 2 reviewer 2".into()]);
-
-        assert_eq!(
-            allocate_display_name(&mut used, Some("Round 2 Reviewer")),
-            "Round 2 Reviewer 3"
-        );
-    }
-
-    #[test]
-    fn collision_suffix_keeps_name_within_32_bytes() {
-        let base = "A1234567890123456789012345678901";
-        let mut used = HashSet::from([base.to_lowercase()]);
-
-        let allocated = allocate_display_name(&mut used, Some(base));
-
-        assert_eq!(allocated, "A12345678901234567890123456789 2");
-        assert_eq!(allocated.len(), 32);
-    }
-
-    #[test]
-    fn missing_or_invalid_preferred_name_uses_lowest_available_agent_fallback() {
-        for candidate in [None, Some(""), Some("bad\nname"), Some("évaluator")] {
-            let mut used = HashSet::from(["agent 1".into()]);
-            assert_eq!(allocate_display_name(&mut used, candidate), "Agent 2");
-        }
-    }
-
-    #[test]
-    fn name_reservations_are_case_insensitive_and_reusable_after_release() {
-        let mut used = HashSet::new();
-        assert_eq!(
-            allocate_display_name(&mut used, Some("Reviewer")),
-            "Reviewer"
-        );
-        assert_eq!(
-            allocate_display_name(&mut used, Some("reviewer")),
-            "reviewer 2"
-        );
-
-        assert!(used.remove("reviewer"));
-        assert_eq!(
-            allocate_display_name(&mut used, Some("Reviewer")),
-            "Reviewer"
-        );
-    }
-
-    #[tokio::test]
-    async fn manager_name_allocation_is_atomic_across_concurrent_insertions() {
-        let root = tempfile::tempdir().unwrap();
-        let manager = manager_with_generic_harness(root.path(), vec!["--no-fork".into()]);
-        let starts = (0..8)
-            .map(|_| {
-                let manager = manager.clone();
-                tokio::spawn(async move { manager.insert_starting_for_test().await })
-            })
-            .collect::<Vec<_>>();
-        let mut allocated = HashSet::new();
-        for start in starts {
-            allocated.insert(start.await.unwrap().to_lowercase());
-        }
-
-        assert_eq!(allocated.len(), 8);
-        assert_eq!(manager.sessions.lock().unwrap().len(), 8);
-    }
-
-    #[test]
-    fn name_allocation_summarizes_tasks_as_single_bounded_lines() {
-        assert_eq!(task_summary("  trace\n\t the   flow  "), "trace the flow");
-        assert_eq!(task_summary(" \n\t "), "Untitled task");
-        let summary = task_summary(&"é".repeat(97));
-        assert_eq!(summary.chars().count(), 96);
-        assert!(summary.ends_with('…'));
-    }
-
-    #[test]
-    fn subagent_value_reads_legacy_and_current_handles_and_rejects_malformed_shapes() {
-        let legacy = serde_json::from_value::<SubagentValue>(json!({
-            "id": "s-old", "output": null, "generation": 1
-        }))
-        .expect("legacy handle remains readable");
-        assert_eq!(legacy.name, None);
-
-        let current = serde_json::from_value::<SubagentValue>(json!({
-            "id": "s-current", "name": "Scout", "output": "done", "generation": 2
-        }))
-        .expect("current handle remains readable");
-        assert_eq!(current.name.as_deref(), Some("Scout"));
-        assert!(
-            serde_json::from_value::<SubagentValue>(json!({
-                "id": "s-bad", "name": 42, "output": null, "generation": 1
-            }))
-            .is_err()
-        );
-        assert!(
-            serde_json::from_value::<SubagentValue>(json!({
-                "id": "s-bad", "output": null, "generation": 1, "extra": true
-            }))
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn subagent_value_schema_accepts_legacy_and_current_handles() {
-        let validator = jsonschema::validator_for(&value_schema()).unwrap();
-        assert!(validator.is_valid(&json!({
-            "id": "s-old", "output": null, "generation": 1
-        })));
-        assert!(validator.is_valid(&json!({
-            "id": "s-new", "name": "Scout", "output": null, "generation": 1
-        })));
-        assert!(!validator.is_valid(&json!({
-            "id": "s-bad", "name": 7, "output": null, "generation": 1
-        })));
-    }
-
-    #[test]
-    fn model_inputs_prefer_optional_subagent_names() {
-        let input = serde_json::from_value::<Input>(json!({
-            "prompt": "work", "name": "Implementer"
-        }))
-        .unwrap();
-        assert_eq!(input.name.as_deref(), Some("Implementer"));
-        assert!(
-            serde_json::from_value::<ForkInput>(json!({
-                "subagent": {"id": "s", "output": null, "generation": 1},
-                "prompt": "fork work",
-                "name": "Round 2 Reviewer"
-            }))
-            .is_ok()
-        );
-        let directory = tempfile::tempdir().unwrap();
-        let manager = manager_with_generic_harness(directory.path(), Vec::new());
-        let subagent = SubagentTool::new(manager.clone(), 1);
-        let fork = ForkTool::new(manager, 1);
-        for schema in [&subagent.spec.input_schema, &fork.spec.input_schema] {
-            let name = &schema["properties"]["name"];
-            assert!(name.get("maxLength").is_none());
-            assert!(
-                name["description"]
-                    .as_str()
-                    .unwrap()
-                    .contains("1-32 bytes of printable ASCII")
-            );
-        }
-    }
-
-    #[test]
-    fn structured_output_is_parsed_and_validated() {
-        let contract = OutputContract::new(json!({
-            "type": "object",
-            "properties": {"approved": {"type": "boolean"}},
-            "required": ["approved"],
-            "additionalProperties": false
-        }))
-        .unwrap();
-
-        assert_eq!(
-            contract.parse(r#"{"approved":true}"#).unwrap(),
-            json!({"approved": true})
-        );
-        assert!(contract.parse(r#"{"approved":"yes"}"#).is_none());
-        assert!(contract.parse("```json\n{}\n```").is_none());
-    }
-
-    #[test]
-    fn invalid_output_schema_is_rejected() {
-        assert!(OutputContract::new(json!({"type": 42})).is_err());
-    }
-
-    #[test]
-    fn explicit_null_output_schema_is_rejected() {
-        assert!(
-            serde_json::from_value::<Input>(json!({"prompt": "test", "output_schema": null}))
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn boolean_output_schema_is_supported() {
-        let contract = OutputContract::new(Value::Bool(true)).unwrap();
-        assert_eq!(contract.parse("[1, 2]").unwrap(), json!([1, 2]));
-    }
-
-    #[test]
-    fn unstructured_output_remains_text() {
-        assert_eq!(
-            structured_output("plain text".into(), None),
-            Value::String("plain text".into())
-        );
-    }
-
-    #[test]
-    fn text_only_values_keep_the_existing_json_shape() {
-        let value = SubagentValue {
-            id: "child".into(),
-            name: None,
-            output: Value::String("done".into()),
-            generation: 1,
-            updates: None,
-        };
-
-        assert_eq!(
-            serde_json::to_value(value).unwrap(),
-            json!({"id": "child", "output": "done", "generation": 1})
-        );
-    }
-
-    #[tokio::test]
-    async fn fork_snapshot_releases_source_before_child_work() {
-        let directory = tempfile::tempdir().unwrap();
-        let transcript = vec![Item::text(ItemKind::System, "system")];
-        let sessions = directory.path().join("sessions");
-        let opened = session::open_in(
-            directory.path(),
-            &sessions,
-            "source",
-            false,
-            false,
-            transcript,
-        )
-        .unwrap();
-        let manager = Subagents::new(
-            ChildConfig {
-                root: directory.path().to_path_buf(),
-                model: "test".into(),
-                provider: Default::default(),
-                reasoning_effort: None,
-                openrouter_api_key: None,
-                mcp_config: None,
-                credential_storage: Default::default(),
-                telemetry: Default::default(),
-                harnesses: Default::default(),
-                default_harness: crate::acp_child::BUILTIN_HARNESS.into(),
-                parent_id: None,
-                parent_name: None,
-            },
-            2,
-        );
-        let state = Arc::new(AsyncMutex::new(State {
-            name: "Scout".into(),
-            status: SubagentStatus::Idle,
-            task: "done".into(),
-            generation: 1,
-            handle_generation: 1,
-            outcome: Some(GenerationOutcome::Success),
-            created_at_unix_ms: 1,
-            generation_started_at_unix_ms: 1,
-            generation_finished_at_unix_ms: Some(2),
-            output: Value::String("done".into()),
-            updates: None,
-            harness: crate::acp_child::BUILTIN_HARNESS.into(),
-            model: None,
-            kit: true,
-            child: Some(ChildSession::disconnected_for_test()),
-            _permit: Arc::clone(&manager.capacity).try_acquire_owned().unwrap(),
-        }));
-        manager.sessions.lock().unwrap().insert(
-            "source".into(),
-            SessionEntry {
-                name: "Scout".into(),
-                state: Arc::clone(&state),
-            },
-        );
-        let prior = SubagentValue {
-            id: "source".into(),
-            name: Some("Scout".into()),
-            output: Value::String("done".into()),
-            generation: 1,
-            updates: None,
-        };
-
-        let branch = manager
-            .clone_for_fork(&prior, &TurnCancellation::default(), &sessions)
-            .await
-            .unwrap();
-
-        assert!(
-            state.try_lock().is_ok(),
-            "source remained locked after snapshot"
-        );
-        assert!(session::load_in(directory.path(), &sessions, &branch).is_ok());
-        drop(opened);
-    }
-    fn manager_with_disconnected_session(
-        root: &Path,
-    ) -> (Subagents, Arc<AsyncMutex<State>>, SubagentValue) {
-        let manager = Subagents::new(
-            ChildConfig {
-                root: root.to_path_buf(),
-                model: "test".into(),
-                provider: Default::default(),
-                reasoning_effort: None,
-                openrouter_api_key: None,
-                mcp_config: None,
-                credential_storage: Default::default(),
-                telemetry: Default::default(),
-                harnesses: Default::default(),
-                default_harness: crate::acp_child::BUILTIN_HARNESS.into(),
-                parent_id: None,
-                parent_name: None,
-            },
-            2,
-        );
-        let state = Arc::new(AsyncMutex::new(State {
-            name: "Scout".into(),
-            status: SubagentStatus::Idle,
-            task: "done".into(),
-            generation: 1,
-            handle_generation: 1,
-            outcome: Some(GenerationOutcome::Success),
-            created_at_unix_ms: 1,
-            generation_started_at_unix_ms: 1,
-            generation_finished_at_unix_ms: Some(2),
-            output: Value::String("done".into()),
-            updates: None,
-            harness: crate::acp_child::BUILTIN_HARNESS.into(),
-            model: None,
-            kit: true,
-            child: Some(ChildSession::disconnected_for_test()),
-            _permit: Arc::clone(&manager.capacity).try_acquire_owned().unwrap(),
-        }));
-        manager.sessions.lock().unwrap().insert(
-            "source".into(),
-            SessionEntry {
-                name: "Scout".into(),
-                state: Arc::clone(&state),
-            },
-        );
-        let prior = SubagentValue {
-            id: "source".into(),
-            name: Some("Scout".into()),
-            output: Value::String("done".into()),
-            generation: 1,
-            updates: None,
-        };
-        (manager, state, prior)
-    }
-
-    #[tokio::test]
-    async fn close_does_not_block_listings_or_allow_stale_reuse() {
-        let root = tempfile::tempdir().unwrap();
-        let fixture = format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR"));
-        let harnesses = crate::acp_child::AcpHarnesses::new(std::collections::BTreeMap::from([(
-            "generic".into(),
-            crate::acp_child::AcpHarnessProfile {
-                command: "python3".into(),
-                args: vec![fixture, "--slow-close".into()],
-                permissions: Default::default(),
-            },
-        )]))
-        .unwrap();
-        let manager = Subagents::new(
-            ChildConfig {
-                root: root.path().to_path_buf(),
-                model: "unused".into(),
-                provider: Default::default(),
-                reasoning_effort: None,
-                openrouter_api_key: None,
-                mcp_config: None,
-                credential_storage: Default::default(),
-                telemetry: Default::default(),
-                harnesses,
-                default_harness: "acp.generic".into(),
-                parent_id: None,
-                parent_name: None,
-            },
-            2,
-        );
-        let handle = manager
-            .create(
-                "base".into(),
-                CreateOptions::default(),
-                0,
-                TurnCancellation::default(),
-                None,
-            )
-            .await
-            .unwrap();
-        let close_manager = manager.clone();
-        let close_id = handle.id.clone();
-        let close = tokio::spawn(async move {
-            close_manager
-                .close(&close_id, &TurnCancellation::default())
-                .await
-        });
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        let listing = tokio::time::timeout(
-            std::time::Duration::from_millis(150),
-            manager.list(&TurnCancellation::default()),
-        )
-        .await
-        .expect("listing blocked behind child close")
-        .unwrap();
-        assert!(listing.is_empty());
-        let reuse = tokio::time::timeout(
-            std::time::Duration::from_millis(150),
-            manager.prompt(
-                handle,
-                "stale reuse".into(),
-                TurnCancellation::default(),
-                None,
-            ),
-        )
-        .await
-        .expect("reuse blocked behind child close");
-        assert!(reuse.is_err());
-        close.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn listing_omits_closed_subagents() {
-        let directory = tempfile::tempdir().unwrap();
-        let (manager, state, prior) = manager_with_disconnected_session(directory.path());
-        let (child, closed) = ChildSession::closure_probe_for_test();
-        state.lock().await.child = Some(child);
-        drop(state);
-
-        let cancellation = TurnCancellation::default();
-        assert_eq!(manager.list(&cancellation).await.unwrap().len(), 1);
-        assert_eq!(
-            listing_id(&manager.list(&cancellation).await.unwrap()[0]),
-            prior.id
-        );
-        manager.close(&prior.id, &cancellation).await.unwrap();
-        assert!(manager.list(&cancellation).await.unwrap().is_empty());
-        assert!(manager.lookup(&prior).is_err());
-        tokio::time::timeout(std::time::Duration::from_secs(1), closed)
-            .await
-            .expect("closing did not terminate the child actor")
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn dropping_a_session_manager_terminates_its_children() {
-        let directory = tempfile::tempdir().unwrap();
-        let (manager, state, _) = manager_with_disconnected_session(directory.path());
-        let (child, closed) = ChildSession::closure_probe_for_test();
-        state.lock().await.child = Some(child);
-        drop(state);
-
-        drop(manager);
-
-        tokio::time::timeout(std::time::Duration::from_secs(1), closed)
-            .await
-            .expect("manager drop did not terminate the child actor")
-            .unwrap();
-    }
-
-    #[test]
-    fn close_input_accepts_a_handle_subagent_id_or_background_call_id() {
-        let handle = json!({"id": "child", "output": "done", "generation": 1});
-        let id = json!({"id": "child"});
-        let call_id = json!({"call_id": "call_123"});
-        assert_eq!(
-            serde_json::from_value::<CloseInput>(handle)
-                .unwrap()
-                .target()
-                .0,
-            "child"
-        );
-        assert_eq!(
-            serde_json::from_value::<CloseInput>(id).unwrap().target().0,
-            "child"
-        );
-        assert_eq!(
-            serde_json::from_value::<CloseInput>(call_id)
-                .unwrap()
-                .target(),
-            ("call_123".into(), true)
-        );
-        assert!(
-            serde_json::from_value::<CloseInput>(json!({"id": "child", "extra": true})).is_err()
-        );
-    }
-
-    #[test]
-    fn live_session_limit_is_120_per_manager() {
-        let directory = tempfile::tempdir().unwrap();
-        let (manager, _, prior) = manager_with_disconnected_session(directory.path());
-        manager.sessions.lock().unwrap().remove(&prior.id);
-        let permits = (0..MAX_LIVE_SUBAGENTS)
-            .map(|_| manager.reserve().unwrap())
-            .collect::<Vec<_>>();
-        assert_eq!(permits.len(), 120);
-        assert_eq!(
-            manager.reserve().unwrap_err().to_string(),
-            "live subagent session limit (120) reached"
-        );
-    }
-
-    #[test]
-    fn invalid_structured_output_remains_recoverable_as_text() {
-        let contract = OutputContract::new(json!({"type": "object"})).unwrap();
-
-        assert_eq!(
-            structured_output("not JSON".into(), Some(&contract)),
-            Value::String("not JSON".into())
-        );
-    }
-
-    fn manager_with_generic_harness(root: &Path, args: Vec<String>) -> Subagents {
-        let fixture = format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR"));
-        let harnesses = crate::acp_child::AcpHarnesses::new(std::collections::BTreeMap::from([(
-            "generic".into(),
-            crate::acp_child::AcpHarnessProfile {
-                command: "python3".into(),
-                args: std::iter::once(fixture).chain(args).collect(),
-                permissions: Default::default(),
-            },
-        )]))
-        .unwrap();
-        Subagents::new(
-            ChildConfig {
-                root: root.to_path_buf(),
-                model: "unused".into(),
-                provider: Default::default(),
-                reasoning_effort: None,
-                openrouter_api_key: None,
-                mcp_config: None,
-                credential_storage: Default::default(),
-                telemetry: Default::default(),
-                harnesses,
-                default_harness: "acp.generic".into(),
-                parent_id: None,
-                parent_name: None,
-            },
-            2,
-        )
-    }
-
-    mod lifecycle_events {
-        use super::*;
-
-        fn transitions(manager: &Subagents) -> Vec<(SubagentStatus, Option<GenerationOutcome>)> {
-            manager
-                .runtime_events_for_test()
-                .into_iter()
-                .filter_map(|event| match event {
-                    events::RuntimeEvent::SubagentStateChanged {
-                        status, outcome, ..
-                    } => Some((status, outcome)),
-                    _ => None,
-                })
-                .collect()
-        }
-
-        #[tokio::test]
-        async fn nested_runtime_events_include_only_the_immediate_parent() {
-            let root = tempfile::tempdir().unwrap();
-            let base = manager_with_generic_harness(root.path(), Vec::new());
-            let mut config = base.child_config();
-            config.parent_id = Some("s-parent".into());
-            config.parent_name = Some("偵察 🦀".into());
-            let manager = Subagents::new(config, 2);
-
-            manager.insert_starting_for_test().await;
-
-            assert!(matches!(
-                manager.runtime_events_for_test().as_slice(),
-                [events::RuntimeEvent::SubagentStateChanged {
-                    parent_id: Some(parent_id),
-                    parent_name: Some(parent_name),
-                    ..
-                }] if parent_id == "s-parent" && parent_name == "偵察 🦀"
-            ));
-        }
-
-        #[tokio::test]
-        async fn emits_committed_create_prompt_failure_and_close_transitions() {
-            let root = tempfile::tempdir().unwrap();
-            let manager = manager_with_generic_harness(root.path(), vec!["--no-fork".into()]);
-            let handle = manager
-                .create(
-                    "base task".into(),
-                    CreateOptions::default(),
-                    0,
-                    TurnCancellation::default(),
-                    None,
-                )
-                .await
-                .unwrap();
-            assert_eq!(
-                transitions(&manager),
-                vec![
-                    (SubagentStatus::Starting, None),
-                    (SubagentStatus::Working, None),
-                    (SubagentStatus::Idle, Some(GenerationOutcome::Success)),
-                ]
-            );
-
-            let handle = manager
-                .prompt(
-                    handle,
-                    "successful continuation".into(),
-                    TurnCancellation::default(),
-                    None,
-                )
-                .await
-                .unwrap();
-            assert_eq!(
-                &transitions(&manager)[3..],
-                &[
-                    (SubagentStatus::Working, None),
-                    (SubagentStatus::Idle, Some(GenerationOutcome::Success)),
-                ]
-            );
-
-            let error = manager
-                .prompt(
-                    handle.clone(),
-                    "MOCK_REFUSAL".into(),
-                    TurnCancellation::default(),
-                    None,
-                )
-                .await
-                .unwrap_err();
-            assert_eq!(error.to_string(), "nested agent refused the prompt");
-            manager
-                .close(&handle.id, &TurnCancellation::default())
-                .await
-                .unwrap();
-
-            let emitted = manager.runtime_events_for_test();
-            assert_eq!(
-                &transitions(&manager)[5..],
-                &[
-                    (SubagentStatus::Working, None),
-                    (SubagentStatus::Idle, Some(GenerationOutcome::Failed)),
-                    (SubagentStatus::Removed, Some(GenerationOutcome::Failed)),
-                ]
-            );
-            assert!(emitted.iter().all(|event| event.parent_call().is_none()));
-            let generations = emitted
-                .iter()
-                .filter_map(|event| match event {
-                    events::RuntimeEvent::SubagentStateChanged { generation, .. } => {
-                        Some(*generation)
-                    }
-                    _ => None,
-                })
-                .collect::<Vec<_>>();
-            assert_eq!(generations, vec![1, 1, 1, 2, 2, 3, 3, 3]);
-            assert!(
-                matches!(emitted.last(), Some(events::RuntimeEvent::SubagentStateChanged { id, name, status: SubagentStatus::Removed, generation_finished_at_unix_ms: Some(_), .. }) if id.as_str() == handle.id.as_str() && Some(name.as_str()) == handle.name.as_deref())
-            );
-        }
-
-        #[tokio::test]
-        async fn failing_event_transport_does_not_change_subagent_operations() {
-            use std::sync::atomic::{AtomicUsize, Ordering};
-
-            let root = tempfile::tempdir().unwrap();
-            let attempts = Arc::new(AtomicUsize::new(0));
-            let sink_attempts = Arc::clone(&attempts);
-            let manager = manager_with_generic_harness(root.path(), vec!["--no-fork".into()])
-                .with_event_sink_for_test(Arc::new(move |_| {
-                    sink_attempts.fetch_add(1, Ordering::Relaxed);
-                    Err(())
-                }));
-
-            let handle = manager
-                .create(
-                    "create".into(),
-                    CreateOptions::default(),
-                    0,
-                    TurnCancellation::default(),
-                    None,
-                )
-                .await
-                .expect("event failure must not fail create");
-            let handle = manager
-                .prompt(handle, "continue".into(), TurnCancellation::default(), None)
-                .await
-                .expect("event failure must not fail prompt");
-            assert_eq!(
-                manager.lookup(&handle).unwrap().lock().await.status,
-                SubagentStatus::Idle
-            );
-            manager
-                .close(&handle.id, &TurnCancellation::default())
-                .await
-                .expect("event failure must not fail close");
-            assert!(manager.lookup(&handle).is_err());
-            assert!(attempts.load(Ordering::Relaxed) >= 6);
-        }
-
-        #[tokio::test]
-        async fn closed_sessions_emit_one_removed_transition_before_name_reuse() {
-            for (working, expected_outcome) in [
-                (false, Some(GenerationOutcome::Success)),
-                (true, Some(GenerationOutcome::Failed)),
-            ] {
-                let root = tempfile::tempdir().unwrap();
-                let (manager, state, prior) = manager_with_disconnected_session(root.path());
-                if working {
-                    let mut state = state.lock().await;
-                    state.status = SubagentStatus::Working;
-                    state.outcome = None;
-                    state.generation_finished_at_unix_ms = None;
-                }
-
-                manager.insert_starting_for_test().await;
-                let removed = manager
-                    .runtime_events_for_test()
-                    .into_iter()
-                    .filter(|event| {
-                        matches!(event, events::RuntimeEvent::SubagentStateChanged { id, status: SubagentStatus::Removed, .. } if id == &prior.id)
-                    })
-                    .collect::<Vec<_>>();
-                assert_eq!(removed.len(), 1);
-                assert!(matches!(
-                    &removed[0],
-                    events::RuntimeEvent::SubagentStateChanged { outcome, generation_finished_at_unix_ms: Some(_), .. } if *outcome == expected_outcome
-                ));
-                assert!(manager.lookup(&prior).is_err());
-            }
-        }
-
-        #[tokio::test]
-        async fn idle_child_exit_promptly_retires_the_direct_handle_once() {
-            let root = tempfile::tempdir().unwrap();
-            let manager =
-                manager_with_generic_harness(root.path(), vec!["--exit-after-prompt".into()]);
-            let handle = manager
-                .create(
-                    "finish before exiting".into(),
-                    CreateOptions::default(),
-                    0,
-                    TurnCancellation::default(),
-                    None,
-                )
-                .await
-                .unwrap();
-
-            tokio::time::timeout(std::time::Duration::from_secs(1), async {
-                loop {
-                    if transitions(&manager).last()
-                        == Some(&(SubagentStatus::Removed, Some(GenerationOutcome::Success)))
-                    {
-                        break;
-                    }
-                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-                }
-            })
-            .await
-            .expect("idle child exit did not emit direct removal promptly");
-
-            assert_eq!(
-                transitions(&manager),
-                vec![
-                    (SubagentStatus::Starting, None),
-                    (SubagentStatus::Working, None),
-                    (SubagentStatus::Idle, Some(GenerationOutcome::Success)),
-                    (SubagentStatus::Removed, Some(GenerationOutcome::Success)),
-                ]
-            );
-            assert!(manager.lookup(&handle).is_err());
-            assert_eq!(manager.capacity.available_permits(), MAX_LIVE_SUBAGENTS);
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            assert_eq!(
-                transitions(&manager)
-                    .into_iter()
-                    .filter(|(status, _)| *status == SubagentStatus::Removed)
-                    .count(),
-                1
-            );
-            manager.insert_starting_for_test().await;
-        }
-
-        #[tokio::test]
-        async fn emits_removed_after_failed_creation_and_terminal_retirement() {
-            let root = tempfile::tempdir().unwrap();
-            let failed = manager_with_generic_harness(root.path(), vec!["--fail-start".into()]);
-            assert!(
-                failed
-                    .create(
-                        "create".into(),
-                        CreateOptions::default(),
-                        0,
-                        TurnCancellation::default(),
-                        None
-                    )
-                    .await
-                    .is_err()
-            );
-            assert_eq!(
-                transitions(&failed),
-                vec![
-                    (SubagentStatus::Starting, None),
-                    (SubagentStatus::Removed, Some(GenerationOutcome::Failed)),
-                ]
-            );
-
-            let (terminal, _, prior) = manager_with_disconnected_session(root.path());
-            assert!(
-                terminal
-                    .prompt(prior, "continue".into(), TurnCancellation::default(), None)
-                    .await
-                    .is_err()
-            );
-            assert_eq!(
-                transitions(&terminal),
-                vec![
-                    (SubagentStatus::Working, None),
-                    (SubagentStatus::Removed, Some(GenerationOutcome::Failed)),
-                ]
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn failed_create_and_fork_startup_record_failed_removed_transitions() {
-        let root = tempfile::tempdir().unwrap();
-        let failed_create = manager_with_generic_harness(root.path(), vec!["--fail-start".into()]);
-        assert!(
-            failed_create
-                .create(
-                    "create".into(),
-                    CreateOptions::default(),
-                    0,
-                    TurnCancellation::default(),
-                    None,
-                )
-                .await
-                .is_err()
-        );
-        let create_transitions = failed_create.failed_removals_for_test();
-        assert_eq!(create_transitions.len(), 1);
-        assert_eq!(create_transitions[0].status, SubagentStatus::Removed);
-        assert_eq!(
-            create_transitions[0].outcome,
-            Some(GenerationOutcome::Failed)
-        );
-        assert!(create_transitions[0].finished_at_unix_ms.is_some());
-
-        let failed_fork = manager_with_generic_harness(root.path(), vec!["--fail-fork".into()]);
-        let source = failed_fork
-            .create(
-                "source".into(),
-                CreateOptions::default(),
-                0,
-                TurnCancellation::default(),
-                None,
-            )
-            .await
-            .unwrap();
-        assert!(
-            failed_fork
-                .fork(
-                    source,
-                    "fork".into(),
-                    None,
-                    0,
-                    TurnCancellation::default(),
-                    None,
-                )
-                .await
-                .is_err()
-        );
-        let fork_transitions = failed_fork.failed_removals_for_test();
-        assert_eq!(fork_transitions.len(), 1);
-        assert_eq!(fork_transitions[0].status, SubagentStatus::Removed);
-        assert_eq!(fork_transitions[0].outcome, Some(GenerationOutcome::Failed));
-        assert!(fork_transitions[0].finished_at_unix_ms.is_some());
-    }
-
-    #[tokio::test]
-    async fn terminal_child_errors_do_not_depend_on_channel_close_timing() {
-        let (child, _) = ChildSession::closure_probe_for_test();
-        assert!(child_error_is_terminal(
-            &ChildError::TerminalCancelled,
-            &child
-        ));
-        assert!(child_error_is_terminal(
-            &ChildError::TerminalFailed("transport ended".into()),
-            &child
-        ));
-    }
-
-    #[tokio::test]
-    async fn reusable_prompt_failure_remains_failed_idle_and_can_be_retried() {
-        let root = tempfile::tempdir().unwrap();
-        let fixture = format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR"));
-        let harnesses = crate::acp_child::AcpHarnesses::new(std::collections::BTreeMap::from([(
-            "generic".into(),
-            crate::acp_child::AcpHarnessProfile {
-                command: "python3".into(),
-                args: vec![fixture, "--no-fork".into()],
-                permissions: Default::default(),
-            },
-        )]))
-        .unwrap();
-        let manager = Subagents::new(
-            ChildConfig {
-                root: root.path().to_path_buf(),
-                model: "unused".into(),
-                provider: Default::default(),
-                reasoning_effort: None,
-                openrouter_api_key: None,
-                mcp_config: None,
-                credential_storage: Default::default(),
-                telemetry: Default::default(),
-                harnesses,
-                default_harness: "acp.generic".into(),
-                parent_id: None,
-                parent_name: None,
-            },
-            2,
-        );
-        let handle = manager
-            .create(
-                "base".into(),
-                CreateOptions::default(),
-                0,
-                TurnCancellation::default(),
-                None,
-            )
-            .await
-            .unwrap();
-
-        let error = manager
-            .prompt(
-                handle.clone(),
-                "MOCK_REFUSAL".into(),
-                TurnCancellation::default(),
-                None,
-            )
-            .await
-            .unwrap_err();
-        assert_eq!(error.to_string(), "nested agent refused the prompt");
-        let state = manager
-            .lookup(&handle)
-            .expect("live child remains reusable");
-        let state = state.lock().await;
-        assert_eq!(state.status, SubagentStatus::Idle);
-        assert_eq!(state.outcome, Some(GenerationOutcome::Failed));
-        assert!(state.generation_finished_at_unix_ms.is_some());
-        drop(state);
-
-        let original_name = handle.name.clone();
-        let retried = manager
-            .prompt(handle, "retry".into(), TurnCancellation::default(), None)
-            .await
-            .expect("failed reusable generation does not stale the last handle");
-        assert_eq!(retried.generation, 3);
-        assert_eq!(retried.name, original_name);
-    }
-
-    #[tokio::test]
-    async fn listing_omits_terminally_retired_subagents() {
-        let directory = tempfile::tempdir().unwrap();
-        let (manager, _, prior) = manager_with_disconnected_session(directory.path());
-
-        assert!(
-            manager
-                .prompt(
-                    prior.clone(),
-                    "continue".into(),
-                    TurnCancellation::default(),
-                    None,
-                )
-                .await
-                .is_err()
-        );
-        assert!(manager.lookup(&prior).is_err());
-        assert!(
-            manager
-                .list(&TurnCancellation::default())
-                .await
-                .unwrap()
-                .is_empty()
-        );
-    }
-    #[tokio::test]
-    async fn listing_includes_named_starting_and_idle_subagents() {
-        let root = tempfile::tempdir().unwrap();
-        let fixture = format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR"));
-        let harnesses = crate::acp_child::AcpHarnesses::new(std::collections::BTreeMap::from([(
-            "generic".into(),
-            crate::acp_child::AcpHarnessProfile {
-                command: "python3".into(),
-                args: vec![fixture, "--no-fork".into()],
-                permissions: Default::default(),
-            },
-        )]))
-        .unwrap();
-        let manager = Subagents::new(
-            ChildConfig {
-                root: root.path().to_path_buf(),
-                model: "unused".into(),
-                provider: Default::default(),
-                reasoning_effort: None,
-                openrouter_api_key: None,
-                mcp_config: None,
-                credential_storage: Default::default(),
-                telemetry: Default::default(),
-                harnesses,
-                default_harness: "acp.generic".into(),
-                parent_id: None,
-                parent_name: None,
-            },
-            2,
-        );
-        let create_manager = manager.clone();
-        let create = tokio::spawn(async move {
-            create_manager
-                .create(
-                    "first prompt".into(),
-                    CreateOptions::default(),
-                    0,
-                    TurnCancellation::default(),
-                    None,
-                )
-                .await
-        });
-
-        let listing = tokio::time::timeout(std::time::Duration::from_secs(2), async {
-            loop {
-                if let Some(listing) = manager
-                    .list(&TurnCancellation::default())
-                    .await
-                    .unwrap()
-                    .into_iter()
-                    .next()
-                {
-                    break listing;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("starting subagent was not registered");
-        let allocated_name = listing.name.clone();
-        assert_eq!(listing.status, SubagentStatus::Starting);
-        assert_eq!(listing.generation, 1);
-        assert_eq!(listing.task, "first prompt");
-
-        let completed = create.await.unwrap().unwrap();
-        assert_eq!(completed.name.as_deref(), Some(allocated_name.as_str()));
-        let listings = manager.list(&TurnCancellation::default()).await.unwrap();
-        assert_eq!(listings[0].id, completed.id);
-        assert_eq!(listings[0].name, allocated_name);
-        assert_eq!(listings[0].status, SubagentStatus::Idle);
-        assert_eq!(listings[0].generation, 1);
-        assert_eq!(listings[0].task, "first prompt");
-        assert_eq!(
-            serde_json::to_value(&listings[0]).unwrap(),
-            json!({
-                "id": completed.id,
-                "name": allocated_name.clone(),
-                "status": "idle",
-                "generation": 1,
-                "task": "first prompt"
-            })
-        );
-
-        let mut informational_name = completed.clone();
-        informational_name.name = Some("Imposter".into());
-        let prompt_manager = manager.clone();
-        let continued = tokio::spawn(async move {
-            prompt_manager
-                .prompt(
-                    informational_name,
-                    "second prompt".into(),
-                    TurnCancellation::default(),
-                    None,
-                )
-                .await
-        });
-        tokio::time::timeout(std::time::Duration::from_secs(2), async {
-            loop {
-                let listing = manager.list(&TurnCancellation::default()).await.unwrap();
-                if listing[0].status == SubagentStatus::Working {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("working continuation was not listable");
-        let continued = continued.await.unwrap().unwrap();
-        assert_eq!(continued.name.as_deref(), Some(allocated_name.as_str()));
-        let listing = manager.list(&TurnCancellation::default()).await.unwrap();
-        assert_eq!(listing[0].generation, 2);
-        assert_eq!(listing[0].task, "second prompt");
-    }
-
-    #[tokio::test]
-    async fn fork_uses_its_fresh_preferred_name() {
-        let root = tempfile::tempdir().unwrap();
-        let manager = manager_with_generic_harness(root.path(), Vec::new());
-        let source = manager
-            .create(
-                "source".into(),
-                CreateOptions {
-                    name: Some("Implementer".into()),
-                    ..Default::default()
-                },
-                0,
-                TurnCancellation::default(),
-                None,
-            )
-            .await
-            .unwrap();
-        let source_name = source.name.clone();
-
-        let fork = manager
-            .fork(
-                source,
-                "branch".into(),
-                Some("Reviewer".into()),
-                0,
-                TurnCancellation::default(),
-                None,
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(source_name.as_deref(), Some("Implementer"));
-        assert_eq!(fork.name.as_deref(), Some("Reviewer"));
-    }
-
-    #[tokio::test]
-    async fn generic_harness_without_native_fork_returns_unsupported() {
-        let root = tempfile::tempdir().unwrap();
-        let fixture = format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR"));
-        let harnesses = crate::acp_child::AcpHarnesses::new(std::collections::BTreeMap::from([(
-            "generic".into(),
-            crate::acp_child::AcpHarnessProfile {
-                command: "python3".into(),
-                args: vec![fixture, "--no-fork".into()],
-                permissions: Default::default(),
-            },
-        )]))
-        .unwrap();
-        let manager = Subagents::new(
-            ChildConfig {
-                root: root.path().to_path_buf(),
-                model: "unused".into(),
-                provider: Default::default(),
-                reasoning_effort: None,
-                openrouter_api_key: None,
-                mcp_config: None,
-                credential_storage: Default::default(),
-                telemetry: Default::default(),
-                harnesses,
-                default_harness: "acp.generic".into(),
-                parent_id: None,
-                parent_name: None,
-            },
-            2,
-        );
-        let prior = manager
-            .create(
-                "base".into(),
-                CreateOptions::default(),
-                0,
-                TurnCancellation::default(),
-                None,
-            )
-            .await
-            .unwrap();
-
-        let error = manager
-            .fork(
-                prior,
-                "branch".into(),
-                None,
-                0,
-                TurnCancellation::default(),
-                None,
-            )
-            .await
-            .unwrap_err();
-
-        assert_eq!(
-            error.to_string(),
-            "ACP harness \"acp.generic\" does not advertise session/fork; transcript fallback is only available for Kit"
-        );
-    }
-}
+#[path = "subagent/tests.rs"]
+mod tests;

--- a/src/tools/subagent/tests.rs
+++ b/src/tools/subagent/tests.rs
@@ -1,0 +1,1676 @@
+use std::path::Path;
+
+use super::*;
+
+fn listing_id(value: &SubagentListing) -> &str {
+    &value.id
+}
+
+type EventLog = Arc<Mutex<Vec<events::RuntimeEvent>>>;
+
+fn observe_events(mut manager: Subagents) -> (Subagents, EventLog) {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&events);
+    manager.event_sink = Arc::new(move |event| {
+        captured.lock().unwrap().push(event.clone());
+        Ok(())
+    });
+    (manager, events)
+}
+
+fn emitted(events: &EventLog) -> Vec<events::RuntimeEvent> {
+    events.lock().unwrap().clone()
+}
+
+impl Subagents {
+    fn with_event_sink_for_test(mut self, event_sink: EventSink) -> Self {
+        self.event_sink = event_sink;
+        self
+    }
+
+    async fn insert_starting_for_test(&self) -> String {
+        let now = events::now_millis();
+        let state = self
+            .insert_starting(
+                session::new_id(),
+                State {
+                    name: String::new(),
+                    status: SubagentStatus::Starting,
+                    task: "test".into(),
+                    generation: 1,
+                    handle_generation: 1,
+                    outcome: None,
+                    created_at_unix_ms: now,
+                    generation_started_at_unix_ms: now,
+                    generation_finished_at_unix_ms: None,
+                    output: Value::Null,
+                    updates: None,
+                    harness: crate::acp_child::BUILTIN_HARNESS.into(),
+                    model: None,
+                    kit: true,
+                    child: None,
+                    forking: None,
+                    permit: Some(self.reserve().unwrap()),
+                },
+            )
+            .unwrap();
+        state.lock().await.name.clone()
+    }
+}
+
+#[test]
+fn preferred_name_is_trimmed_and_reserved() {
+    let mut used = HashSet::new();
+
+    assert_eq!(
+        allocate_display_name(&mut used, Some("  Round 2 Implementer  ")).unwrap(),
+        "Round 2 Implementer"
+    );
+    assert!(used.contains("round 2 implementer"));
+}
+
+#[test]
+fn preferred_name_collisions_receive_case_insensitive_numeric_suffixes() {
+    let mut used = HashSet::from(["round 2 reviewer".into(), "round 2 reviewer 2".into()]);
+
+    assert_eq!(
+        allocate_display_name(&mut used, Some("Round 2 Reviewer")).unwrap(),
+        "Round 2 Reviewer 3"
+    );
+}
+
+#[test]
+fn collision_suffix_keeps_name_within_32_bytes() {
+    let base = "A1234567890123456789012345678901";
+    let mut used = HashSet::from([base.to_lowercase()]);
+
+    let allocated = allocate_display_name(&mut used, Some(base)).unwrap();
+
+    assert_eq!(allocated, "A12345678901234567890123456789 2");
+    assert_eq!(allocated.len(), 32);
+}
+
+#[test]
+fn bounded_name_allocation_reports_an_exhausted_fallback_space() {
+    let mut used = (1..=MAX_LIVE_SUBAGENTS + 1)
+        .map(|number| format!("agent {number}"))
+        .collect();
+
+    assert!(allocate_display_name(&mut used, None).is_err());
+}
+
+#[test]
+fn missing_or_invalid_preferred_name_uses_lowest_available_agent_fallback() {
+    for candidate in [None, Some(""), Some("bad\nname"), Some("évaluator")] {
+        let mut used = HashSet::from(["agent 1".into()]);
+        assert_eq!(
+            allocate_display_name(&mut used, candidate).unwrap(),
+            "Agent 2"
+        );
+    }
+}
+
+#[test]
+fn name_reservations_are_case_insensitive_and_reusable_after_release() {
+    let mut used = HashSet::new();
+    assert_eq!(
+        allocate_display_name(&mut used, Some("Reviewer")).unwrap(),
+        "Reviewer"
+    );
+    assert_eq!(
+        allocate_display_name(&mut used, Some("reviewer")).unwrap(),
+        "reviewer 2"
+    );
+
+    assert!(used.remove("reviewer"));
+    assert_eq!(
+        allocate_display_name(&mut used, Some("Reviewer")).unwrap(),
+        "Reviewer"
+    );
+}
+
+#[tokio::test]
+async fn manager_name_allocation_is_atomic_across_concurrent_insertions() {
+    let root = tempfile::tempdir().unwrap();
+    let manager = manager_with_generic_harness(root.path(), vec!["--no-fork".into()]);
+    let starts = (0..8)
+        .map(|_| {
+            let manager = manager.clone();
+            tokio::spawn(async move { manager.insert_starting_for_test().await })
+        })
+        .collect::<Vec<_>>();
+    let mut allocated = HashSet::new();
+    for start in starts {
+        allocated.insert(start.await.unwrap().to_lowercase());
+    }
+
+    assert_eq!(allocated.len(), 8);
+    assert_eq!(manager.sessions.lock().unwrap().len(), 8);
+}
+
+#[test]
+fn name_allocation_summarizes_tasks_as_single_bounded_lines() {
+    assert_eq!(task_summary("  trace\n\t the   flow  "), "trace the flow");
+    assert_eq!(task_summary(" \n\t "), "Untitled task");
+    let summary = task_summary(&"é".repeat(97));
+    assert_eq!(summary.chars().count(), 96);
+    assert!(summary.ends_with('…'));
+}
+
+#[test]
+fn subagent_value_reads_legacy_and_current_handles_and_rejects_malformed_shapes() {
+    let legacy = serde_json::from_value::<SubagentValue>(json!({
+        "id": "s-old", "output": null, "generation": 1
+    }))
+    .expect("legacy handle remains readable");
+    assert_eq!(legacy.name, None);
+
+    let current = serde_json::from_value::<SubagentValue>(json!({
+        "id": "s-current", "name": "Scout", "output": "done", "generation": 2
+    }))
+    .expect("current handle remains readable");
+    assert_eq!(current.name.as_deref(), Some("Scout"));
+    assert!(
+        serde_json::from_value::<SubagentValue>(json!({
+            "id": "s-bad", "name": 42, "output": null, "generation": 1
+        }))
+        .is_err()
+    );
+    assert!(
+        serde_json::from_value::<SubagentValue>(json!({
+            "id": "s-bad", "output": null, "generation": 1, "extra": true
+        }))
+        .is_err()
+    );
+}
+
+#[test]
+fn subagent_value_schema_accepts_legacy_and_current_handles() {
+    let validator = jsonschema::validator_for(&value_schema()).unwrap();
+    assert!(validator.is_valid(&json!({
+        "id": "s-old", "output": null, "generation": 1
+    })));
+    assert!(validator.is_valid(&json!({
+        "id": "s-new", "name": "Scout", "output": null, "generation": 1
+    })));
+    assert!(!validator.is_valid(&json!({
+        "id": "s-bad", "name": 7, "output": null, "generation": 1
+    })));
+}
+
+#[test]
+fn model_inputs_prefer_optional_subagent_names() {
+    let input = serde_json::from_value::<Input>(json!({
+        "prompt": "work", "name": "Implementer"
+    }))
+    .unwrap();
+    assert_eq!(input.name.as_deref(), Some("Implementer"));
+    assert!(
+        serde_json::from_value::<ForkInput>(json!({
+            "subagent": {"id": "s", "output": null, "generation": 1},
+            "prompt": "fork work",
+            "name": "Round 2 Reviewer"
+        }))
+        .is_ok()
+    );
+    let directory = tempfile::tempdir().unwrap();
+    let manager = manager_with_generic_harness(directory.path(), Vec::new());
+    let subagent = SubagentTool::new(manager.clone(), 1);
+    let fork = ForkTool::new(manager, 1);
+    for schema in [&subagent.spec.input_schema, &fork.spec.input_schema] {
+        let name = &schema["properties"]["name"];
+        assert!(name.get("maxLength").is_none());
+        let guidance = name["description"].as_str().unwrap();
+        assert!(guidance.contains("unique among live sibling subagents"));
+        assert!(guidance.contains("1-32 bytes of printable ASCII"));
+        assert!(!guidance.contains('`'));
+    }
+}
+
+#[test]
+fn structured_output_is_parsed_and_validated() {
+    let contract = OutputContract::new(json!({
+        "type": "object",
+        "properties": {"approved": {"type": "boolean"}},
+        "required": ["approved"],
+        "additionalProperties": false
+    }))
+    .unwrap();
+
+    assert_eq!(
+        contract.parse(r#"{"approved":true}"#).unwrap(),
+        json!({"approved": true})
+    );
+    assert!(contract.parse(r#"{"approved":"yes"}"#).is_none());
+    assert!(contract.parse("```json\n{}\n```").is_none());
+}
+
+#[test]
+fn invalid_output_schema_is_rejected() {
+    assert!(OutputContract::new(json!({"type": 42})).is_err());
+}
+
+#[test]
+fn explicit_null_output_schema_is_rejected() {
+    assert!(
+        serde_json::from_value::<Input>(json!({"prompt": "test", "output_schema": null})).is_err()
+    );
+}
+
+#[test]
+fn boolean_output_schema_is_supported() {
+    let contract = OutputContract::new(Value::Bool(true)).unwrap();
+    assert_eq!(contract.parse("[1, 2]").unwrap(), json!([1, 2]));
+}
+
+#[test]
+fn unstructured_output_remains_text() {
+    assert_eq!(
+        structured_output("plain text".into(), None),
+        Value::String("plain text".into())
+    );
+}
+
+#[test]
+fn text_only_values_keep_the_existing_json_shape() {
+    let value = SubagentValue {
+        id: "child".into(),
+        name: None,
+        output: Value::String("done".into()),
+        generation: 1,
+        updates: None,
+    };
+
+    assert_eq!(
+        serde_json::to_value(value).unwrap(),
+        json!({"id": "child", "output": "done", "generation": 1})
+    );
+}
+
+fn manager_with_disconnected_session(
+    root: &Path,
+) -> (Subagents, Arc<AsyncMutex<State>>, SubagentValue) {
+    let manager = Subagents::new(
+        ChildConfig {
+            root: root.to_path_buf(),
+            model: "test".into(),
+            provider: Default::default(),
+            reasoning_effort: None,
+            openrouter_api_key: None,
+            mcp_config: None,
+            credential_storage: Default::default(),
+            telemetry: Default::default(),
+            harnesses: Default::default(),
+            default_harness: crate::acp_child::BUILTIN_HARNESS.into(),
+            parent_id: None,
+            parent_name: None,
+        },
+        2,
+    );
+    let state = Arc::new(AsyncMutex::new(State {
+        name: "Scout".into(),
+        status: SubagentStatus::Idle,
+        task: "done".into(),
+        generation: 1,
+        handle_generation: 1,
+        outcome: Some(GenerationOutcome::Success),
+        created_at_unix_ms: 1,
+        generation_started_at_unix_ms: 1,
+        generation_finished_at_unix_ms: Some(2),
+        output: Value::String("done".into()),
+        updates: None,
+        harness: crate::acp_child::BUILTIN_HARNESS.into(),
+        model: None,
+        kit: true,
+        child: Some(ChildSession::disconnected_for_test()),
+        forking: None,
+        permit: Some(Arc::clone(&manager.capacity).try_acquire_owned().unwrap()),
+    }));
+    manager.sessions.lock().unwrap().insert(
+        "source".into(),
+        SessionEntry {
+            name: "Scout".into(),
+            state: Arc::clone(&state),
+        },
+    );
+    let prior = SubagentValue {
+        id: "source".into(),
+        name: Some("Scout".into()),
+        output: Value::String("done".into()),
+        generation: 1,
+        updates: None,
+    };
+    (manager, state, prior)
+}
+
+#[tokio::test]
+async fn close_does_not_block_listings_or_allow_stale_reuse() {
+    let root = tempfile::tempdir().unwrap();
+    let fixture = format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR"));
+    let harnesses = crate::acp_child::AcpHarnesses::new(std::collections::BTreeMap::from([(
+        "generic".into(),
+        crate::acp_child::AcpHarnessProfile {
+            command: "python3".into(),
+            args: vec![fixture, "--slow-close".into()],
+            permissions: Default::default(),
+        },
+    )]))
+    .unwrap();
+    let manager = Subagents::new(
+        ChildConfig {
+            root: root.path().to_path_buf(),
+            model: "unused".into(),
+            provider: Default::default(),
+            reasoning_effort: None,
+            openrouter_api_key: None,
+            mcp_config: None,
+            credential_storage: Default::default(),
+            telemetry: Default::default(),
+            harnesses,
+            default_harness: "acp.generic".into(),
+            parent_id: None,
+            parent_name: None,
+        },
+        2,
+    );
+    let handle = manager
+        .create(
+            "base".into(),
+            CreateOptions::default(),
+            0,
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap();
+    let close_manager = manager.clone();
+    let close_id = handle.id.clone();
+    let close = tokio::spawn(async move {
+        close_manager
+            .close(&close_id, &TurnCancellation::default())
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let listing = tokio::time::timeout(
+        std::time::Duration::from_millis(150),
+        manager.list(&TurnCancellation::default()),
+    )
+    .await
+    .expect("listing blocked behind child close")
+    .unwrap();
+    assert!(listing.is_empty());
+    let reuse = tokio::time::timeout(
+        std::time::Duration::from_millis(150),
+        manager.prompt(
+            handle,
+            "stale reuse".into(),
+            TurnCancellation::default(),
+            None,
+        ),
+    )
+    .await
+    .expect("reuse blocked behind child close");
+    assert!(reuse.is_err());
+    close.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn listing_omits_closed_subagents() {
+    let directory = tempfile::tempdir().unwrap();
+    let (manager, state, prior) = manager_with_disconnected_session(directory.path());
+    let (child, closed) = ChildSession::closure_probe_for_test();
+    state.lock().await.child = Some(child);
+    drop(state);
+
+    let cancellation = TurnCancellation::default();
+    assert_eq!(manager.list(&cancellation).await.unwrap().len(), 1);
+    assert_eq!(
+        listing_id(&manager.list(&cancellation).await.unwrap()[0]),
+        prior.id
+    );
+    manager.close(&prior.id, &cancellation).await.unwrap();
+    assert!(manager.list(&cancellation).await.unwrap().is_empty());
+    assert!(manager.lookup(&prior).is_err());
+    tokio::time::timeout(std::time::Duration::from_secs(1), closed)
+        .await
+        .expect("closing did not terminate the child actor")
+        .unwrap();
+}
+
+#[tokio::test]
+async fn dropping_a_session_manager_terminates_its_children() {
+    let directory = tempfile::tempdir().unwrap();
+    let (manager, state, _) = manager_with_disconnected_session(directory.path());
+    let (child, closed) = ChildSession::closure_probe_for_test();
+    state.lock().await.child = Some(child);
+    drop(state);
+
+    drop(manager);
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), closed)
+        .await
+        .expect("manager drop did not terminate the child actor")
+        .unwrap();
+}
+
+#[test]
+fn close_input_accepts_a_handle_subagent_id_or_background_call_id() {
+    let handle = json!({"id": "child", "output": "done", "generation": 1});
+    let id = json!({"id": "child"});
+    let call_id = json!({"call_id": "call_123"});
+    assert_eq!(
+        serde_json::from_value::<CloseInput>(handle)
+            .unwrap()
+            .target()
+            .0,
+        "child"
+    );
+    assert_eq!(
+        serde_json::from_value::<CloseInput>(id).unwrap().target().0,
+        "child"
+    );
+    assert_eq!(
+        serde_json::from_value::<CloseInput>(call_id)
+            .unwrap()
+            .target(),
+        ("call_123".into(), true)
+    );
+    assert!(serde_json::from_value::<CloseInput>(json!({"id": "child", "extra": true})).is_err());
+}
+
+#[test]
+fn live_session_limit_is_120_per_manager() {
+    let directory = tempfile::tempdir().unwrap();
+    let (manager, _, prior) = manager_with_disconnected_session(directory.path());
+    manager.sessions.lock().unwrap().remove(&prior.id);
+    let permits = (0..MAX_LIVE_SUBAGENTS)
+        .map(|_| manager.reserve().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(permits.len(), 120);
+    assert_eq!(
+        manager.reserve().unwrap_err().to_string(),
+        "live subagent session limit (120) reached"
+    );
+}
+
+#[test]
+fn invalid_structured_output_remains_recoverable_as_text() {
+    let contract = OutputContract::new(json!({"type": "object"})).unwrap();
+
+    assert_eq!(
+        structured_output("not JSON".into(), Some(&contract)),
+        Value::String("not JSON".into())
+    );
+}
+
+fn manager_with_generic_harness(root: &Path, args: Vec<String>) -> Subagents {
+    let fixture = format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR"));
+    let harnesses = crate::acp_child::AcpHarnesses::new(std::collections::BTreeMap::from([(
+        "generic".into(),
+        crate::acp_child::AcpHarnessProfile {
+            command: "python3".into(),
+            args: std::iter::once(fixture).chain(args).collect(),
+            permissions: Default::default(),
+        },
+    )]))
+    .unwrap();
+    Subagents::new(
+        ChildConfig {
+            root: root.to_path_buf(),
+            model: "unused".into(),
+            provider: Default::default(),
+            reasoning_effort: None,
+            openrouter_api_key: None,
+            mcp_config: None,
+            credential_storage: Default::default(),
+            telemetry: Default::default(),
+            harnesses,
+            default_harness: "acp.generic".into(),
+            parent_id: None,
+            parent_name: None,
+        },
+        2,
+    )
+}
+
+fn fixture_path_arg(name: &str, path: &Path) -> String {
+    format!("{name}={}", path.display())
+}
+
+#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+#[serde(tag = "method")]
+enum LoggedRequest {
+    #[serde(rename = "session/new")]
+    New,
+    #[serde(rename = "session/fork")]
+    Fork {
+        #[serde(rename = "sessionId")]
+        session_id: String,
+    },
+    #[serde(rename = "session/prompt")]
+    Prompt {
+        #[serde(rename = "sessionId")]
+        session_id: String,
+        text: String,
+    },
+    #[serde(rename = "session/close")]
+    Close {
+        #[serde(rename = "sessionId")]
+        session_id: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
+fn logged_requests(path: &Path) -> Vec<LoggedRequest> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+async fn wait_for_logged(
+    path: &Path,
+    matches: impl Fn(&LoggedRequest) -> bool,
+) -> Vec<LoggedRequest> {
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            let requests = logged_requests(path);
+            if requests.iter().any(&matches) {
+                return requests;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("mock ACP request was not observed")
+}
+
+async fn wait_for_available_permits(manager: &Subagents, expected: usize) {
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            if manager.capacity.available_permits() == expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("subagent capacity was not released");
+}
+
+#[derive(Default)]
+struct ScenarioOptions {
+    gate_new: bool,
+    gate_fork: bool,
+    gate_prompt: Option<&'static str>,
+    fail_close_session: Option<&'static str>,
+}
+
+struct MockAcpScenario {
+    _root: tempfile::TempDir,
+    manager: Subagents,
+    requests: std::path::PathBuf,
+    new_release: std::path::PathBuf,
+    fork_release: std::path::PathBuf,
+    prompt_release: std::path::PathBuf,
+}
+
+impl MockAcpScenario {
+    fn new(options: ScenarioOptions) -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let requests = root.path().join("requests.jsonl");
+        let new_release = root.path().join("release-new");
+        let fork_release = root.path().join("release-fork");
+        let prompt_release = root.path().join("release-prompt");
+        let mut args = vec![fixture_path_arg("--request-log", &requests)];
+        if options.gate_new {
+            args.push(fixture_path_arg("--new-release", &new_release));
+        }
+        if options.gate_fork {
+            args.push(fixture_path_arg("--fork-release", &fork_release));
+        }
+        if let Some(text) = options.gate_prompt {
+            args.push(fixture_path_arg("--prompt-release", &prompt_release));
+            args.push(format!("--prompt-release-text={text}"));
+        }
+        if let Some(session_id) = options.fail_close_session {
+            args.push(format!("--fail-close-session={session_id}"));
+        }
+        let manager = manager_with_generic_harness(root.path(), args);
+        Self {
+            _root: root,
+            manager,
+            requests,
+            new_release,
+            fork_release,
+            prompt_release,
+        }
+    }
+
+    async fn create(&self, prompt: &str) -> SubagentValue {
+        self.manager
+            .create(
+                prompt.into(),
+                CreateOptions::default(),
+                0,
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+            .unwrap()
+    }
+
+    fn spawn_fork(
+        &self,
+        source: SubagentValue,
+        prompt: &'static str,
+    ) -> tokio::task::JoinHandle<Result<SubagentValue, ChildError>> {
+        let manager = self.manager.clone();
+        tokio::spawn(async move {
+            manager
+                .fork(
+                    source,
+                    prompt.into(),
+                    None,
+                    0,
+                    TurnCancellation::default(),
+                    None,
+                )
+                .await
+        })
+    }
+
+    async fn wait_for(&self, matches: impl Fn(&LoggedRequest) -> bool) -> Vec<LoggedRequest> {
+        wait_for_logged(&self.requests, matches).await
+    }
+
+    fn release(path: &Path) {
+        std::fs::write(path, b"release").unwrap();
+    }
+}
+
+mod lifecycle_events {
+    use super::*;
+
+    fn transitions(events: &EventLog) -> Vec<(SubagentStatus, Option<GenerationOutcome>)> {
+        emitted(events)
+            .into_iter()
+            .filter_map(|event| match event {
+                events::RuntimeEvent::SubagentStateChanged {
+                    status, outcome, ..
+                } => Some((status, outcome)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn nested_runtime_events_include_only_the_immediate_parent() {
+        let root = tempfile::tempdir().unwrap();
+        let base = manager_with_generic_harness(root.path(), Vec::new());
+        let mut config = base.child_config();
+        config.parent_id = Some("s-parent".into());
+        config.parent_name = Some("偵察 🦀".into());
+        let (manager, events) = observe_events(Subagents::new(config, 2));
+
+        manager.insert_starting_for_test().await;
+
+        assert!(matches!(
+            emitted(&events).as_slice(),
+            [events::RuntimeEvent::SubagentStateChanged {
+                parent_id: Some(parent_id),
+                parent_name: Some(parent_name),
+                ..
+            }] if parent_id == "s-parent" && parent_name == "偵察 🦀"
+        ));
+    }
+
+    #[tokio::test]
+    async fn emits_committed_create_prompt_failure_and_close_transitions() {
+        let root = tempfile::tempdir().unwrap();
+        let (manager, events) = observe_events(manager_with_generic_harness(
+            root.path(),
+            vec!["--no-fork".into()],
+        ));
+        let handle = manager
+            .create(
+                "base task".into(),
+                CreateOptions::default(),
+                0,
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            transitions(&events),
+            vec![
+                (SubagentStatus::Starting, None),
+                (SubagentStatus::Working, None),
+                (SubagentStatus::Idle, Some(GenerationOutcome::Success)),
+            ]
+        );
+
+        let handle = manager
+            .prompt(
+                handle,
+                "successful continuation".into(),
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            &transitions(&events)[3..],
+            &[
+                (SubagentStatus::Working, None),
+                (SubagentStatus::Idle, Some(GenerationOutcome::Success)),
+            ]
+        );
+
+        let error = manager
+            .prompt(
+                handle.clone(),
+                "MOCK_REFUSAL".into(),
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.to_string(), "nested agent refused the prompt");
+        manager
+            .close(&handle.id, &TurnCancellation::default())
+            .await
+            .unwrap();
+
+        let emitted = emitted(&events);
+        assert_eq!(
+            &transitions(&events)[5..],
+            &[
+                (SubagentStatus::Working, None),
+                (SubagentStatus::Idle, Some(GenerationOutcome::Failed)),
+                (SubagentStatus::Removed, Some(GenerationOutcome::Failed)),
+            ]
+        );
+        assert!(emitted.iter().all(|event| event.parent_call().is_none()));
+        let generations = emitted
+            .iter()
+            .filter_map(|event| match event {
+                events::RuntimeEvent::SubagentStateChanged { generation, .. } => Some(*generation),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(generations, vec![1, 1, 1, 2, 2, 3, 3, 3]);
+        assert!(
+            matches!(emitted.last(), Some(events::RuntimeEvent::SubagentStateChanged { id, name, status: SubagentStatus::Removed, generation_finished_at_unix_ms: Some(_), .. }) if id.as_str() == handle.id.as_str() && Some(name.as_str()) == handle.name.as_deref())
+        );
+    }
+
+    #[tokio::test]
+    async fn failing_event_transport_does_not_change_subagent_operations() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let root = tempfile::tempdir().unwrap();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let sink_attempts = Arc::clone(&attempts);
+        let manager = manager_with_generic_harness(root.path(), vec!["--no-fork".into()])
+            .with_event_sink_for_test(Arc::new(move |_| {
+                sink_attempts.fetch_add(1, Ordering::Relaxed);
+                Err(())
+            }));
+
+        let handle = manager
+            .create(
+                "create".into(),
+                CreateOptions::default(),
+                0,
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+            .expect("event failure must not fail create");
+        let handle = manager
+            .prompt(handle, "continue".into(), TurnCancellation::default(), None)
+            .await
+            .expect("event failure must not fail prompt");
+        assert_eq!(
+            manager.lookup(&handle).unwrap().lock().await.status,
+            SubagentStatus::Idle
+        );
+        manager
+            .close(&handle.id, &TurnCancellation::default())
+            .await
+            .expect("event failure must not fail close");
+        assert!(manager.lookup(&handle).is_err());
+        assert!(attempts.load(Ordering::Relaxed) >= 6);
+    }
+
+    #[tokio::test]
+    async fn closed_sessions_emit_one_removed_transition_before_name_reuse() {
+        for (working, expected_outcome) in [
+            (false, Some(GenerationOutcome::Success)),
+            (true, Some(GenerationOutcome::Failed)),
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            let (manager, state, prior) = manager_with_disconnected_session(root.path());
+            let (manager, events) = observe_events(manager);
+            if working {
+                let mut state = state.lock().await;
+                state.status = SubagentStatus::Working;
+                state.outcome = None;
+                state.generation_finished_at_unix_ms = None;
+            }
+
+            manager.insert_starting_for_test().await;
+            let removed = emitted(&events)
+                    .into_iter()
+                    .filter(|event| {
+                        matches!(event, events::RuntimeEvent::SubagentStateChanged { id, status: SubagentStatus::Removed, .. } if id == &prior.id)
+                    })
+                    .collect::<Vec<_>>();
+            assert_eq!(removed.len(), 1);
+            assert!(matches!(
+                &removed[0],
+                events::RuntimeEvent::SubagentStateChanged { outcome, generation_finished_at_unix_ms: Some(_), .. } if *outcome == expected_outcome
+            ));
+            assert!(manager.lookup(&prior).is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn idle_child_exit_promptly_retires_the_direct_handle_once() {
+        let root = tempfile::tempdir().unwrap();
+        let (manager, events) = observe_events(manager_with_generic_harness(
+            root.path(),
+            vec!["--exit-after-prompt".into()],
+        ));
+        let handle = manager
+            .create(
+                "finish before exiting".into(),
+                CreateOptions::default(),
+                0,
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if transitions(&events).last()
+                    == Some(&(SubagentStatus::Removed, Some(GenerationOutcome::Success)))
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("idle child exit did not emit direct removal promptly");
+
+        assert_eq!(
+            transitions(&events),
+            vec![
+                (SubagentStatus::Starting, None),
+                (SubagentStatus::Working, None),
+                (SubagentStatus::Idle, Some(GenerationOutcome::Success)),
+                (SubagentStatus::Removed, Some(GenerationOutcome::Success)),
+            ]
+        );
+        assert!(manager.lookup(&handle).is_err());
+        assert_eq!(manager.capacity.available_permits(), MAX_LIVE_SUBAGENTS);
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            transitions(&events)
+                .into_iter()
+                .filter(|(status, _)| *status == SubagentStatus::Removed)
+                .count(),
+            1
+        );
+        manager.insert_starting_for_test().await;
+    }
+
+    #[tokio::test]
+    async fn emits_removed_after_failed_creation_and_terminal_retirement() {
+        let root = tempfile::tempdir().unwrap();
+        let (failed, failed_events) = observe_events(manager_with_generic_harness(
+            root.path(),
+            vec!["--fail-start".into()],
+        ));
+        assert!(
+            failed
+                .create(
+                    "create".into(),
+                    CreateOptions::default(),
+                    0,
+                    TurnCancellation::default(),
+                    None
+                )
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            transitions(&failed_events),
+            vec![
+                (SubagentStatus::Starting, None),
+                (SubagentStatus::Removed, Some(GenerationOutcome::Failed)),
+            ]
+        );
+
+        let (terminal, _, prior) = manager_with_disconnected_session(root.path());
+        let (terminal, terminal_events) = observe_events(terminal);
+        assert!(
+            terminal
+                .prompt(prior, "continue".into(), TurnCancellation::default(), None)
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            transitions(&terminal_events),
+            vec![
+                (SubagentStatus::Working, None),
+                (SubagentStatus::Removed, Some(GenerationOutcome::Failed)),
+            ]
+        );
+    }
+}
+
+#[tokio::test]
+async fn failed_create_and_fork_startup_record_failed_removed_transitions() {
+    let root = tempfile::tempdir().unwrap();
+    let (failed_create, create_events) = observe_events(manager_with_generic_harness(
+        root.path(),
+        vec!["--fail-start".into()],
+    ));
+    assert!(
+        failed_create
+            .create(
+                "create".into(),
+                CreateOptions::default(),
+                0,
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+            .is_err()
+    );
+    let create_events = emitted(&create_events);
+    assert!(matches!(
+        create_events.last(),
+        Some(events::RuntimeEvent::SubagentStateChanged {
+            status: SubagentStatus::Removed,
+            outcome: Some(GenerationOutcome::Failed),
+            generation_finished_at_unix_ms: Some(_),
+            ..
+        })
+    ));
+
+    let (failed_fork, fork_events) = observe_events(manager_with_generic_harness(
+        root.path(),
+        vec!["--fail-fork".into()],
+    ));
+    let source = failed_fork
+        .create(
+            "source".into(),
+            CreateOptions::default(),
+            0,
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        failed_fork
+            .fork(
+                source,
+                "fork".into(),
+                None,
+                0,
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+            .is_err()
+    );
+    let fork_events = emitted(&fork_events);
+    assert!(matches!(
+        fork_events.last(),
+        Some(events::RuntimeEvent::SubagentStateChanged {
+            status: SubagentStatus::Removed,
+            outcome: Some(GenerationOutcome::Failed),
+            generation_finished_at_unix_ms: Some(_),
+            ..
+        })
+    ));
+}
+
+#[tokio::test]
+async fn close_during_create_or_fork_prompt_cannot_publish_idle() {
+    let create_scenario = MockAcpScenario::new(ScenarioOptions {
+        gate_new: true,
+        ..Default::default()
+    });
+    let create_manager = create_scenario.manager.clone();
+    let create = tokio::spawn(async move {
+        create_manager
+            .create(
+                "create".into(),
+                CreateOptions::default(),
+                0,
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+    });
+    create_scenario
+        .wait_for(|request| matches!(request, LoggedRequest::New))
+        .await;
+    let starting = create_scenario
+        .manager
+        .list(&TurnCancellation::default())
+        .await
+        .unwrap();
+    assert_eq!(starting.len(), 1);
+    assert_eq!(starting[0].status, SubagentStatus::Starting);
+    create_scenario
+        .manager
+        .close(&starting[0].id, &TurnCancellation::default())
+        .await
+        .unwrap();
+    MockAcpScenario::release(&create_scenario.new_release);
+    assert!(create.await.unwrap().is_err());
+    assert!(
+        create_scenario
+            .manager
+            .list(&TurnCancellation::default())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    wait_for_available_permits(&create_scenario.manager, MAX_LIVE_SUBAGENTS).await;
+
+    let fork_scenario = MockAcpScenario::new(ScenarioOptions {
+        gate_prompt: Some("branch"),
+        ..Default::default()
+    });
+    let source = fork_scenario.create("source").await;
+    let fork = fork_scenario.spawn_fork(source.clone(), "branch");
+    fork_scenario
+        .wait_for(
+            |request| matches!(request, LoggedRequest::Prompt { text, .. } if text == "branch"),
+        )
+        .await;
+    let branch = fork_scenario
+        .manager
+        .list(&TurnCancellation::default())
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|listing| listing.id != source.id)
+        .unwrap();
+    assert_eq!(branch.status, SubagentStatus::Working);
+    fork_scenario
+        .manager
+        .close(&branch.id, &TurnCancellation::default())
+        .await
+        .unwrap();
+    MockAcpScenario::release(&fork_scenario.prompt_release);
+    assert!(fork.await.unwrap().is_err());
+    assert_eq!(
+        fork_scenario
+            .manager
+            .list(&TurnCancellation::default())
+            .await
+            .unwrap()
+            .iter()
+            .map(listing_id)
+            .collect::<Vec<_>>(),
+        [source.id.as_str()]
+    );
+    fork_scenario
+        .manager
+        .close(&source.id, &TurnCancellation::default())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn native_fork_releases_the_source_before_the_branch_prompt() {
+    let scenario = MockAcpScenario::new(ScenarioOptions {
+        gate_fork: true,
+        gate_prompt: Some("branch"),
+        ..Default::default()
+    });
+    let source = scenario.create("source").await;
+    let fork = scenario.spawn_fork(source.clone(), "branch");
+    scenario
+        .wait_for(|request| matches!(request, LoggedRequest::Fork { .. }))
+        .await;
+
+    let listed = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        scenario.manager.list(&TurnCancellation::default()),
+    )
+    .await
+    .expect("list blocked behind native fork I/O")
+    .unwrap();
+    assert!(listed.iter().any(|listing| listing.id == source.id));
+    assert!(
+        listed.iter().any(|listing| {
+            listing.id != source.id && listing.status == SubagentStatus::Starting
+        })
+    );
+
+    let prompt_error = scenario
+        .manager
+        .prompt(
+            source.clone(),
+            "advance source".into(),
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(prompt_error.to_string(), "subagent session is being forked");
+    let fork_error = scenario
+        .manager
+        .fork(
+            source.clone(),
+            "second branch".into(),
+            None,
+            0,
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(fork_error.to_string(), "subagent session is being forked");
+
+    MockAcpScenario::release(&scenario.fork_release);
+    scenario
+        .wait_for(
+            |request| matches!(request, LoggedRequest::Prompt { text, .. } if text == "branch"),
+        )
+        .await;
+    let advanced = scenario
+        .manager
+        .prompt(
+            source.clone(),
+            "advance source".into(),
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(advanced.generation, source.generation + 1);
+    MockAcpScenario::release(&scenario.prompt_release);
+    let branch = fork.await.unwrap().unwrap();
+    let requests = logged_requests(&scenario.requests);
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| matches!(request, LoggedRequest::Fork { .. }))
+            .count(),
+        1
+    );
+    assert!(requests.iter().any(|request| {
+        matches!(request, LoggedRequest::Prompt { text, .. } if text == "advance source")
+    }));
+    scenario
+        .manager
+        .close(&branch.id, &TurnCancellation::default())
+        .await
+        .unwrap();
+    scenario
+        .manager
+        .close(&source.id, &TurnCancellation::default())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn dropped_fork_with_failed_close_holds_only_its_permit_until_process_exit() {
+    let scenario = MockAcpScenario::new(ScenarioOptions {
+        gate_prompt: Some("branch"),
+        fail_close_session: Some("branch-1"),
+        ..Default::default()
+    });
+    let source = scenario.create("source").await;
+    let fork = scenario.spawn_fork(source.clone(), "branch");
+    scenario
+        .wait_for(|request| {
+            matches!(
+                request,
+                LoggedRequest::Prompt { session_id, text }
+                    if session_id == "branch-1" && text == "branch"
+            )
+        })
+        .await;
+    fork.abort();
+    assert!(fork.await.unwrap_err().is_cancelled());
+    MockAcpScenario::release(&scenario.prompt_release);
+    scenario
+        .wait_for(|request| {
+            matches!(request, LoggedRequest::Close { session_id } if session_id == "branch-1")
+        })
+        .await;
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        loop {
+            let state = scenario.manager.lookup(&source).unwrap();
+            if state.lock().await.forking.is_none() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("fork reservation was not cleared");
+    assert_eq!(
+        scenario.manager.capacity.available_permits(),
+        MAX_LIVE_SUBAGENTS - 2
+    );
+    assert_eq!(
+        scenario
+            .manager
+            .list(&TurnCancellation::default())
+            .await
+            .unwrap()
+            .iter()
+            .map(listing_id)
+            .collect::<Vec<_>>(),
+        [source.id.as_str()]
+    );
+
+    scenario
+        .manager
+        .close(&source.id, &TurnCancellation::default())
+        .await
+        .unwrap();
+    wait_for_available_permits(&scenario.manager, MAX_LIVE_SUBAGENTS).await;
+}
+
+#[tokio::test]
+async fn successful_fork_handoff_cleans_up_if_receipt_is_not_acknowledged() {
+    let scenario = MockAcpScenario::new(ScenarioOptions::default());
+    let branch = scenario.create("branch").await;
+    let (reply, response) = oneshot::channel();
+    let manager = scenario.manager.clone();
+    let cleanup_branch = branch.clone();
+    let handoff = tokio::spawn(async move {
+        manager.handoff_fork_success(reply, cleanup_branch).await;
+    });
+
+    let success = response.await.unwrap().unwrap();
+    assert_eq!(success.value.id, branch.id);
+    drop(success);
+    handoff.await.unwrap();
+
+    assert!(
+        scenario
+            .manager
+            .list(&TurnCancellation::default())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    wait_for_available_permits(&scenario.manager, MAX_LIVE_SUBAGENTS).await;
+}
+
+#[tokio::test]
+async fn prompt_error_after_close_emits_no_ghost_idle_row() {
+    let scenario = MockAcpScenario::new(ScenarioOptions {
+        gate_prompt: Some("MOCK_REFUSAL"),
+        ..Default::default()
+    });
+    let source = scenario.create("source").await;
+    let prompt_manager = scenario.manager.clone();
+    let prompt_source = source.clone();
+    let prompt = tokio::spawn(async move {
+        prompt_manager
+            .prompt(
+                prompt_source,
+                "MOCK_REFUSAL".into(),
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+    });
+    scenario
+        .wait_for(|request| {
+            matches!(request, LoggedRequest::Prompt { text, .. } if text == "MOCK_REFUSAL")
+        })
+        .await;
+    scenario
+        .manager
+        .close(&source.id, &TurnCancellation::default())
+        .await
+        .unwrap();
+    MockAcpScenario::release(&scenario.prompt_release);
+    assert!(prompt.await.unwrap().is_err());
+    assert!(
+        scenario
+            .manager
+            .list(&TurnCancellation::default())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn terminal_child_errors_do_not_depend_on_channel_close_timing() {
+    let (child, _) = ChildSession::closure_probe_for_test();
+    assert!(child_error_is_terminal(
+        &ChildError::TerminalCancelled,
+        &child
+    ));
+    assert!(child_error_is_terminal(
+        &ChildError::TerminalFailed("transport ended".into()),
+        &child
+    ));
+}
+
+#[tokio::test]
+async fn reusable_prompt_failure_remains_failed_idle_and_can_be_retried() {
+    let root = tempfile::tempdir().unwrap();
+    let fixture = format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR"));
+    let harnesses = crate::acp_child::AcpHarnesses::new(std::collections::BTreeMap::from([(
+        "generic".into(),
+        crate::acp_child::AcpHarnessProfile {
+            command: "python3".into(),
+            args: vec![fixture, "--no-fork".into()],
+            permissions: Default::default(),
+        },
+    )]))
+    .unwrap();
+    let manager = Subagents::new(
+        ChildConfig {
+            root: root.path().to_path_buf(),
+            model: "unused".into(),
+            provider: Default::default(),
+            reasoning_effort: None,
+            openrouter_api_key: None,
+            mcp_config: None,
+            credential_storage: Default::default(),
+            telemetry: Default::default(),
+            harnesses,
+            default_harness: "acp.generic".into(),
+            parent_id: None,
+            parent_name: None,
+        },
+        2,
+    );
+    let handle = manager
+        .create(
+            "base".into(),
+            CreateOptions::default(),
+            0,
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let error = manager
+        .prompt(
+            handle.clone(),
+            "MOCK_REFUSAL".into(),
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.to_string(), "nested agent refused the prompt");
+    let state = manager
+        .lookup(&handle)
+        .expect("live child remains reusable");
+    let state = state.lock().await;
+    assert_eq!(state.status, SubagentStatus::Idle);
+    assert_eq!(state.outcome, Some(GenerationOutcome::Failed));
+    assert!(state.generation_finished_at_unix_ms.is_some());
+    drop(state);
+
+    let original_name = handle.name.clone();
+    let retried = manager
+        .prompt(handle, "retry".into(), TurnCancellation::default(), None)
+        .await
+        .expect("failed reusable generation does not stale the last handle");
+    assert_eq!(retried.generation, 3);
+    assert_eq!(retried.name, original_name);
+}
+
+#[tokio::test]
+async fn listing_omits_terminally_retired_subagents() {
+    let directory = tempfile::tempdir().unwrap();
+    let (manager, _, prior) = manager_with_disconnected_session(directory.path());
+
+    assert!(
+        manager
+            .prompt(
+                prior.clone(),
+                "continue".into(),
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+            .is_err()
+    );
+    assert!(manager.lookup(&prior).is_err());
+    assert!(
+        manager
+            .list(&TurnCancellation::default())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+#[tokio::test]
+async fn listing_includes_named_starting_and_idle_subagents() {
+    let root = tempfile::tempdir().unwrap();
+    let fixture = format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR"));
+    let harnesses = crate::acp_child::AcpHarnesses::new(std::collections::BTreeMap::from([(
+        "generic".into(),
+        crate::acp_child::AcpHarnessProfile {
+            command: "python3".into(),
+            args: vec![fixture, "--no-fork".into()],
+            permissions: Default::default(),
+        },
+    )]))
+    .unwrap();
+    let manager = Subagents::new(
+        ChildConfig {
+            root: root.path().to_path_buf(),
+            model: "unused".into(),
+            provider: Default::default(),
+            reasoning_effort: None,
+            openrouter_api_key: None,
+            mcp_config: None,
+            credential_storage: Default::default(),
+            telemetry: Default::default(),
+            harnesses,
+            default_harness: "acp.generic".into(),
+            parent_id: None,
+            parent_name: None,
+        },
+        2,
+    );
+    let create_manager = manager.clone();
+    let create = tokio::spawn(async move {
+        create_manager
+            .create(
+                "first prompt".into(),
+                CreateOptions::default(),
+                0,
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+    });
+
+    let listing = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            if let Some(listing) = manager
+                .list(&TurnCancellation::default())
+                .await
+                .unwrap()
+                .into_iter()
+                .next()
+            {
+                break listing;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("starting subagent was not registered");
+    let allocated_name = listing.name.clone();
+    assert_eq!(listing.status, SubagentStatus::Starting);
+    assert_eq!(listing.generation, 1);
+    assert_eq!(listing.task, "first prompt");
+
+    let completed = create.await.unwrap().unwrap();
+    assert_eq!(completed.name.as_deref(), Some(allocated_name.as_str()));
+    let listings = manager.list(&TurnCancellation::default()).await.unwrap();
+    assert_eq!(listings[0].id, completed.id);
+    assert_eq!(listings[0].name, allocated_name);
+    assert_eq!(listings[0].status, SubagentStatus::Idle);
+    assert_eq!(listings[0].generation, 1);
+    assert_eq!(listings[0].task, "first prompt");
+    assert_eq!(
+        serde_json::to_value(&listings[0]).unwrap(),
+        json!({
+            "id": completed.id,
+            "name": allocated_name.clone(),
+            "status": "idle",
+            "generation": 1,
+            "task": "first prompt"
+        })
+    );
+
+    let mut informational_name = completed.clone();
+    informational_name.name = Some("Imposter".into());
+    let prompt_manager = manager.clone();
+    let continued = tokio::spawn(async move {
+        prompt_manager
+            .prompt(
+                informational_name,
+                "second prompt".into(),
+                TurnCancellation::default(),
+                None,
+            )
+            .await
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let listing = manager.list(&TurnCancellation::default()).await.unwrap();
+            if listing[0].status == SubagentStatus::Working {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("working continuation was not listable");
+    let continued = continued.await.unwrap().unwrap();
+    assert_eq!(continued.name.as_deref(), Some(allocated_name.as_str()));
+    let listing = manager.list(&TurnCancellation::default()).await.unwrap();
+    assert_eq!(listing[0].generation, 2);
+    assert_eq!(listing[0].task, "second prompt");
+}
+
+#[tokio::test]
+async fn fork_uses_its_fresh_preferred_name() {
+    let root = tempfile::tempdir().unwrap();
+    let manager = manager_with_generic_harness(root.path(), Vec::new());
+    let source = manager
+        .create(
+            "source".into(),
+            CreateOptions {
+                name: Some("Implementer".into()),
+                ..Default::default()
+            },
+            0,
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap();
+    let source_name = source.name.clone();
+
+    let fork = manager
+        .fork(
+            source,
+            "branch".into(),
+            Some("Reviewer".into()),
+            0,
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(source_name.as_deref(), Some("Implementer"));
+    assert_eq!(fork.name.as_deref(), Some("Reviewer"));
+}
+
+#[tokio::test]
+async fn generic_harness_without_native_fork_returns_unsupported() {
+    let root = tempfile::tempdir().unwrap();
+    let fixture = format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR"));
+    let harnesses = crate::acp_child::AcpHarnesses::new(std::collections::BTreeMap::from([(
+        "generic".into(),
+        crate::acp_child::AcpHarnessProfile {
+            command: "python3".into(),
+            args: vec![fixture, "--no-fork".into()],
+            permissions: Default::default(),
+        },
+    )]))
+    .unwrap();
+    let manager = Subagents::new(
+        ChildConfig {
+            root: root.path().to_path_buf(),
+            model: "unused".into(),
+            provider: Default::default(),
+            reasoning_effort: None,
+            openrouter_api_key: None,
+            mcp_config: None,
+            credential_storage: Default::default(),
+            telemetry: Default::default(),
+            harnesses,
+            default_harness: "acp.generic".into(),
+            parent_id: None,
+            parent_name: None,
+        },
+        2,
+    );
+    let prior = manager
+        .create(
+            "base".into(),
+            CreateOptions::default(),
+            0,
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let error = manager
+        .fork(
+            prior,
+            "branch".into(),
+            None,
+            0,
+            TurnCancellation::default(),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "ACP harness \"acp.generic\" does not advertise session/fork; transcript fallback is only available for Kit"
+    );
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1047,14 +1047,15 @@ impl App {
         self.working()
             || !self.transcript_dynamic.is_empty()
             || self.toast.is_some()
-            || self.agents.values().any(|row| {
-                matches!(
-                    row.status,
-                    SubagentStatus::Starting | SubagentStatus::Working
-                ) || (row.outcome == Some(GenerationOutcome::Failed)
-                    && row.generation_finished_at_unix_ms.is_some_and(|finished| {
-                        crate::events::now_millis().saturating_sub(finished) < 4_000
-                    }))
+            || self.agents.values().any(|row| match row.status {
+                SubagentStatus::Starting | SubagentStatus::Working => true,
+                SubagentStatus::Removed => row.outcome == Some(GenerationOutcome::Failed),
+                SubagentStatus::Idle => {
+                    row.outcome == Some(GenerationOutcome::Failed)
+                        && row.generation_finished_at_unix_ms.is_some_and(|finished| {
+                            crate::events::now_millis().saturating_sub(finished) < 4_000
+                        })
+                }
             })
     }
 
@@ -1827,6 +1828,7 @@ impl App {
             Update::Stopped(reason) => self.finish_with_stop_reason(reason),
             Update::ProcessExited(error) => {
                 self.finish_turn_with_outcome(false, None);
+                self.retire_active_agents_at(crate::events::now_millis());
                 self.push_block(Block::Error(error));
             }
         }
@@ -2032,6 +2034,25 @@ impl App {
 
     fn apply_agent_runtime(&mut self, event: RuntimeEvent) {
         self.apply_agent_runtime_at(event, crate::events::now_millis());
+    }
+
+    fn retire_active_agents_at(&mut self, now_unix_ms: u64) {
+        for row in self.agents.values_mut() {
+            if matches!(
+                row.status,
+                SubagentStatus::Starting | SubagentStatus::Working
+            ) {
+                row.status = SubagentStatus::Removed;
+                row.outcome = Some(GenerationOutcome::Failed);
+                row.generation_finished_at_unix_ms
+                    .get_or_insert(now_unix_ms);
+                self.agent_versions.insert(
+                    row.id.clone(),
+                    (row.generation, agent_status_rank(SubagentStatus::Removed)),
+                );
+            }
+        }
+        self.clamp_agents_scroll();
     }
 
     #[cfg(test)]
@@ -4338,6 +4359,107 @@ mod tests {
                 .status,
             SubagentStatus::Idle
         );
+    }
+
+    #[test]
+    fn process_exit_retires_active_agents_without_overwriting_terminal_rows() {
+        use crate::events::{GenerationOutcome, SubagentStatus};
+
+        let mut app = app();
+        for event in [
+            agent_event(
+                "starting",
+                "Starting",
+                SubagentStatus::Starting,
+                None,
+                1,
+                None,
+                (10, 20, None),
+            ),
+            agent_event(
+                "working",
+                "Working",
+                SubagentStatus::Working,
+                None,
+                2,
+                None,
+                (11, 21, None),
+            ),
+            agent_event(
+                "idle-failed",
+                "Idle failed",
+                SubagentStatus::Idle,
+                Some(GenerationOutcome::Failed),
+                1,
+                None,
+                (12, 22, Some(30)),
+            ),
+            agent_event(
+                "removed-failed",
+                "Removed failed",
+                SubagentStatus::Removed,
+                Some(GenerationOutcome::Failed),
+                1,
+                None,
+                (13, 23, Some(90)),
+            ),
+        ] {
+            app.apply_runtime_at(event, 100);
+        }
+
+        app.apply(Update::ProcessExited("runtime exited".into()));
+
+        for id in ["starting", "working"] {
+            let row = app
+                .agents
+                .get(id)
+                .expect("active row remains as a tombstone");
+            assert_eq!(row.status, SubagentStatus::Removed);
+            assert_eq!(row.outcome, Some(GenerationOutcome::Failed));
+            assert!(row.generation_finished_at_unix_ms.is_some());
+        }
+        let idle = app.agents.get("idle-failed").unwrap();
+        assert_eq!(idle.status, SubagentStatus::Idle);
+        assert_eq!(idle.generation_finished_at_unix_ms, Some(30));
+        let removed = app.agents.get("removed-failed").unwrap();
+        assert_eq!(removed.status, SubagentStatus::Removed);
+        assert_eq!(removed.generation_finished_at_unix_ms, Some(90));
+        assert_eq!(app.agent_counts().starting, 0);
+        assert_eq!(app.agent_counts().working, 0);
+
+        let retired_at = app.agents["working"]
+            .generation_finished_at_unix_ms
+            .unwrap();
+        app.tick_at(retired_at + 4_000);
+        assert_eq!(
+            app.agents.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["idle-failed"]
+        );
+        assert!(!app.needs_redraw_tick());
+    }
+
+    #[test]
+    fn expired_failed_removed_agent_keeps_ticker_enabled_until_cleanup() {
+        use crate::events::{GenerationOutcome, SubagentStatus};
+
+        let mut app = app();
+        app.apply_runtime_at(
+            agent_event(
+                "failed",
+                "Failed",
+                SubagentStatus::Removed,
+                Some(GenerationOutcome::Failed),
+                1,
+                None,
+                (10, 20, Some(1_000)),
+            ),
+            1_000,
+        );
+
+        assert!(app.needs_redraw_tick());
+        app.tick_at(5_000);
+        assert!(!app.agents.contains_key("failed"));
+        assert!(!app.needs_redraw_tick());
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -13,6 +13,7 @@ use ratatui::{
         ScrollbarState,
     },
 };
+use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 #[cfg(test)]
@@ -75,6 +76,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App, images: &mut ImageRuntime) {
     let show_start = frame.area().width >= 20
         && available_start_prompt_rows >= START_MIN_PROMPT_ROWS
         && app.blocks.is_empty()
+        && !app.show_agents()
         && app.pending_steers.is_empty()
         && !app.show_logs;
 
@@ -483,9 +485,12 @@ fn draw_start(frame: &mut Frame<'_>, app: &App, width: u16, prompt_rows: u16) {
     draw_status(frame, app, status);
 }
 
-fn body_layout(area: Rect, show_agents: bool) -> (Rect, Option<Rect>) {
+fn body_layout(area: Rect, show_agents: bool, transcript_empty: bool) -> (Rect, Option<Rect>) {
     if !show_agents {
         return (area, None);
+    }
+    if transcript_empty {
+        return (Rect::new(area.x, area.y, area.width, 0), Some(area));
     }
     let [transcript, agents] = if area.width >= SIDE_BY_SIDE_WIDTH {
         Layout::horizontal([Constraint::Min(40), Constraint::Length(AGENTS_WIDTH)]).areas(area)
@@ -496,7 +501,7 @@ fn body_layout(area: Rect, show_agents: bool) -> (Rect, Option<Rect>) {
 }
 
 fn draw_body(frame: &mut Frame<'_>, app: &mut App, images: &mut ImageRuntime, area: Rect) {
-    let (transcript, agents) = body_layout(area, app.show_agents());
+    let (transcript, agents) = body_layout(area, app.show_agents(), app.blocks.is_empty());
     draw_transcript(frame, app, images, transcript);
     if let Some(agents) = agents {
         draw_agents(frame, app, agents);
@@ -1362,13 +1367,13 @@ fn truncate_to_width(text: &str, width: usize) -> String {
 
     let content_width = width.saturating_sub(1);
     let mut truncated = String::new();
-    for character in text.chars() {
-        let candidate_width = UnicodeWidthStr::width(truncated.as_str())
-            + unicode_width::UnicodeWidthChar::width(character).unwrap_or(0);
-        if candidate_width > content_width {
+    for grapheme in text.graphemes(true) {
+        let previous_len = truncated.len();
+        truncated.push_str(grapheme);
+        if UnicodeWidthStr::width(truncated.as_str()) > content_width {
+            truncated.truncate(previous_len);
             break;
         }
-        truncated.push(character);
     }
     truncated.push('…');
     truncated
@@ -1795,11 +1800,12 @@ mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
     use ratatui::{Terminal, backend::TestBackend};
     use ratatui_image::picker::Picker;
+    use unicode_width::UnicodeWidthStr;
 
     use super::{
         MAX_PROMPT_ROWS, ModelDialogRow, agent_lines, body_layout, draw, draw_agents,
         model_dialog_rows, model_dialog_viewport, prompt_lines, refresh_transcript_cache,
-        refresh_transcript_cache_with_images, user_block_rows, user_line,
+        refresh_transcript_cache_with_images, truncate_to_width, user_block_rows, user_line,
     };
     use crate::{
         events::{GenerationOutcome, RuntimeEvent, SubagentStatus},
@@ -1928,6 +1934,20 @@ mod tests {
     }
 
     #[test]
+    fn truncate_to_width_preserves_extended_grapheme_clusters() {
+        for (text, width, expected) in [
+            ("❤️x", 2, "…"),
+            ("❤️xx", 3, "❤️…"),
+            ("🇺🇸xx", 3, "🇺🇸…"),
+            ("e\u{301}xx", 2, "e\u{301}…"),
+            ("👩‍💻xx", 3, "👩‍💻…"),
+        ] {
+            assert_eq!(truncate_to_width(text, width), expected);
+            assert!(UnicodeWidthStr::width(expected) <= width);
+        }
+    }
+
+    #[test]
     fn agent_rows_truncate_unicode_before_reserved_duration() {
         let row = test_agent(
             "Scout",
@@ -1953,9 +1973,9 @@ mod tests {
     #[test]
     fn agents_layout_obeys_hidden_and_107_108_boundaries() {
         let area_107 = ratatui::layout::Rect::new(2, 3, 107, 20);
-        assert_eq!(body_layout(area_107, false), (area_107, None));
+        assert_eq!(body_layout(area_107, false, false), (area_107, None));
         assert_eq!(
-            body_layout(area_107, true),
+            body_layout(area_107, true, false),
             (
                 ratatui::layout::Rect::new(2, 3, 107, 11),
                 Some(ratatui::layout::Rect::new(2, 14, 107, 9)),
@@ -1964,7 +1984,7 @@ mod tests {
 
         let area_108 = ratatui::layout::Rect::new(2, 3, 108, 20);
         assert_eq!(
-            body_layout(area_108, true),
+            body_layout(area_108, true, false),
             (
                 ratatui::layout::Rect::new(2, 3, 62, 20),
                 Some(ratatui::layout::Rect::new(64, 3, 46, 20)),
@@ -2223,6 +2243,19 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn agents_panel_is_visible_before_the_first_transcript_block() {
+        let mut app = panel_app(1);
+        assert!(app.blocks.is_empty());
+        app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL));
+
+        for (width, height) in [(120, 30), (80, 12)] {
+            let screen = render(&mut app, width, height);
+            assert!(screen.contains("agent roster"), "{screen}");
+            assert!(screen.contains("Scout 0"), "{screen}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hardens subagent creation, prompting, forking, closing, and roster rendering against concurrent lifecycle transitions. Removed sessions no longer reappear, fork ownership and cleanup remain bounded, and the TUI consistently retires and renders roster entries.

## Motivation

The named subagent roster exposed starting sessions to concurrent list and close operations, while fork and prompt work continued outside the state lock. Several completion and failure paths could overwrite a successful removal, return an unusable handle, retain stale UI state, or snapshot a newer source generation than the supplied handle.

## Impact

Concurrent fork, prompt, and close operations now preserve generation and removal semantics. Failed tombstones expire reliably, process exit retires active roster entries, compact terminals show the roster before transcript content exists, and Unicode task labels truncate without splitting grapheme clusters.

## Technical details

### Lifecycle ownership

Forks reserve the source only through snapshot creation and run in a manager-owned operation. The result uses an acknowledged handoff so abandoned callers trigger branch cleanup, while failed remote cleanup retains only the capacity permit until the shared process exits.

### Review cleanup

Subagent tests now live in a separate module and assert emitted lifecycle behavior instead of storing test-only fields in `Subagents`. Display-name allocation is bounded by the live-agent limit, guidance requires sibling-unique names without leading examples, and nested Kit arguments safely accept names beginning with a hyphen.

### Unicode truncation

Adds an exact direct dependency on `unicode-segmentation` 1.13.3, which was already present in the lockfile transitively. The audited addition changes no resolved package versions, checksums, features, or transitive packages.

The package version is bumped to 0.1.110.