### PR TITLE
fix(mcp): restore discovered tool dispatch

### DIFF
--- a/fixtures/mock-mcp.py
+++ b/fixtures/mock-mcp.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+for line in sys.stdin:
+    message = json.loads(line)
+    request_id = message.get("id")
+    method = message.get("method")
+    if request_id is None:
+        continue
+    if method == "initialize":
+        result = {
+            "protocolVersion": message["params"]["protocolVersion"],
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "mock-mcp", "version": "1.0.0"},
+        }
+    elif method == "tools/list":
+        result = {
+            "tools": [
+                {
+                    "name": "echo",
+                    "description": "Echo text.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}},
+                        "required": ["text"],
+                        "additionalProperties": False,
+                    },
+                }
+            ]
+        }
+    elif method == "tools/call":
+        result = {
+            "content": [
+                {"type": "text", "text": message["params"]["arguments"]["text"]}
+            ]
+        }
+    else:
+        response = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": "method not found"},
+        }
+        print(json.dumps(response), flush=True)
+        continue
+    print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}), flush=True)

--- a/src/tools/mcp.rs
+++ b/src/tools/mcp.rs
@@ -21,8 +21,8 @@ use agentkit_mcp::{
 };
 use agentkit_plugins::PluginMcpTransport;
 use agentkit_tools_core::{
-    CatalogReader, Tool, ToolContext, ToolError, ToolExecutionOutcome, ToolExecutionScope,
-    ToolName, ToolRequest, ToolResult, ToolSource, ToolSpec,
+    BasicToolExecutor, CatalogReader, Tool, ToolContext, ToolError, ToolExecutionOutcome,
+    ToolExecutionScope, ToolExecutor, ToolName, ToolRequest, ToolResult, ToolSource, ToolSpec,
 };
 use async_trait::async_trait;
 use rmcp::transport::auth::AuthorizationManager;
@@ -2096,6 +2096,7 @@ impl Drop for ReplayCleanup {
 pub struct McpTool {
     runtime: McpRuntime,
     catalog: CatalogReader,
+    executor: Arc<dyn ToolExecutor>,
     spec: ToolSpec,
 }
 
@@ -2121,9 +2122,12 @@ struct ExecutedMcpCall {
 
 impl McpTool {
     pub fn new(runtime: McpRuntime) -> Self {
+        let catalog = runtime.catalog();
+        let source: Arc<dyn ToolSource> = Arc::new(catalog.clone());
         Self {
-            catalog: runtime.catalog(),
             runtime,
+            catalog,
+            executor: Arc::new(BasicToolExecutor::new([source])),
             spec: ToolSpec::new(
                 ToolName::new("tool"),
                 "Invoke an authenticated MCP tool returned by tool_search.",
@@ -2272,6 +2276,10 @@ impl McpTool {
             self.runtime.clone(),
             server.clone(),
         );
+        let scope = ToolExecutionScope {
+            executor: Arc::clone(&self.executor),
+            ..scope
+        };
         let outcome = scope
             .execute_child(
                 ToolRequest::new(

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -9,8 +9,8 @@ use agentkit_core::{
     TurnId,
 };
 use agentkit_tools_core::{
-    AllowAllPermissions, BasicToolExecutor, ToolExecutionOutcome, ToolExecutionScope, ToolName,
-    ToolRequest, ToolSource,
+    AllowAllPermissions, BasicToolExecutor, ToolError, ToolExecutionOutcome, ToolExecutionScope,
+    ToolName, ToolRequest, ToolSource,
 };
 use serde_json::json;
 
@@ -90,6 +90,70 @@ return { found }"#,
 
     let outcome = execute_compose(&runtime, r#"return tool({ name: "shell", args: {} })"#).await;
     assert!(matches!(outcome, ToolExecutionOutcome::Failed(_)));
+}
+
+#[tokio::test]
+async fn discovered_mcp_tools_are_dispatchable_without_being_advertised() {
+    let directory = tempfile::tempdir().unwrap();
+    let fixture = format!("{}/fixtures/mock-mcp.py", env!("CARGO_MANIFEST_DIR"));
+    let config = directory.path().join("mcp.json");
+    std::fs::write(
+        &config,
+        serde_json::to_vec(&json!({
+            "mcpServers": {
+                "mock": {
+                    "command": "python3",
+                    "args": [fixture]
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let runtime = kit::Runtime::new(directory.path(), "gpt-5.4").unwrap();
+    let runtime = kit::Runtime::with_mcp_config(
+        runtime,
+        Some(&config),
+        Vec::new(),
+        false,
+        kit::tools::CredentialStorage::Memory,
+    )
+    .await
+    .unwrap();
+
+    let compose = runtime.compose(0);
+    assert_eq!(
+        compose
+            .specs()
+            .iter()
+            .map(|spec| spec.name.0.as_str())
+            .collect::<Vec<_>>(),
+        ["compose"],
+        "MCP tools must remain hidden from the model-visible catalog"
+    );
+    let bypass = execute_compose(
+        &runtime,
+        r#"found = tool_search({ query: "echo" })
+assert(found.total_returned == 1, "mock MCP tool was not discovered")
+return mcp_mock_echo({ text: "bypass" })"#,
+    )
+    .await;
+    assert!(
+        matches!(bypass, ToolExecutionOutcome::Failed(ToolError::InvalidInput(ref error)) if error.contains("`mcp_mock_echo` is not registered")),
+        "raw MCP adapter bypassed the tool meta-tool: {bypass:?}"
+    );
+
+    let outcome = execute_compose(
+        &runtime,
+        r#"found = tool_search({ query: "echo" })
+assert(found.total_returned == 1, "mock MCP tool was not discovered")
+return tool({ name: found.servers[0].tools[0].name, args: { text: "hello" } })"#,
+    )
+    .await;
+    let ToolExecutionOutcome::Completed(result) = outcome else {
+        panic!("discovered MCP tool was not dispatchable: {outcome:?}");
+    };
+    assert_eq!(result.result.output, ToolOutput::structured(json!("hello")));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Restore invocation of MCP tools returned by `tool_search` while keeping raw MCP adapters inaccessible to Runlet programs. Add end-to-end coverage with a local mock MCP server for discovery, guarded dispatch, and successful invocation through the `tool` meta-tool.

## Motivation

The `tool` meta-tool validated discovered names against the MCP catalog, but its nested execution reused a scope whose executor could not resolve those adapters. Discovered MCP tool calls therefore failed with `tool not found` after successful discovery.

## Technical details

### Private adapter executor

`McpTool` owns a catalog-backed executor and substitutes it only for the nested adapter call. The derived scope retains the original permissions, resources, cancellation, and request context, while the raw MCP catalog remains absent from Compose so literal `mcp_*` calls cannot bypass timeout and OAuth/replay lifecycle handling.