### PR TITLE
fix(tui): show command completion during sessions

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -882,9 +882,7 @@ impl App {
     }
 
     fn command_completion_prefix(&self) -> Option<&str> {
-        (self.phase == Phase::Idle)
-            .then(|| command::completion_prefix(self.editor.text(), self.editor.cursor()))
-            .flatten()
+        command::completion_prefix(self.editor.text(), self.editor.cursor())
     }
 
     pub fn command_completions(&self) -> Vec<SlashCommand> {
@@ -3844,7 +3842,7 @@ mod tests {
     }
 
     #[test]
-    fn completion_is_hidden_after_arguments_and_while_working() {
+    fn completion_is_hidden_after_arguments_but_available_while_working() {
         let mut app = app();
         app.paste("/model sonnet");
         assert!(app.command_completions().is_empty());
@@ -3852,7 +3850,7 @@ mod tests {
         app.editor.clear();
         app.paste("/mo");
         app.phase = Phase::Working;
-        assert!(app.command_completions().is_empty());
+        assert_eq!(app.command_completions()[0].name, "/model");
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1868,7 +1868,7 @@ mod tests {
         events::{GenerationOutcome, RuntimeEvent, SubagentStatus},
         tui::app::{
             Action, AgentRow, AgentTreeRow, App, Block, EffortChoice, EffortDialog, ModelDialog,
-            Update, UserImage, UserMessage,
+            Phase, Update, UserImage, UserMessage,
         },
     };
 
@@ -2317,7 +2317,8 @@ mod tests {
         assert!(start.contains("/model"), "{start}");
         assert!(start.contains("Choose a model"), "{start}");
 
-        app.show_logs = true;
+        app.blocks.push(Block::Agent("session response".into()));
+        app.phase = Phase::Working;
         let compact = render(&mut app, 80, 24);
         assert!(compact.contains("/model"), "{compact}");
         assert!(compact.contains("Choose a model"), "{compact}");


### PR DESCRIPTION
## Summary

Makes slash-command suggestions and Tab completion available in the in-session composer, including while a turn is active. Adds regression coverage using the transcript-backed compact layout rather than an artificial layout toggle.

## Motivation

Completion was gated on the client being idle, so it reliably appeared on the landing screen but disappeared from the composer during active session work, where slash commands are most useful.

## Impact

Users can discover, select, and complete slash commands throughout a session. Command submission keeps the existing active-turn safety checks; this change only removes the visibility and completion restriction.
