### PR TITLE
fix(release): authenticate pushes with deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,6 +463,7 @@ jobs:
         with:
           ref: ${{ needs.verify.outputs.source_sha }}
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
       - uses: ./.github/actions/checkout-release-candidate
         with:
           release-sha: ${{ needs.verify.outputs.release_sha }}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -23,6 +23,11 @@ running, the release stops without updating either ref and must be run again. A
 rerun of the failed jobs resumes publication when the release commit and tag were
 pushed but a later publishing step failed.
 
+The atomic push authenticates with the repository's write-enabled `kit-release`
+deploy key. Add **Deploy keys** to the `main` ruleset bypass list and store that
+key's private half in the repository Actions secret `RELEASE_DEPLOY_KEY`. The
+default `GITHUB_TOKEN` cannot bypass the pull-request and status-check rules.
+
 The newly built Linux Kit CLI reviews every change since the previous release and
 writes the GitHub release notes before the workflow attaches the archives and
 checksums. Configure the repository Actions secret `OPENROUTER_API_KEY` for this


### PR DESCRIPTION
## Summary

Authenticate the release workflow’s atomic `main` and tag push with the repository-scoped release deploy key. Keep the default GitHub Actions token for GitHub Release publication.

## Motivation

The repository ruleset rejects direct pushes made with the default `GITHUB_TOKEN`, even after every release build and required check succeeds. The write-enabled deploy key is the dedicated ruleset bypass actor for release ref publication.

## Technical details

The publish checkout configures `RELEASE_DEPLOY_KEY` as its SSH credential, which remains available to the existing leased atomic push and is removed by the checkout post-step. The release guide records the deploy-key, ruleset, and Actions-secret requirements.
