### PR TITLE
chore(deps): update compose tool and Runlet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-tool-compose"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099026fd6086dc317e03759b3c099ddae5ba85f8811cd50e83aff138c0fac249"
+checksum = "ddfa6bc961e33850391795f78557d86d581d85267fbb797c2846be7df27dbf80"
 dependencies = [
  "agentkit-core",
  "agentkit-tools-core",
@@ -3732,9 +3732,9 @@ dependencies = [
 
 [[package]]
 name = "runlet"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9b6f0c4843401c750d52863fcf8079e2385ab59cc39e9ce28a0ebd8de5e5ea"
+checksum = "927f293f868ee447cfc55b1e5220f1717a907c566f45d836c8810e5155b3b6c8"
 dependencies = [
  "hex",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ agentkit-plugins = "=0.10.7"
 agentkit-provider-openai = "=0.10.6"
 agentkit-provider-openrouter = "=0.10.8"
 agentkit-task-manager = "=0.10.7"
-agentkit-tool-compose = { version = "=0.10.9", default-features = false, features = ["runlet"] }
+agentkit-tool-compose = { version = "=0.10.10", default-features = false, features = ["runlet"] }
 agentkit-tool-skills = "=0.10.8"
 agentkit-tools-core = "=0.10.5"
 async-trait = "=0.1.92"
@@ -51,7 +51,7 @@ ratatui = { version = "=0.30.2", default-features = false, features = ["crosster
 ratatui-image = { version = "=11.0.6", default-features = false, features = ["crossterm"] }
 reqwest = { version = "=0.13.4", default-features = false, features = ["blocking", "form", "rustls", "stream"] }
 rmcp = { version = "=3.1.4", default-features = false, features = ["auth", "client"] }
-runlet = "=0.4.0"
+runlet = "=0.5.0"
 serde = { version = "=1.0.229", features = ["derive"] }
 serde_json = "=1.0.151"
 shlex = "=2.0.1"

--- a/src/tui/plan.rs
+++ b/src/tui/plan.rs
@@ -96,6 +96,12 @@ fn statement_nodes(statement: &Stmt, depth: usize, script: &str, nodes: &mut Vec
                 expression(condition, depth, "", None, script, nodes);
             }
         }
+        StmtKind::Break { value, condition } => {
+            if let Some(condition) = condition {
+                expression(condition, depth, "", None, script, nodes);
+            }
+            expression(value, depth, "", None, script, nodes);
+        }
         StmtKind::Assert { condition, message } => {
             expression(condition, depth, "", None, script, nodes);
             if let Some(message) = message {
@@ -483,6 +489,25 @@ mod tests {
                 .filter_map(|node| node.tool.as_deref())
                 .collect::<Vec<_>>(),
             ["shell", "edit", "shell"]
+        );
+    }
+
+    #[test]
+    fn includes_break_conditions_and_values() {
+        let nodes = parse(
+            "total = fold acc = 0 for item in [] {\n\
+                 break finish({ acc }) if should_stop({ item })\n\
+                 return acc + item\n\
+             }\n\
+             return total",
+        );
+
+        assert_eq!(
+            nodes
+                .iter()
+                .filter_map(|node| node.tool.as_deref())
+                .collect::<Vec<_>>(),
+            ["should_stop", "finish"]
         );
     }
 


### PR DESCRIPTION
## Summary

Updates `agentkit-tool-compose` to 0.10.10 and Runlet to 0.5.0 so Kit uses the latest compose runtime release.

## Impact

Compose scripts can use Runlet 0.5 fold `break` statements. The TUI execution plan now traverses calls in both break conditions and values.
