### PR TITLE
feat(acp): support native session forks

### DIFF
--- a/docs/user/subagents-and-acp-harnesses.md
+++ b/docs/user/subagents-and-acp-harnesses.md
@@ -178,9 +178,9 @@ Omitting `allow_model_overrides` allows all explicit model selections accepted b
 
 ## Fork capability and transcript fallback
 
-Kit reads fork capability from the child's ACP `initialize` response at runtime. If advertised, `fork` uses native `session/fork`. If not advertised:
+Kit reads fork capability from the child's ACP `initialize` response at runtime. The built-in Kit ACP server advertises native `session/fork`, so current Kit children fork in-process. If a child does not advertise it:
 
-- `acp.kit` clones a completed durable transcript and starts an isolated Kit process for the branch. This fallback also applies when `[acp.kit]` overrides the executable/base arguments.
+- `acp.kit` clones a sanitized completed transcript and starts an isolated Kit process for the branch. This compatibility fallback applies to older Kit executables and to `[acp.kit]` overrides whose executable/base arguments do not expose native fork.
 - A generic profile fails with `ACP harness "acp.name" does not advertise session/fork; transcript fallback is only available for Kit`. Its existing session still supports ordinary `prompt` calls.
 
 Do not infer support from the agent name or an old compatibility table; ACP capabilities can change between agent releases.

--- a/src/acp_child.rs
+++ b/src/acp_child.rs
@@ -622,6 +622,11 @@ impl ChildSession {
     }
 
     pub async fn close(&self) -> Result<(), ChildError> {
+        if let Some(ancestor_id) = &self.descendant_parent {
+            crate::events::emit(&crate::events::RuntimeEvent::SubagentDescendantsRemoved {
+                ancestor_id: ancestor_id.clone(),
+            });
+        }
         if self.capabilities.session_capabilities.close.is_none() {
             return if self.tx.strong_count() == 1 {
                 Ok(())
@@ -641,19 +646,11 @@ impl ChildSession {
             .map_err(|_| {
                 ChildError::TerminalFailed("nested agent process is no longer running".into())
             })?;
-        let result = response.await.map_err(|_| {
+        response.await.map_err(|_| {
             ChildError::TerminalFailed(
                 "nested agent process exited without a close response".into(),
             )
-        })?;
-        if result.is_ok()
-            && let Some(ancestor_id) = &self.descendant_parent
-        {
-            crate::events::emit(&crate::events::RuntimeEvent::SubagentDescendantsRemoved {
-                ancestor_id: ancestor_id.clone(),
-            });
-        }
-        result
+        })?
     }
 
     #[cfg(test)]

--- a/src/acp_child.rs
+++ b/src/acp_child.rs
@@ -1,7 +1,7 @@
 //! Generic parent-owned ACP subprocesses used for nested agents.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     path::{Path, PathBuf},
     process::Stdio,
     sync::{
@@ -36,6 +36,8 @@ const PRE_HANDSHAKE_EXIT_SETTLE: Duration = Duration::from_millis(250);
 const CANCEL_SETTLE: Duration = Duration::from_secs(5);
 const MAX_CAPTURED_UPDATES: usize = 64;
 const MAX_CAPTURED_UPDATE_BYTES: usize = 64 * 1024;
+const FORK_PARENT_ID_META: &str = "kit.subagent.parent_id";
+const FORK_PARENT_NAME_META: &str = "kit.subagent.parent_name";
 pub const BUILTIN_HARNESS: &str = "acp.kit";
 
 /// How a headless nested ACP client handles permission requests.
@@ -422,6 +424,7 @@ struct Prompt {
 struct Fork {
     session_id: SessionId,
     model: Option<String>,
+    parent: Option<(String, String)>,
     cancellation: TurnCancellation,
     reply: oneshot::Sender<Result<SessionId, ChildError>>,
 }
@@ -437,6 +440,7 @@ enum Request {
 struct Ready {
     session_id: SessionId,
     capabilities: agentkit_acp::AgentCapabilities,
+    descendant_parent: Option<String>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -535,6 +539,7 @@ pub(crate) struct ChildSession {
     capabilities: agentkit_acp::AgentCapabilities,
     serial: Arc<tokio::sync::Mutex<()>>,
     closed: watch::Receiver<bool>,
+    descendant_parent: Option<String>,
 }
 
 impl ChildSession {
@@ -594,6 +599,7 @@ impl ChildSession {
                 capabilities: ready.capabilities,
                 serial: Arc::new(tokio::sync::Mutex::new(())),
                 closed: closed_rx,
+                descendant_parent: ready.descendant_parent,
             }),
             Err(error) => {
                 task.abort();
@@ -635,11 +641,19 @@ impl ChildSession {
             .map_err(|_| {
                 ChildError::TerminalFailed("nested agent process is no longer running".into())
             })?;
-        response.await.map_err(|_| {
+        let result = response.await.map_err(|_| {
             ChildError::TerminalFailed(
                 "nested agent process exited without a close response".into(),
             )
-        })?
+        })?;
+        if result.is_ok()
+            && let Some(ancestor_id) = &self.descendant_parent
+        {
+            crate::events::emit(&crate::events::RuntimeEvent::SubagentDescendantsRemoved {
+                ancestor_id: ancestor_id.clone(),
+            });
+        }
+        result
     }
 
     #[cfg(test)]
@@ -657,6 +671,7 @@ impl ChildSession {
                 capabilities: agentkit_acp::AgentCapabilities::default(),
                 serial: Arc::new(tokio::sync::Mutex::new(())),
                 closed: watch::channel(false).1,
+                descendant_parent: None,
             },
             closed_rx,
         )
@@ -672,12 +687,14 @@ impl ChildSession {
             capabilities: agentkit_acp::AgentCapabilities::default(),
             serial: Arc::new(tokio::sync::Mutex::new(())),
             closed: watch::channel(false).1,
+            descendant_parent: None,
         }
     }
 
     pub async fn fork(
         &self,
         model: Option<&str>,
+        parent: Option<(String, String)>,
         cancellation: &TurnCancellation,
     ) -> Result<Self, ChildError> {
         let _serial = tokio::select! {
@@ -689,11 +706,13 @@ impl ChildSession {
                 "ACP harness does not support session/fork".into(),
             ));
         }
+        let descendant_parent = parent.as_ref().map(|(id, _)| id.clone());
         let (reply, response) = oneshot::channel();
         tokio::select! {
             sent = self.tx.send(Request::Fork(Fork {
                 session_id: self.session_id.clone(),
                 model: model.map(str::to_owned),
+                parent,
                 cancellation: cancellation.clone(),
                 reply,
             })) => sent.map_err(|_| ChildError::TerminalFailed("nested agent process is no longer running".into()))?,
@@ -708,6 +727,7 @@ impl ChildSession {
             capabilities: self.capabilities.clone(),
             serial: Arc::new(tokio::sync::Mutex::new(())),
             closed: self.closed.clone(),
+            descendant_parent,
         })
     }
 
@@ -804,6 +824,7 @@ async fn run(
         .ok_or("could not open ACP harness stderr")?;
     let label = harness.clone();
     let ancestor_id = config.parent_id.clone();
+    let descendant_parent = ancestor_id.clone();
     tokio::spawn(async move {
         forward_stderr(
             stderr,
@@ -878,7 +899,11 @@ async fn run(
             let (fatal_tx, mut fatal_rx) = mpsc::unbounded_channel();
             let mut tasks = JoinSet::new();
             ready_flag.store(true, Ordering::Release);
-            let _ = ready.send(Ok(Ready { session_id: session.session_id, capabilities }));
+            let _ = ready.send(Ok(Ready {
+                session_id: session.session_id,
+                capabilities,
+                descendant_parent,
+            }));
             loop {
                 let request = tokio::select! {
                     request = rx.recv() => match request { Some(request) => request, None => break },
@@ -890,12 +915,15 @@ async fn run(
                         let connection = connection.clone();
                         let sessions = Arc::clone(&sessions);
                         let root = root.clone();
-                        let fatal = fatal_tx.clone();
                         tasks.spawn(async move {
-                            let request = connection
-                                .send_request(ForkSessionRequest::new(fork.session_id, root))
-                                .block_task();
-                            tokio::pin!(request);
+                            let mut request = ForkSessionRequest::new(fork.session_id, root);
+                            if let Some((id, name)) = fork.parent {
+                                request.meta = Some(serde_json::Map::from_iter([
+                                    (FORK_PARENT_ID_META.into(), Value::String(id)),
+                                    (FORK_PARENT_NAME_META.into(), Value::String(name)),
+                                ]));
+                            }
+                            let mut request = Box::pin(connection.send_request(request).block_task());
                             let result = tokio::select! {
                                 result = &mut request => match result {
                                     Ok(response) => {
@@ -944,11 +972,53 @@ async fn run(
                                     Err(error) => Err(ChildError::Failed(error.to_string())),
                                 },
                                 () = fork.cancellation.cancelled() => {
-                                    let _ = fatal.send(());
+                                    let cleanup_connection = connection.clone();
+                                    let cleanup_sessions = Arc::clone(&sessions);
+                                    tokio::spawn(async move {
+                                        let Ok(response) = request.await else {
+                                            return;
+                                        };
+                                        let session_id = response.session_id;
+                                        let closed = supports_close
+                                            && tokio::time::timeout(
+                                                CANCEL_SETTLE,
+                                                cleanup_connection
+                                                    .send_request(CloseSessionRequest::new(session_id.clone()))
+                                                    .block_task(),
+                                            )
+                                            .await
+                                            .is_ok_and(|result| result.is_ok());
+                                        if !closed
+                                            && let Ok(mut sessions) = cleanup_sessions.lock()
+                                        {
+                                            sessions.push(session_id);
+                                        }
+                                    });
                                     Err(ChildError::Cancelled)
-                                }
+                                },
                                 () = tokio::time::sleep(HANDSHAKE) => {
-                                    let _ = fatal.send(());
+                                    let cleanup_connection = connection.clone();
+                                    let cleanup_sessions = Arc::clone(&sessions);
+                                    tokio::spawn(async move {
+                                        let Ok(response) = request.await else {
+                                            return;
+                                        };
+                                        let session_id = response.session_id;
+                                        let closed = supports_close
+                                            && tokio::time::timeout(
+                                                CANCEL_SETTLE,
+                                                cleanup_connection
+                                                    .send_request(CloseSessionRequest::new(session_id.clone()))
+                                                    .block_task(),
+                                            )
+                                            .await
+                                            .is_ok_and(|result| result.is_ok());
+                                        if !closed
+                                            && let Ok(mut sessions) = cleanup_sessions.lock()
+                                        {
+                                            sessions.push(session_id);
+                                        }
+                                    });
                                     Err(ChildError::Failed(format!(
                                         "ACP harness did not answer session/fork within {} seconds",
                                         HANDSHAKE.as_secs()
@@ -1089,20 +1159,31 @@ async fn forward_stderr(
     ancestor_id: Option<&str>,
     mut output: impl FnMut(ForwardedStderr),
 ) {
+    let mut ancestors = ancestor_id
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
     let mut lines = BufReader::new(stderr).lines();
     while let Ok(Some(line)) = lines.next_line().await {
-        if crate::events::parse(&line).is_some_and(|event| event.forward_from_child()) {
+        if let Some(event) = crate::events::parse(&line)
+            && event.forward_from_child()
+        {
+            if let crate::events::RuntimeEvent::SubagentStateChanged {
+                parent_id: Some(parent_id),
+                ..
+            } = event
+            {
+                ancestors.insert(parent_id);
+            }
             // Preserve recursively forwarded private runtime events byte-for-byte.
             output(ForwardedStderr::RuntimeLine(line));
         } else if let Some(line) = harness_diagnostic(label, &line) {
             output(ForwardedStderr::Diagnostic(line));
         }
     }
-    if let Some(ancestor_id) = ancestor_id {
+    for ancestor_id in ancestors {
         output(ForwardedStderr::Cleanup(
-            crate::events::RuntimeEvent::SubagentDescendantsRemoved {
-                ancestor_id: ancestor_id.to_owned(),
-            },
+            crate::events::RuntimeEvent::SubagentDescendantsRemoved { ancestor_id },
         ));
     }
 }
@@ -1829,7 +1910,10 @@ mod tests {
                 .text,
             "standard"
         );
-        let closed = base.fork(None, &TurnCancellation::default()).await.unwrap();
+        let closed = base
+            .fork(None, None, &TurnCancellation::default())
+            .await
+            .unwrap();
         closed.close().await.unwrap();
         assert_eq!(
             base.prompt("after sibling close".into(), TurnCancellation::default())
@@ -1839,8 +1923,14 @@ mod tests {
             "after sibling close"
         );
 
-        let first = base.fork(None, &TurnCancellation::default()).await.unwrap();
-        let second = base.fork(None, &TurnCancellation::default()).await.unwrap();
+        let first = base
+            .fork(None, None, &TurnCancellation::default())
+            .await
+            .unwrap();
+        let second = base
+            .fork(None, None, &TurnCancellation::default())
+            .await
+            .unwrap();
         let started = std::time::Instant::now();
         let (first, second) = tokio::join!(
             first.prompt("first".into(), TurnCancellation::default()),
@@ -1854,7 +1944,10 @@ mod tests {
             started.elapsed()
         );
 
-        let same_session = base.fork(None, &TurnCancellation::default()).await.unwrap();
+        let same_session = base
+            .fork(None, None, &TurnCancellation::default())
+            .await
+            .unwrap();
         let same_session_clone = same_session.clone();
         let started = std::time::Instant::now();
         let (first, second) = tokio::join!(
@@ -1868,6 +1961,72 @@ mod tests {
             "one logical session was not serialized: {:?}",
             started.elapsed()
         );
+    }
+
+    #[tokio::test]
+    async fn cancelling_native_fork_keeps_the_shared_process_usable() {
+        let root = tempfile::tempdir().unwrap();
+        let release = root.path().join("release-fork");
+        let mut profiles = BTreeMap::new();
+        profiles.insert(
+            "mock".into(),
+            AcpHarnessProfile {
+                command: "python3".into(),
+                args: vec![
+                    format!("{}/fixtures/mock-acp.py", env!("CARGO_MANIFEST_DIR")),
+                    format!("--fork-release={}", release.display()),
+                ],
+                permissions: AcpPermissionPolicy::Deny,
+            },
+        );
+        let config = ChildConfig {
+            root: root.path().to_path_buf(),
+            model: "unused".into(),
+            provider: Default::default(),
+            reasoning_effort: None,
+            openrouter_api_key: None,
+            configured_mcp_config: None,
+            configured_mcp_config_inherited: false,
+            legacy_mcp_config: false,
+            mcp_config: None,
+            credential_storage: Default::default(),
+            telemetry: Default::default(),
+            harnesses: AcpHarnesses::new(profiles).unwrap(),
+            default_harness: "acp.mock".into(),
+            parent_id: None,
+            parent_name: None,
+        };
+        let base = ChildSession::start(
+            config,
+            "acp.mock".into(),
+            None,
+            None,
+            1,
+            TurnCancellation::default(),
+        )
+        .await
+        .unwrap();
+        let controller = agentkit_core::CancellationController::new();
+        let cancellation = controller.handle().checkpoint();
+        let child = base.clone();
+        let fork = tokio::spawn(async move { child.fork(None, None, &cancellation).await });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        controller.interrupt();
+
+        assert!(matches!(fork.await.unwrap(), Err(ChildError::Cancelled)));
+        assert_eq!(
+            base.prompt(
+                "source survives cancellation".into(),
+                TurnCancellation::default(),
+            )
+            .await
+            .unwrap()
+            .text,
+            "source survives cancellation"
+        );
+        std::fs::write(release, b"ready").unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        base.close().await.unwrap();
     }
 
     #[test]

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -15,15 +15,16 @@ use agentkit_acp::{
     AcpClientHandle, AcpClientMessage, AcpIntegration, AcpRuntimeError, AcpSessionBinding,
     AudioContent, AutoDenyResolver, AvailableCommand, AvailableCommandsUpdate,
     BlobResourceContents, CancelNotification, CloseSessionRequest, CloseSessionResponse,
-    ContentBlock, ContentChunk, EmbeddedResource, EmbeddedResourceResource, ImageContent,
-    InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
-    LoadSessionRequest, LoadSessionResponse, NewSessionRequest, NewSessionResponse, Notice,
-    NoticeSeverity, PromptCapabilities, PromptRequest, PromptResponse, ResourceLink,
-    SessionAdditionalDirectoriesCapabilities, SessionCapabilities, SessionCloseCapabilities,
-    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectGroup,
-    SessionConfigSelectOption, SessionInfo, SessionListCapabilities, SessionNotification,
-    SessionUpdate, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, StopReason,
-    TextContent, TextResourceContents, ToolCallStatus, ToolCallUpdateFields,
+    ContentBlock, ContentChunk, EmbeddedResource, EmbeddedResourceResource, ForkSessionRequest,
+    ForkSessionResponse, ImageContent, InitializeRequest, InitializeResponse, ListSessionsRequest,
+    ListSessionsResponse, LoadSessionRequest, LoadSessionResponse, NewSessionRequest,
+    NewSessionResponse, Notice, NoticeSeverity, PromptCapabilities, PromptRequest, PromptResponse,
+    ResourceLink, SessionAdditionalDirectoriesCapabilities, SessionCapabilities,
+    SessionCloseCapabilities, SessionConfigOption, SessionConfigOptionCategory,
+    SessionConfigSelectGroup, SessionConfigSelectOption, SessionForkCapabilities, SessionInfo,
+    SessionListCapabilities, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
+    SetSessionConfigOptionResponse, StopReason, TextContent, TextResourceContents, ToolCallStatus,
+    ToolCallUpdateFields,
 };
 use agentkit_core::{
     CancellationController, DataRef, FinishReason, Item, ItemKind, MediaPart, MetadataMap,
@@ -48,12 +49,14 @@ pub mod v2;
 
 use crate::{
     provider::{ModelGroup, ModelSelection, ReasoningEffort, SelectableAdapter, model_catalog},
-    runtime::{AcpDriverContext, BackgroundJobs, DetachRegistration, Runtime},
+    runtime::{AcpDriverContext, AcpForkState, BackgroundJobs, DetachRegistration, Runtime},
 };
 
 const MODEL_CONFIG_ID: &str = "model";
 const REASONING_EFFORT_CONFIG_ID: &str = "reasoning_effort";
 const SESSION_LIST_PAGE_SIZE: usize = 100;
+const FORK_PARENT_ID_META: &str = "kit.subagent.parent_id";
+const FORK_PARENT_NAME_META: &str = "kit.subagent.parent_name";
 
 fn available_commands_update(session_id: agentkit_acp::SessionId) -> SessionNotification {
     SessionNotification::new(
@@ -344,6 +347,10 @@ enum Command {
         request: SetSessionConfigOptionRequest,
         reply: oneshot::Sender<Result<SetSessionConfigOptionResponse, AcpRuntimeError>>,
     },
+    Fork {
+        parent_context: Option<(String, String)>,
+        reply: oneshot::Sender<Result<AcpForkState, AcpRuntimeError>>,
+    },
     Close {
         reply: oneshot::Sender<()>,
     },
@@ -571,6 +578,11 @@ struct PreparedLoad {
     activation: oneshot::Sender<()>,
 }
 
+struct PreparedFork {
+    response: ForkSessionResponse,
+    activation: oneshot::Sender<()>,
+}
+
 /// Owns an ACP integration binding for an in-flight request or live actor.
 /// Dropping either owner must release the durable identity.
 struct SessionBindingGuard {
@@ -700,6 +712,7 @@ impl Server {
                 request.additional_directories,
                 connection,
                 claim,
+                None,
             )
             .await?;
         let AttachedSession {
@@ -770,6 +783,7 @@ impl Server {
                 request.additional_directories,
                 connection,
                 claim,
+                None,
             )
             .await?;
         let replay = transcript_replay(&attached.session_id, &attached.canonical_transcript);
@@ -780,12 +794,53 @@ impl Server {
         })
     }
 
+    async fn fork_session(
+        self: &Arc<Self>,
+        request: ForkSessionRequest,
+        connection: ConnectionTo<Client>,
+    ) -> Result<PreparedFork, AcpRuntimeError> {
+        if !request.mcp_servers.is_empty() {
+            return Err(AcpRuntimeError::Loop(
+                "Kit does not accept per-session MCP servers".into(),
+            ));
+        }
+        let parent_context = fork_parent_context(request.meta.as_ref());
+        let sender = self.sender(&request.session_id).await?;
+        let (tx, rx) = oneshot::channel();
+        sender
+            .send(Command::Fork {
+                parent_context,
+                reply: tx,
+            })
+            .await
+            .map_err(|_| AcpRuntimeError::SessionNotFound(request.session_id.to_string()))?;
+        let forked = rx
+            .await
+            .map_err(|_| AcpRuntimeError::SessionNotFound(request.session_id.to_string()))??;
+        let claim = self.runtime.claim_session_fork()?;
+        let attached = self
+            .attach_session(
+                request.cwd,
+                request.additional_directories,
+                connection,
+                claim,
+                Some(forked),
+            )
+            .await?;
+        Ok(PreparedFork {
+            response: ForkSessionResponse::new(attached.session_id)
+                .config_options(Some(attached.config_options)),
+            activation: attached.activation,
+        })
+    }
+
     async fn attach_session(
         self: &Arc<Self>,
         cwd: PathBuf,
         additional_directories: Vec<PathBuf>,
         connection: ConnectionTo<Client>,
         mut claim: crate::runtime::SessionClaim,
+        forked: Option<AcpForkState>,
     ) -> Result<AttachedSession, AcpRuntimeError> {
         // Claim the durable identity before binding ACP so every layer uses
         // the same id and any bind failure releases the selection or reservation.
@@ -826,7 +881,11 @@ impl Server {
             cancellation: handle.cancellation_handle(),
             response_attempt_replacement: true,
         };
-        let driver = match self.runtime.start_acp_driver(context, &mut claim).await {
+        let driver = match self
+            .runtime
+            .start_acp_driver_with_initial(context, &mut claim, forked)
+            .await
+        {
             Ok(driver) => driver,
             Err(error) => {
                 return Err(record_acp_runtime_failure(
@@ -1141,6 +1200,24 @@ async fn session_actor<S: ModelSession>(actor: SessionActor<S>) {
                 Some(Command::Cancel) => {}
                 Some(Command::SetConfig { request, reply }) => {
                     let result = set_config(&adapter, &catalog, request);
+                    let _ = reply.send(result);
+                }
+                Some(Command::Fork {
+                    parent_context,
+                    reply,
+                }) => {
+                    let result = (|| {
+                        let mut transcript = driver.snapshot().transcript;
+                        crate::transcript::sanitize_forked_transcript(&mut transcript);
+                        Ok(AcpForkState {
+                            transcript,
+                            selection: adapter.selection().map_err(AcpRuntimeError::Loop)?,
+                            reasoning_effort: adapter
+                                .reasoning_effort()
+                                .map_err(AcpRuntimeError::Loop)?,
+                            parent_context,
+                        })
+                    })();
                     let _ = reply.send(result);
                 }
                 Some(Command::Close { reply }) => {
@@ -1768,6 +1845,28 @@ fn component(
         .on_receive_request(
             {
                 let state = Arc::clone(&state);
+                async move |request: ForkSessionRequest, responder, cx| {
+                    let state = Arc::clone(&state);
+                    let connection = cx.clone();
+                    cx.spawn(async move {
+                        match state.fork_session(request, connection.clone()).await {
+                            Ok(prepared) => {
+                                let session_id = prepared.response.session_id.clone();
+                                responder.respond(prepared.response)?;
+                                let _ = prepared.activation.send(());
+                                connection.send_notification(available_commands_update(session_id))
+                            }
+                            Err(error) => responder.respond_with_result(Err(sdk_error(error))),
+                        }
+                    })?;
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let state = Arc::clone(&state);
                 async move |request: ListSessionsRequest, responder, cx| {
                     let state = Arc::clone(&state);
                     cx.spawn(async move {
@@ -1866,6 +1965,24 @@ fn component(
         ))
 }
 
+fn fork_parent_context(
+    meta: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> Option<(String, String)> {
+    let meta = meta?;
+    let id = meta.get(FORK_PARENT_ID_META)?.as_str()?;
+    let name = meta.get(FORK_PARENT_NAME_META)?.as_str()?;
+    crate::session::validate_id(id).ok()?;
+    if name.is_empty()
+        || name.len() > 32
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() || byte == b' ')
+    {
+        return None;
+    }
+    Some((id.into(), name.into()))
+}
+
 fn parse_session_list_cursor(cursor: &str) -> Result<usize, ListSessionsError> {
     cursor
         .strip_prefix("offset:")
@@ -1885,6 +2002,7 @@ fn capabilities() -> agentkit_acp::AgentCapabilities {
         .session_capabilities(
             SessionCapabilities::new()
                 .list(SessionListCapabilities::new())
+                .fork(SessionForkCapabilities::new())
                 .additional_directories(SessionAdditionalDirectoriesCapabilities::new())
                 .close(SessionCloseCapabilities::new()),
         )
@@ -3659,9 +3777,17 @@ pub(super) mod tests {
     }
 
     #[tokio::test]
-    async fn kit_server_advertises_supported_session_discovery_and_restoration() {
+    async fn kit_server_advertises_supported_session_discovery_restoration_and_forking() {
         let root = tempfile::tempdir().unwrap();
-        let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
+        let credentials = crate::credentials::CredentialStorage::Memory;
+        crate::provider::store_openrouter_test_credentials(&credentials);
+        let runtime = Runtime::new_with_provider_and_credentials(
+            root.path(),
+            "test-model",
+            crate::ProviderKind::OpenRouter,
+            credentials,
+        )
+        .unwrap();
         let (client_transport, agent_transport) = Channel::duplex();
         let server = tokio::spawn(serve_transport(runtime, agent_transport));
 
@@ -3677,7 +3803,7 @@ pub(super) mod tests {
                 let sessions = &initialized.agent_capabilities.session_capabilities;
                 assert!(sessions.list.is_some());
                 assert!(sessions.resume.is_none());
-                assert!(sessions.fork.is_none());
+                assert!(sessions.fork.is_some());
 
                 let listed = connection
                     .send_request(ListSessionsRequest::new().cwd(root.path().to_path_buf()))
@@ -3696,13 +3822,43 @@ pub(super) mod tests {
                 assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
 
                 connection
-                    .send_request(agentkit_acp::ForkSessionRequest::new(
+                    .send_request(ForkSessionRequest::new(
                         "missing",
                         root.path().to_path_buf(),
                     ))
                     .block_task()
                     .await
-                    .expect_err("the Kit ACP server has no session/fork route");
+                    .expect_err("an unknown fork source must fail");
+
+                let source = connection
+                    .send_request(NewSessionRequest::new(root.path().to_path_buf()))
+                    .block_task()
+                    .await?;
+                let configured = connection
+                    .send_request(SetSessionConfigOptionRequest::new(
+                        source.session_id.clone(),
+                        REASONING_EFFORT_CONFIG_ID,
+                        "high",
+                    ))
+                    .block_task()
+                    .await?;
+                let fork = connection
+                    .send_request(ForkSessionRequest::new(
+                        source.session_id.clone(),
+                        root.path().to_path_buf(),
+                    ))
+                    .block_task()
+                    .await?;
+                assert_ne!(fork.session_id, source.session_id);
+                assert_eq!(fork.config_options, Some(configured.config_options));
+                connection
+                    .send_request(CloseSessionRequest::new(fork.session_id))
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(CloseSessionRequest::new(source.session_id))
+                    .block_task()
+                    .await?;
                 Ok(())
             })
             .await

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -570,6 +570,7 @@ struct AttachedSession {
     config_options: Vec<SessionConfigOption>,
     canonical_transcript: Vec<Item>,
     activation: oneshot::Sender<()>,
+    pending_fork_creation: Option<crate::session::SessionObserver>,
 }
 
 struct PreparedLoad {
@@ -581,6 +582,7 @@ struct PreparedLoad {
 struct PreparedFork {
     response: ForkSessionResponse,
     activation: oneshot::Sender<()>,
+    creation: crate::session::SessionObserver,
 }
 
 /// Owns an ACP integration binding for an in-flight request or live actor.
@@ -831,6 +833,9 @@ impl Server {
             response: ForkSessionResponse::new(attached.session_id)
                 .config_options(Some(attached.config_options)),
             activation: attached.activation,
+            creation: attached
+                .pending_fork_creation
+                .expect("fork attachment must defer transcript creation"),
         })
     }
 
@@ -962,14 +967,19 @@ impl Server {
         self.registry
             .register(registered)
             .map_err(|()| AcpRuntimeError::ClientClosed)?;
-        if let Err(error) = claim.commit() {
-            self.registry.remove(token);
-            return Err(record_acp_runtime_failure(
-                &session_id,
-                "session_commit",
-                error,
-            ));
-        }
+        let pending_fork_creation = if claim.is_fork() {
+            Some(claim.defer_fork_commit())
+        } else {
+            if let Err(error) = claim.commit() {
+                self.registry.remove(token);
+                return Err(record_acp_runtime_failure(
+                    &session_id,
+                    "session_commit",
+                    error,
+                ));
+            }
+            None
+        };
         crate::events::emit(&crate::events::RuntimeEvent::SessionStarted {
             session_id: session_id.to_string(),
         });
@@ -989,6 +999,7 @@ impl Server {
             config_options,
             canonical_transcript,
             activation,
+            pending_fork_creation,
         })
     }
 
@@ -1853,6 +1864,7 @@ fn component(
                             Ok(prepared) => {
                                 let session_id = prepared.response.session_id.clone();
                                 responder.respond(prepared.response)?;
+                                prepared.creation.commit_creation();
                                 let _ = prepared.activation.send(());
                                 connection.send_notification(available_commands_update(session_id))
                             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -167,6 +167,7 @@ pub(crate) struct SessionClaim {
     runtime: Arc<Runtime>,
     request: SessionRequest,
     kind: SessionClaimKind,
+    fork_observer: Option<crate::session::SessionObserver>,
     committed: bool,
 }
 
@@ -190,7 +191,32 @@ impl SessionClaim {
         }
     }
 
+    fn guard_fork_transcript(&mut self, observer: &crate::session::SessionObserver) {
+        if matches!(self.kind, SessionClaimKind::Fork) {
+            self.fork_observer = Some(observer.clone());
+        }
+    }
+
+    pub(crate) fn is_fork(&self) -> bool {
+        matches!(self.kind, SessionClaimKind::Fork)
+    }
+
+    pub(crate) fn defer_fork_commit(mut self) -> crate::session::SessionObserver {
+        debug_assert!(self.is_fork());
+        self.committed = true;
+        self.fork_observer
+            .take()
+            .expect("an opened fork claim must retain its transcript observer")
+    }
+
     pub(crate) fn commit(mut self) -> Result<(), AcpRuntimeError> {
+        if matches!(self.kind, SessionClaimKind::Fork) {
+            if let Some(observer) = self.fork_observer.take() {
+                observer.commit_creation();
+            }
+            self.committed = true;
+            return Ok(());
+        }
         let mut selection =
             self.runtime.session.lock().map_err(|_| {
                 AcpRuntimeError::Loop("runtime session selection is poisoned".into())
@@ -203,7 +229,7 @@ impl SessionClaim {
             SessionClaimKind::Load { configured } => {
                 selection.finish_load(&self.request, configured, true)
             }
-            SessionClaimKind::Fork => {}
+            SessionClaimKind::Fork => unreachable!("fork claims commit before locking selection"),
         }
         self.committed = true;
         Ok(())
@@ -1101,6 +1127,7 @@ impl Runtime {
                 configured,
                 opened_new: false,
             },
+            fork_observer: None,
             committed: false,
         })
     }
@@ -1114,6 +1141,7 @@ impl Runtime {
                 force: false,
             },
             kind: SessionClaimKind::Fork,
+            fork_observer: None,
             committed: false,
         })
     }
@@ -1131,6 +1159,7 @@ impl Runtime {
             runtime: Arc::clone(self),
             request,
             kind: SessionClaimKind::Load { configured },
+            fork_observer: None,
             committed: false,
         })
     }
@@ -1176,6 +1205,7 @@ impl Runtime {
             ),
             None => (None, None, None),
         };
+        let is_fork = forked_transcript.is_some();
         let initial = if let Some(transcript) = forked_transcript {
             if request.resume {
                 return Err(AcpRuntimeError::Loop(
@@ -1193,15 +1223,22 @@ impl Runtime {
                 .await
                 .map_err(AcpRuntimeError::Loop)?
         };
-        let opened = crate::session::open(
-            &self.root,
-            &request.id,
-            request.resume,
-            request.force,
-            initial,
-        )
+        let opened = if is_fork {
+            crate::session::open_uncommitted(&self.root, &request.id, initial)
+        } else {
+            crate::session::open(
+                &self.root,
+                &request.id,
+                request.resume,
+                request.force,
+                initial,
+            )
+        }
         .map_err(AcpRuntimeError::Loop)?;
         claim.mark_opened();
+        if is_fork {
+            claim.guard_fork_transcript(&opened.observer);
+        }
         // Every ACP route owns its model selection. Changing one session
         // cannot redirect another session served by the same runtime.
         let (selection, reasoning_effort) = selected.unwrap_or_else(|| {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -34,7 +34,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     acp_child::{AcpHarnesses, BUILTIN_HARNESS, ChildConfig},
-    provider::{ProviderKind, SelectableAdapter, SelectableSession},
+    provider::{
+        ModelSelection, ProviderKind, ReasoningEffort, SelectableAdapter, SelectableSession,
+    },
     tools::{
         A2aTool, AuthTool, CloseTool, DocsTool, EditTool, ForkTool, McpTool, Observed, PromptTool,
         ShellTool, SubagentTool, Subagents, SubagentsTool, ToolSearch, observe_shared,
@@ -139,6 +141,13 @@ impl SessionSelection {
     }
 }
 
+pub(crate) struct AcpForkState {
+    pub transcript: Vec<Item>,
+    pub selection: ModelSelection,
+    pub reasoning_effort: Option<ReasoningEffort>,
+    pub parent_context: Option<(String, String)>,
+}
+
 pub(crate) struct AcpDriverContext<I = AcpIntegration> {
     pub cwd: PathBuf,
     pub additional_directories: Vec<PathBuf>,
@@ -151,6 +160,7 @@ pub(crate) struct AcpDriverContext<I = AcpIntegration> {
 enum SessionClaimKind {
     New { configured: bool, opened_new: bool },
     Load { configured: bool },
+    Fork,
 }
 
 pub(crate) struct SessionClaim {
@@ -170,6 +180,7 @@ impl SessionClaim {
             SessionClaimKind::New { configured, .. } | SessionClaimKind::Load { configured } => {
                 configured
             }
+            SessionClaimKind::Fork => false,
         }
     }
 
@@ -192,6 +203,7 @@ impl SessionClaim {
             SessionClaimKind::Load { configured } => {
                 selection.finish_load(&self.request, configured, true)
             }
+            SessionClaimKind::Fork => {}
         }
         self.committed = true;
         Ok(())
@@ -211,6 +223,7 @@ impl Drop for SessionClaim {
                 SessionClaimKind::Load { configured } => {
                     selection.finish_load(&self.request, configured, false)
                 }
+                SessionClaimKind::Fork => {}
             }
         }
     }
@@ -1092,6 +1105,19 @@ impl Runtime {
         })
     }
 
+    pub(crate) fn claim_session_fork(self: &Arc<Self>) -> Result<SessionClaim, AcpRuntimeError> {
+        Ok(SessionClaim {
+            runtime: Arc::clone(self),
+            request: SessionRequest {
+                id: crate::session::new_id(),
+                resume: false,
+                force: false,
+            },
+            kind: SessionClaimKind::Fork,
+            committed: false,
+        })
+    }
+
     pub(crate) fn claim_session_load(
         self: &Arc<Self>,
         id: &str,
@@ -1117,6 +1143,19 @@ impl Runtime {
     where
         I: LoopObserver + Clone + 'static,
     {
+        self.start_acp_driver_with_initial(context, claim, None)
+            .await
+    }
+
+    pub(crate) async fn start_acp_driver_with_initial<I>(
+        self: &Arc<Self>,
+        context: AcpDriverContext<I>,
+        claim: &mut SessionClaim,
+        forked: Option<AcpForkState>,
+    ) -> Result<AcpDriver, AcpRuntimeError>
+    where
+        I: LoopObserver + Clone + 'static,
+    {
         let cwd = context
             .cwd
             .canonicalize()
@@ -1129,7 +1168,22 @@ impl Runtime {
         }
         let request = &claim.request;
         let session_id = request.id.clone();
-        let initial = if request.resume {
+        let (forked_transcript, selected, parent_context) = match forked {
+            Some(forked) => (
+                Some(forked.transcript),
+                Some((forked.selection, forked.reasoning_effort)),
+                forked.parent_context,
+            ),
+            None => (None, None, None),
+        };
+        let initial = if let Some(transcript) = forked_transcript {
+            if request.resume {
+                return Err(AcpRuntimeError::Loop(
+                    "a forked transcript requires a new session identity".into(),
+                ));
+            }
+            transcript
+        } else if request.resume {
             vec![Item::text(
                 ItemKind::System,
                 self.system_prompt(self.base_depth),
@@ -1150,11 +1204,17 @@ impl Runtime {
         claim.mark_opened();
         // Every ACP route owns its model selection. Changing one session
         // cannot redirect another session served by the same runtime.
+        let (selection, reasoning_effort) = selected.unwrap_or_else(|| {
+            (
+                ModelSelection::new(self.provider, self.model.clone()),
+                self.reasoning_effort,
+            )
+        });
         let adapter = SelectableAdapter::new_with_credentials_effort_and_openrouter_key(
-            self.provider,
-            self.model.clone(),
+            selection.provider,
+            selection.model,
             self.credential_storage.clone(),
-            self.reasoning_effort,
+            reasoning_effort,
             self.openrouter_api_key.clone(),
         )
         .map_err(AcpRuntimeError::Loop)?;
@@ -1168,7 +1228,10 @@ impl Runtime {
             format!("compaction-{}", crate::session::new_id()),
         )
         .map_err(AcpRuntimeError::Loop)?;
-        let subagents = self.subagents.fresh();
+        let subagents = match parent_context {
+            Some((id, name)) => self.subagents.fresh_with_parent(id, name),
+            None => self.subagents.fresh(),
+        };
         let task_manager = background_task_manager();
         let tasks = task_manager.handle();
         let background_jobs = BackgroundJobs::default();

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -355,6 +355,49 @@ fn dropped_generated_session_claim_retries_opened_transcript_with_same_id() {
 }
 
 #[test]
+fn dropped_fork_claim_removes_its_uncommitted_transcript() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
+
+    let mut failed = runtime.claim_session_fork().unwrap();
+    let session_id = failed.id().to_owned();
+    let opened = crate::session::open_uncommitted(
+        root.path(),
+        &session_id,
+        vec![agentkit_core::Item::text(ItemKind::System, "system")],
+    )
+    .unwrap();
+    failed.guard_fork_transcript(&opened.observer);
+    drop(opened);
+    assert!(crate::session::load(root.path(), &session_id).is_ok());
+
+    drop(failed);
+
+    assert!(crate::session::load(root.path(), &session_id).is_err());
+}
+
+#[test]
+fn dropped_deferred_fork_creation_removes_transcript_before_response() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
+
+    let mut claim = runtime.claim_session_fork().unwrap();
+    let session_id = claim.id().to_owned();
+    let opened = crate::session::open_uncommitted(
+        root.path(),
+        &session_id,
+        vec![agentkit_core::Item::text(ItemKind::System, "system")],
+    )
+    .unwrap();
+    claim.guard_fork_transcript(&opened.observer);
+    let creation = claim.defer_fork_commit();
+    drop(opened);
+    drop(creation);
+
+    assert!(crate::session::load(root.path(), &session_id).is_err());
+}
+
+#[test]
 fn matching_load_reservation_releases_without_mutation_on_failure() {
     let root = tempfile::tempdir().unwrap();
     let runtime = Runtime::with_session(

--- a/src/session.rs
+++ b/src/session.rs
@@ -160,7 +160,8 @@ pub(crate) fn clone_completed_in(
     source: &str,
     destination: &str,
 ) -> Result<(), String> {
-    let transcript = load_in(root, directory, source)?;
+    let mut transcript = load_in(root, directory, source)?;
+    crate::transcript::sanitize_forked_transcript(&mut transcript);
     let opened = open_with_initial_timestamps_in(
         root,
         directory,
@@ -1636,7 +1637,8 @@ pub(crate) fn validate_id(value: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use agentkit_core::{ItemKind, Part};
+    use agentkit_core::{ItemKind, MetadataMap, Part, ReasoningPart};
+    use serde_json::json;
 
     fn session_directory(root: &Path) -> PathBuf {
         root.join("sessions")
@@ -1995,6 +1997,53 @@ mod tests {
         let cloned = load(root.path(), "branch").unwrap();
         assert_eq!(cloned[0].created_at, None);
         assert_eq!(cloned[1].created_at, Some(Timestamp(77)));
+    }
+
+    #[test]
+    fn cloning_sanitizes_session_bound_continuation_metadata() {
+        let root = tempfile::tempdir().unwrap();
+        let mut metadata = MetadataMap::new();
+        metadata.insert(
+            "openai.responses.continuation.v1".into(),
+            json!({ "session_id": "source" }),
+        );
+        metadata.insert("preserved".into(), true.into());
+        let source = open(
+            root.path(),
+            "source",
+            false,
+            false,
+            vec![Item::new(
+                ItemKind::Assistant,
+                vec![Part::Reasoning(
+                    ReasoningPart::summary("thought").with_metadata(metadata),
+                )],
+            )],
+        )
+        .unwrap();
+        drop(source);
+
+        clone_completed(root.path(), "source", "branch").unwrap();
+
+        let source = load(root.path(), "source").unwrap();
+        let branch = load(root.path(), "branch").unwrap();
+        let Part::Reasoning(source) = &source[0].parts[0] else {
+            panic!("expected source reasoning");
+        };
+        let Part::Reasoning(branch) = &branch[0].parts[0] else {
+            panic!("expected branch reasoning");
+        };
+        assert!(
+            source
+                .metadata
+                .contains_key("openai.responses.continuation.v1")
+        );
+        assert!(
+            !branch
+                .metadata
+                .contains_key("openai.responses.continuation.v1")
+        );
+        assert_eq!(branch.metadata["preserved"], true);
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -76,6 +76,7 @@ struct Writer {
     workspace_root: PathBuf,
     file: File,
     lock: SessionLock,
+    created: Option<CreatedTranscript>,
 }
 
 struct SessionLock {
@@ -90,6 +91,12 @@ struct SessionLock {
 struct CreatedTranscript {
     path: PathBuf,
     keep: bool,
+}
+
+#[derive(Clone, Copy)]
+struct InitialTranscriptOptions {
+    stamp_items: bool,
+    commit_creation: bool,
 }
 
 impl CreatedTranscript {
@@ -169,7 +176,10 @@ pub(crate) fn clone_completed_in(
         false,
         false,
         transcript,
-        false,
+        InitialTranscriptOptions {
+            stamp_items: false,
+            commit_creation: true,
+        },
     )?;
     drop(opened);
     Ok(())
@@ -247,7 +257,37 @@ pub(crate) fn open_in(
     force: bool,
     initial: Vec<Item>,
 ) -> Result<OpenSession, String> {
-    open_with_initial_timestamps_in(root, directory, session_id, resume, force, initial, true)
+    open_with_initial_timestamps_in(
+        root,
+        directory,
+        session_id,
+        resume,
+        force,
+        initial,
+        InitialTranscriptOptions {
+            stamp_items: true,
+            commit_creation: true,
+        },
+    )
+}
+
+pub(crate) fn open_uncommitted(
+    root: &Path,
+    session_id: &str,
+    initial: Vec<Item>,
+) -> Result<OpenSession, String> {
+    open_with_initial_timestamps_in(
+        root,
+        &default_directory()?,
+        session_id,
+        false,
+        false,
+        initial,
+        InitialTranscriptOptions {
+            stamp_items: true,
+            commit_creation: false,
+        },
+    )
 }
 
 fn open_with_initial_timestamps_in(
@@ -257,7 +297,7 @@ fn open_with_initial_timestamps_in(
     resume: bool,
     force: bool,
     initial: Vec<Item>,
-    stamp_initial: bool,
+    initial_options: InitialTranscriptOptions,
 ) -> Result<OpenSession, String> {
     validate_id(session_id)?;
     if !resume && initial.is_empty() {
@@ -322,7 +362,7 @@ fn open_with_initial_timestamps_in(
     let file = options
         .open(&path)
         .map_err(|error| format!("could not open {}: {error}", path.display()))?;
-    let mut created = (!resume).then(|| CreatedTranscript::new(path.clone()));
+    let created = (!resume).then(|| CreatedTranscript::new(path.clone()));
     let mut writer = Writer {
         session_id: session_id.into(),
         generation,
@@ -330,13 +370,14 @@ fn open_with_initial_timestamps_in(
         workspace_root,
         file,
         lock,
+        created,
     };
     if resume && stored_workspace.is_none() {
         writer.replace(&transcript)?;
     }
     if !resume {
         for mut item in initial {
-            if stamp_initial {
+            if initial_options.stamp_items {
                 stamp_item(&mut item, Timestamp::now());
                 writer.append(&item)?;
             } else {
@@ -357,8 +398,8 @@ fn open_with_initial_timestamps_in(
     for item in crate::transcript::repair_unanswered_tool_calls(&mut transcript) {
         writer.append(&item)?;
     }
-    if let Some(created) = created.take() {
-        created.keep();
+    if initial_options.commit_creation {
+        writer.commit_creation();
     }
     Ok(OpenSession {
         transcript,
@@ -367,6 +408,13 @@ fn open_with_initial_timestamps_in(
 }
 
 impl SessionObserver {
+    pub(crate) fn commit_creation(&self) {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .commit_creation();
+    }
+
     /// Durably records a complete transcript replacement produced by a mutator.
     /// Existing append records remain intact, while readers treat this record as
     /// a new canonical snapshot.
@@ -394,6 +442,12 @@ impl TranscriptObserver for SessionObserver {
 }
 
 impl Writer {
+    fn commit_creation(&mut self) {
+        if let Some(created) = self.created.take() {
+            created.keep();
+        }
+    }
+
     fn append(&mut self, item: &Item) -> Result<(), String> {
         if item.created_at.is_none() {
             return Err("transcript item missing created_at before persistence".into());

--- a/src/tools/subagent.rs
+++ b/src/tools/subagent.rs
@@ -282,6 +282,13 @@ impl Subagents {
         Self::new(self.config.clone(), self.max_depth)
     }
 
+    pub(crate) fn fresh_with_parent(&self, id: String, name: String) -> Self {
+        Self::new(
+            self.config.clone().with_parent_context(id, name),
+            self.max_depth,
+        )
+    }
+
     fn emit_event(&self, mut event: events::RuntimeEvent) {
         if let events::RuntimeEvent::SubagentStateChanged {
             parent_id,
@@ -710,9 +717,12 @@ impl Subagents {
             .config
             .clone()
             .with_root(root)
-            .with_parent_context(id.clone(), branch_name);
+            .with_parent_context(id.clone(), branch_name.clone());
         let child_result = if native_fork {
-            source_child.fork(model.as_deref(), &cancellation).await
+            let parent = kit.then(|| (id.clone(), branch_name));
+            source_child
+                .fork(model.as_deref(), parent, &cancellation)
+                .await
         } else {
             ChildSession::start(
                 child_config,
@@ -1114,36 +1124,55 @@ impl Subagents {
     }
 
     fn monitor_child_exit(&self, id: String, state: &Arc<AsyncMutex<State>>, child: &ChildSession) {
-        let manager = self.clone();
+        // Do not keep the manager alive while waiting for the child. Dropping a
+        // session-scoped manager must drop its child handles so their ACP
+        // processes (including native-fork siblings) can terminate.
+        let sessions = Arc::downgrade(&self.sessions);
         let state = Arc::downgrade(state);
+        let event_sink = Arc::clone(&self.event_sink);
+        let parent_id = self.config.parent_id.clone();
+        let parent_name = self.config.parent_name.clone();
         let mut closed = child.closed_signal();
         tokio::spawn(async move {
             if !*closed.borrow() {
                 let _ = closed.changed().await;
             }
-            if let Some(state) = state.upgrade() {
-                manager.retire_closed_child(id, state).await;
+            let Some(state) = state.upgrade() else {
+                return;
+            };
+            let mut locked = state.lock().await;
+            if locked.status == SubagentStatus::Removed {
+                return;
             }
+            if locked.status != SubagentStatus::Idle {
+                locked.outcome = Some(GenerationOutcome::Failed);
+            }
+            locked.status = SubagentStatus::Removed;
+            locked.forking = None;
+            locked
+                .generation_finished_at_unix_ms
+                .get_or_insert_with(events::now_millis);
+            let mut event = locked.runtime_event(id.clone());
+            drop(locked);
+            if let Some(sessions) = sessions.upgrade()
+                && let Ok(mut sessions) = sessions.lock()
+                && sessions
+                    .get(&id)
+                    .is_some_and(|entry| Arc::ptr_eq(&entry.state, &state))
+            {
+                sessions.remove(&id);
+            }
+            if let events::RuntimeEvent::SubagentStateChanged {
+                parent_id: event_parent_id,
+                parent_name: event_parent_name,
+                ..
+            } = &mut event
+            {
+                *event_parent_id = parent_id;
+                *event_parent_name = parent_name;
+            }
+            let _ = event_sink(&event);
         });
-    }
-
-    async fn retire_closed_child(&self, id: String, state: Arc<AsyncMutex<State>>) {
-        let mut locked = state.lock().await;
-        if locked.status == SubagentStatus::Removed {
-            return;
-        }
-        if locked.status != SubagentStatus::Idle {
-            locked.outcome = Some(GenerationOutcome::Failed);
-        }
-        locked.status = SubagentStatus::Removed;
-        locked.forking = None;
-        locked
-            .generation_finished_at_unix_ms
-            .get_or_insert_with(events::now_millis);
-        let event = locked.runtime_event(id.clone());
-        drop(locked);
-        self.remove_if_same(&id, &state);
-        self.emit_event(event);
     }
 
     async fn fail_removed_and_remove(&self, id: &str, state: &Arc<AsyncMutex<State>>) {

--- a/src/tools/subagent/tests.rs
+++ b/src/tools/subagent/tests.rs
@@ -465,7 +465,9 @@ async fn dropping_a_session_manager_terminates_its_children() {
     let directory = tempfile::tempdir().unwrap();
     let (manager, state, _) = manager_with_disconnected_session(directory.path());
     let (child, closed) = ChildSession::closure_probe_for_test();
-    state.lock().await.child = Some(child);
+    state.lock().await.child = Some(child.clone());
+    manager.monitor_child_exit("source".into(), &state, &child);
+    drop(child);
     drop(state);
 
     drop(manager);

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -20,6 +20,9 @@ use agentkit_core::{
 };
 use serde_json::Value;
 
+const OPENAI_RESPONSES_CONTINUATION: &str = "openai.responses.continuation.v1";
+const OPENAI_SUBSCRIPTION_CONTINUATION: &str = "openai.subscription.v1";
+
 const MISSING: &str = "No result for this tool call survived in the stored transcript. The work \
                        it started may or may not have completed; check before assuming either \
                        way.";
@@ -60,6 +63,32 @@ pub fn repair_unanswered_tool_calls(transcript: &mut Vec<Item>) -> Vec<Item> {
     }
     *transcript = repaired;
     synthesized
+}
+
+/// Removes provider continuation state that is bound to the source session.
+///
+/// A fork has a new durable identity, so replaying opaque continuation state from
+/// the source would violate the provider's session binding. Generated assistant
+/// images cannot be encoded without that continuation and are omitted as well.
+pub(crate) fn sanitize_forked_transcript(transcript: &mut [Item]) {
+    for item in transcript {
+        let assistant = item.kind == ItemKind::Assistant;
+        item.parts.retain_mut(|part| {
+            let is_media = matches!(part, Part::Media(_));
+            let metadata = match part {
+                Part::ToolCall(call) => Some(&mut call.metadata),
+                Part::Reasoning(reasoning) => Some(&mut reasoning.metadata),
+                Part::Media(media) => Some(&mut media.metadata),
+                _ => None,
+            };
+            let Some(metadata) = metadata else {
+                return true;
+            };
+            metadata.remove(OPENAI_RESPONSES_CONTINUATION);
+            metadata.remove(OPENAI_SUBSCRIPTION_CONTINUATION);
+            !(assistant && is_media)
+        });
+    }
 }
 
 /// Reports whether any tool call in `transcript` is still unanswered.
@@ -120,6 +149,60 @@ mod tests {
                 ToolOutput::text("done"),
             ))],
         )
+    }
+
+    #[test]
+    fn fork_removes_session_bound_continuations_and_generated_images() {
+        let mut continuation = MetadataMap::new();
+        continuation.insert(
+            OPENAI_RESPONSES_CONTINUATION.into(),
+            json!({ "session_id": "source" }),
+        );
+        continuation.insert(
+            OPENAI_SUBSCRIPTION_CONTINUATION.into(),
+            json!({ "session_id": "source" }),
+        );
+        continuation.insert("preserved".into(), true.into());
+        let user_media = Part::media(
+            agentkit_core::Modality::Image,
+            "image/png",
+            agentkit_core::DataRef::InlineBytes(vec![3]),
+        );
+        let mut transcript = vec![
+            Item::new(
+                ItemKind::Assistant,
+                vec![
+                    Part::ToolCall(
+                        ToolCallPart::new("call-1", "compose", json!({}))
+                            .with_metadata(continuation.clone()),
+                    ),
+                    Part::media(
+                        agentkit_core::Modality::Image,
+                        "image/png",
+                        agentkit_core::DataRef::InlineBytes(vec![1]),
+                    ),
+                    Part::Media(
+                        agentkit_core::MediaPart::new(
+                            agentkit_core::Modality::Image,
+                            "image/png",
+                            agentkit_core::DataRef::InlineBytes(vec![2]),
+                        )
+                        .with_metadata(continuation),
+                    ),
+                ],
+            ),
+            Item::new(ItemKind::User, vec![user_media.clone()]),
+        ];
+
+        sanitize_forked_transcript(&mut transcript);
+
+        assert_eq!(transcript[0].parts.len(), 1);
+        let Part::ToolCall(call) = &transcript[0].parts[0] else {
+            panic!("expected tool call");
+        };
+        assert_eq!(call.metadata.len(), 1);
+        assert_eq!(call.metadata["preserved"], true);
+        assert_eq!(transcript[1].parts, vec![user_media]);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2131,6 +2131,17 @@ impl App {
                 generation_finished_at_unix_ms,
             } => {
                 if self.cleaned_agent_ids.contains(&id) {
+                    if status == SubagentStatus::Removed {
+                        self.agents.remove(&id);
+                    }
+                    return;
+                }
+                if parent_id
+                    .as_ref()
+                    .is_some_and(|parent| self.cleaned_agent_ids.contains(parent))
+                {
+                    self.cleaned_agent_ids.insert(id.clone());
+                    self.agents.remove(&id);
                     return;
                 }
                 let incoming_rank = agent_status_rank(status);
@@ -2188,6 +2199,7 @@ impl App {
                     }
                 }
                 self.agents.retain(|id, _| !removed.contains(id));
+                self.cleaned_agent_ids.insert(ancestor_id);
                 self.cleaned_agent_ids.extend(removed);
             }
             _ => unreachable!("only subagent runtime events reach the roster reducer"),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -570,6 +570,7 @@ pub struct App {
     agent_versions: HashMap<String, (u64, u8)>,
     /// Process-lifetime terminal suppression for IDs removed by subtree cleanup.
     cleaned_agent_ids: HashSet<String>,
+    cleaned_agent_ancestors: HashSet<String>,
     agents_scroll: usize,
     agents_viewport: usize,
     agents_area: Rect,
@@ -854,6 +855,7 @@ impl App {
             agents: HashMap::new(),
             agent_versions: HashMap::new(),
             cleaned_agent_ids: HashSet::new(),
+            cleaned_agent_ancestors: HashSet::new(),
             agents_scroll: 0,
             agents_viewport: 0,
             agents_area: Rect::default(),
@@ -2022,6 +2024,7 @@ impl App {
         self.agents.clear();
         self.agent_versions.clear();
         self.cleaned_agent_ids.clear();
+        self.cleaned_agent_ancestors.clear();
         self.agents_scroll = 0;
         self.agents_viewport = 0;
         self.agents_area = Rect::default();
@@ -2136,10 +2139,10 @@ impl App {
                     }
                     return;
                 }
-                if parent_id
-                    .as_ref()
-                    .is_some_and(|parent| self.cleaned_agent_ids.contains(parent))
-                {
+                if parent_id.as_ref().is_some_and(|parent| {
+                    self.cleaned_agent_ancestors.contains(parent)
+                        || self.cleaned_agent_ids.contains(parent)
+                }) {
                     self.cleaned_agent_ids.insert(id.clone());
                     self.agents.remove(&id);
                     return;
@@ -2199,7 +2202,7 @@ impl App {
                     }
                 }
                 self.agents.retain(|id, _| !removed.contains(id));
-                self.cleaned_agent_ids.insert(ancestor_id);
+                self.cleaned_agent_ancestors.insert(ancestor_id);
                 self.cleaned_agent_ids.extend(removed);
             }
             _ => unreachable!("only subagent runtime events reach the roster reducer"),
@@ -3246,17 +3249,20 @@ mod tests {
             100,
         );
         app.cleaned_agent_ids.insert("cleaned".into());
+        app.cleaned_agent_ancestors.insert("ancestor".into());
         app.set_agents_viewport(Rect::new(20, 5, 10, 4), 2);
 
         assert!(!app.agents.is_empty());
         assert!(!app.agent_versions.is_empty());
         assert!(!app.cleaned_agent_ids.is_empty());
+        assert!(!app.cleaned_agent_ancestors.is_empty());
 
         app.start_session("replacement".into());
 
         assert!(app.agents.is_empty());
         assert!(app.agent_versions.is_empty());
         assert!(app.cleaned_agent_ids.is_empty());
+        assert!(app.cleaned_agent_ancestors.is_empty());
         assert_eq!(app.agents_scroll, 0);
         assert_eq!(app.agents_viewport, 0);
         assert_eq!(app.agents_area, Rect::default());
@@ -4984,6 +4990,73 @@ mod tests {
             100,
         );
         assert!(app.agents().iter().all(|row| row.id != "closed"));
+    }
+
+    #[test]
+    fn descendant_cleanup_suppresses_late_children_but_not_ancestor_updates() {
+        use crate::events::SubagentStatus;
+        let mut app = app();
+        app.apply_runtime_at(
+            agent_event(
+                "root",
+                "Root",
+                SubagentStatus::Idle,
+                None,
+                1,
+                None,
+                (1, 1, Some(2)),
+            ),
+            100,
+        );
+        app.apply_runtime_at(
+            RuntimeEvent::SubagentDescendantsRemoved {
+                ancestor_id: "root".into(),
+            },
+            100,
+        );
+        app.apply_runtime_at(
+            agent_event(
+                "root",
+                "Root",
+                SubagentStatus::Working,
+                None,
+                2,
+                None,
+                (1, 3, None),
+            ),
+            100,
+        );
+        for event in [
+            agent_event(
+                "late-child",
+                "Late child",
+                SubagentStatus::Working,
+                None,
+                1,
+                Some(("root", "Root")),
+                (4, 4, None),
+            ),
+            agent_event(
+                "late-grand",
+                "Late grandchild",
+                SubagentStatus::Working,
+                None,
+                1,
+                Some(("late-child", "Late child")),
+                (5, 5, None),
+            ),
+        ] {
+            app.apply_runtime_at(event, 100);
+        }
+
+        assert!(app.agents().iter().any(|row| {
+            row.id == "root" && row.status == SubagentStatus::Working && row.generation == 2
+        }));
+        assert!(
+            app.agents()
+                .iter()
+                .all(|row| row.id != "late-child" && row.id != "late-grand")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Adds native ACP `session/fork` routing for harnesses that advertise the capability while retaining a safe transcript-cloning fallback. Fork copies discard session-bound provider state without modifying the source transcript.

## Motivation
Fallback forks could copy OpenAI continuation metadata bound to the source session, causing `Responses continuation metadata binding is invalid`. Kit also did not expose the native fork operation already available in the ACP protocol.

## Impact
Kit-backed ACP subagent forks can share one ACP process while preserving independent durable session identities and inherited model settings. Cancelling or timing out a fork leaves the source and sibling sessions usable, and branches rebuild provider continuation state on their next response.

## Technical details
### Fork-safe transcripts
Fork copies remove `openai.responses.continuation.v1`, `openai.subscription.v1`, and generated assistant media. The source transcript remains untouched.

### Session lifecycle
Native forks are claimed and activated as durable sessions, inherit source model and reasoning-effort selection, and carry parent context for nested subagent reporting. Late fork responses are closed instead of orphaned, and per-session close cleans up descendants without terminating the shared ACP process.

### Compatibility
Harnesses without native fork support continue to use sanitized transcript cloning.