### PR TITLE
fix(sessions): read Windows lock token through held handle

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -584,13 +584,7 @@ impl SessionLock {
     }
 
     fn check(&self) -> Result<(), LockError> {
-        let current = fs::read_to_string(&self.path).map_err(|error| {
-            if error.kind() == io::ErrorKind::NotFound {
-                LockError::Missing
-            } else {
-                LockError::Other(format!("session lock was lost: {error}"))
-            }
-        })?;
+        let current = self.read_token()?;
         if current == self.token {
             Ok(())
         } else {
@@ -598,6 +592,42 @@ impl SessionLock {
                 "session lock was overridden by another Kit instance".into(),
             ))
         }
+    }
+
+    // Reads the lock file's token to confirm this process still owns it. On
+    // Unix the advisory lock lets a fresh handle read the path, which also
+    // reports the file being unlinked as `Missing` so the writer can recover.
+    #[cfg(not(windows))]
+    fn read_token(&self) -> Result<String, LockError> {
+        fs::read_to_string(&self.path).map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                LockError::Missing
+            } else {
+                LockError::Other(format!("session lock was lost: {error}"))
+            }
+        })
+    }
+
+    // On Windows `File::try_lock` takes a mandatory exclusive lock, so
+    // re-opening the path to read the token fails with a sharing violation
+    // (os error 33). Read it through the lock-owning handle instead, which the
+    // lock owner is always permitted to do. The lock file is opened without
+    // FILE_SHARE_DELETE, so it cannot be unlinked while this handle is held; a
+    // `Missing` state therefore cannot arise here and losing the handle is
+    // itself the lost-lock condition.
+    #[cfg(windows)]
+    fn read_token(&self) -> Result<String, LockError> {
+        use std::io::Read;
+        let Some(file) = self.file.as_ref() else {
+            return Err(LockError::Missing);
+        };
+        let mut handle: &File = file;
+        let mut current = String::new();
+        handle
+            .seek(SeekFrom::Start(0))
+            .and_then(|_| handle.read_to_string(&mut current))
+            .map_err(|error| LockError::Other(format!("session lock was lost: {error}")))?;
+        Ok(current)
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -546,6 +546,15 @@ impl SessionLock {
         let token = format!("{}:{}:{}", std::process::id(), new_id(), SCHEMA_VERSION);
         let mut options = OpenOptions::new();
         options.read(true).write(true);
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt as _;
+
+            // FILE_SHARE_READ | FILE_SHARE_WRITE. Omitting FILE_SHARE_DELETE
+            // prevents the lock pathname from being renamed or replaced while
+            // token checks read through this handle.
+            options.share_mode(0x0000_0001 | 0x0000_0002);
+        }
         if force {
             options.create(true);
         } else {
@@ -1797,6 +1806,23 @@ mod tests {
         assert!(!path.exists());
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn windows_lock_path_cannot_be_renamed_while_held() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("held.lock");
+        let renamed = root.path().join("renamed.lock");
+        let lock = SessionLock::acquire(path.clone(), false).unwrap();
+
+        assert!(
+            fs::rename(&path, &renamed).is_err(),
+            "held lock path was renamed"
+        );
+        assert!(lock.check().is_ok());
+        drop(lock);
+        assert!(!path.exists());
+    }
+
     #[test]
     fn non_force_lock_loser_does_not_unlink_forced_owner() {
         let root = tempfile::tempdir().unwrap();
@@ -2627,6 +2653,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn writer_reconstructs_deleted_storage_from_open_descriptor() {
         let root = tempfile::tempdir().unwrap();
@@ -3326,6 +3353,7 @@ mod tests {
         assert!(!belongs_to_workspace_in(&second, storage.path(), "legacy").unwrap());
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn writer_fails_closed_when_another_owner_wins_recovery_lock() {
         let root = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Problem

On Windows, every command that persists a session fails immediately with:

```
session lock was lost: The process cannot access the file because another
process has locked a portion of the file. (os error 33)
```

`SessionLock` keeps the lock file open under an exclusive `File::try_lock`, and
`check()` then re-reads that same file *by path* (`fs::read_to_string(&self.path)`)
to confirm the token still matches. On Unix the lock is advisory, so a fresh
read handle succeeds. On Windows `try_lock` maps to a **mandatory** exclusive
lock (`LockFileEx`), so the second handle is denied with a sharing violation
(os error 33). `check()` runs on every append, so `prompt`, `tui`, and `serve`
are all unusable on native Windows.

## Fix

Extract the token read into `read_token()` with a platform split:

- **Unix** keeps the existing path read, preserving its `Missing` / unlink-based
  recovery detection under advisory locking (behavior unchanged).
- **Windows** reads the token through the already-held, lock-owning handle,
  which the lock owner is always permitted to do. The lock file is opened
  without `FILE_SHARE_DELETE`, so it cannot be unlinked while the handle is
  held; a `Missing` state therefore cannot arise there.

No behavior change on Unix; CI (Ubuntu) compiles only the `#[cfg(not(windows))]`
branch, which is a straight extraction of the previous body.

## Testing

- `cargo fmt --check`: clean.
- Native Windows (identical scope, `cargo test --lib session`): **26 → 6**
  failures, zero regressions. The 6 that remain are unrelated pre-existing
  Unix-only assumptions (deleting an open file, Unix signals, a recovery-lock
  race).
- End-to-end on Windows: `prompt` and `--resume` now complete and the lock file
  is cleaned up on exit.


## Note

`origin/main` currently also fails to build on stable Windows due to
`plugins.rs` using the unstable `windows_by_handle` feature (E0658). That is a
separate portability issue and is intentionally out of scope for this fix.