### PR TITLE
feat(macos): add interface zoom shortcuts

### DIFF
--- a/macos/KitDesktop/App/KitDesktopApp.swift
+++ b/macos/KitDesktop/App/KitDesktopApp.swift
@@ -4,11 +4,26 @@ import SwiftUI
 struct KitDesktopApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var model = AppModel()
+    @AppStorage("interfaceZoomLevel") private var interfaceZoomLevel = 3
+
+    private static let zoomSizes: [DynamicTypeSize] = [
+        .xSmall, .small, .medium, .large, .xLarge, .xxLarge, .xxxLarge,
+    ]
+    private static let defaultZoomLevel = 3
+
+    private var boundedZoomLevel: Int {
+        min(max(interfaceZoomLevel, 0), Self.zoomSizes.count - 1)
+    }
+
+    private var interfaceSize: DynamicTypeSize {
+        Self.zoomSizes[boundedZoomLevel]
+    }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(model)
+                .environment(\.dynamicTypeSize, interfaceSize)
                 .onAppear { appDelegate.shutdown = { completion in model.closeAll(completion: completion) } }
                 .frame(minWidth: 980, minHeight: 640)
         }
@@ -18,6 +33,24 @@ struct KitDesktopApp: App {
                 Button("New Conversation") { model.createConversation() }
                     .keyboardShortcut("n", modifiers: [.command, .shift])
                     .disabled(model.selectedWorkspaceID == nil)
+            }
+            CommandGroup(after: .toolbar) {
+                Divider()
+                Button("Zoom In") {
+                    interfaceZoomLevel = min(boundedZoomLevel + 1, Self.zoomSizes.count - 1)
+                }
+                .keyboardShortcut("+", modifiers: .command)
+                .disabled(boundedZoomLevel >= Self.zoomSizes.count - 1)
+
+                Button("Zoom Out") {
+                    interfaceZoomLevel = max(boundedZoomLevel - 1, 0)
+                }
+                .keyboardShortcut("-", modifiers: .command)
+                .disabled(boundedZoomLevel <= 0)
+
+                Button("Actual Size") { interfaceZoomLevel = Self.defaultZoomLevel }
+                    .keyboardShortcut("0", modifiers: .command)
+                    .disabled(interfaceZoomLevel == Self.defaultZoomLevel)
             }
         }
     }


### PR DESCRIPTION
## Summary
- add Command-Plus and Command-Minus shortcuts for interface zoom
- persist the selected zoom level between launches
- add Command-0 to restore the default size

## Testing
- `swiftc -typecheck -module-name Kit $(find macos/KitDesktop -name '*.swift' -type f | sort)`