### PR TITLE
feat(acp): advertise terminal authentication methods

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -504,6 +504,9 @@ enum Command {
         server_credential_file: Option<PathBuf>,
         #[command(flatten)]
         mcp: McpArgs,
+        /// Provider login requested by ACP terminal authentication.
+        #[arg(long, value_enum, hide = true)]
+        terminal_auth_login: Option<AuthProvider>,
         /// Persistent session id selected by the hosting client.
         #[arg(long)]
         session_id: Option<String>,
@@ -532,6 +535,9 @@ enum Command {
         mcp: McpArgs,
         #[arg(long)]
         session_id: Option<String>,
+        /// Provider login requested by ACP terminal authentication.
+        #[arg(long, value_enum, hide = true)]
+        terminal_auth_login: Option<AuthProvider>,
         #[arg(long, requires = "session_id")]
         resume: bool,
         #[arg(long, requires = "resume")]
@@ -592,6 +598,24 @@ enum Command {
         #[arg(long, requires = "resume")]
         force: bool,
     },
+}
+
+impl Command {
+    fn terminal_auth_login(&self) -> Option<(AuthProvider, &CredentialArgs)> {
+        match self {
+            Self::Serve {
+                terminal_auth_login: Some(provider),
+                mcp,
+                ..
+            }
+            | Self::Acp {
+                terminal_auth_login: Some(provider),
+                mcp,
+                ..
+            } => Some((*provider, &mcp.credentials)),
+            _ => None,
+        }
+    }
 }
 
 fn initial_config(home: &Path) -> String {
@@ -859,6 +883,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         execute_auth(action, storage, openrouter_api_key.clone()).await?;
         return Ok(());
     }
+    if let Some((provider, credentials)) = cli.command.terminal_auth_login() {
+        let action = AuthAction::Login { provider };
+        let storage = credentials.storage(&config)?;
+        validate_auth_storage(&action, &storage)?;
+        execute_auth(&action, storage, openrouter_api_key.clone()).await?;
+        return Ok(());
+    }
     match cli.command {
         Command::Init => unreachable!("init returns before loading runtime config"),
         Command::Auth { .. } => unreachable!("auth commands return before loading runtime config"),
@@ -875,6 +906,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             stdio_protocol_version,
             server_credential_file,
             mcp,
+            terminal_auth_login: _,
             session_id,
             resume,
             force,
@@ -962,6 +994,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             reasoning_effort,
             mcp,
             session_id,
+            terminal_auth_login: _,
             resume,
             force,
             subagent_depth,
@@ -1756,6 +1789,14 @@ future_option = true
         assert!(Cli::try_parse_from(["kit", "auth", "status", "openrouter"]).is_ok());
         assert!(Cli::try_parse_from(["kit", "auth", "logout", "openrouter"]).is_ok());
         assert!(Cli::try_parse_from(["kit", "auth", "logout", "--local-only"]).is_err());
+        for command in ["acp", "serve"] {
+            let cli =
+                Cli::try_parse_from(["kit", command, "--terminal-auth-login", "openai"]).unwrap();
+            assert!(matches!(
+                cli.command.terminal_auth_login(),
+                Some((AuthProvider::Openai, _))
+            ));
+        }
         assert!(Cli::try_parse_from(["kit", "tui", "--credential-store", "memory"]).is_ok());
         assert!(Cli::try_parse_from(["kit", "tui", "--mcp-credential-store", "memory"]).is_err());
     }

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -13,18 +13,18 @@ use std::{
 use agent_client_protocol::{Client, ConnectTo, ConnectionTo, Handled};
 use agentkit_acp::{
     AcpClientHandle, AcpClientMessage, AcpIntegration, AcpRuntimeError, AcpSessionBinding,
-    AudioContent, AutoDenyResolver, AvailableCommand, AvailableCommandsUpdate,
-    BlobResourceContents, CancelNotification, CloseSessionRequest, CloseSessionResponse,
-    ContentBlock, ContentChunk, EmbeddedResource, EmbeddedResourceResource, ForkSessionRequest,
-    ForkSessionResponse, ImageContent, InitializeRequest, InitializeResponse, ListSessionsRequest,
-    ListSessionsResponse, LoadSessionRequest, LoadSessionResponse, NewSessionRequest,
-    NewSessionResponse, Notice, NoticeSeverity, PromptCapabilities, PromptRequest, PromptResponse,
-    ResourceLink, SessionAdditionalDirectoriesCapabilities, SessionCapabilities,
-    SessionCloseCapabilities, SessionConfigOption, SessionConfigOptionCategory,
-    SessionConfigSelectGroup, SessionConfigSelectOption, SessionForkCapabilities, SessionInfo,
-    SessionListCapabilities, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
-    SetSessionConfigOptionResponse, StopReason, TextContent, TextResourceContents, ToolCallStatus,
-    ToolCallUpdateFields,
+    AudioContent, AuthMethod, AuthMethodTerminal, AutoDenyResolver, AvailableCommand,
+    AvailableCommandsUpdate, BlobResourceContents, CancelNotification, CloseSessionRequest,
+    CloseSessionResponse, ContentBlock, ContentChunk, EmbeddedResource, EmbeddedResourceResource,
+    ForkSessionRequest, ForkSessionResponse, ImageContent, InitializeRequest, InitializeResponse,
+    ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, LoadSessionResponse,
+    NewSessionRequest, NewSessionResponse, Notice, NoticeSeverity, PromptCapabilities,
+    PromptRequest, PromptResponse, ResourceLink, SessionAdditionalDirectoriesCapabilities,
+    SessionCapabilities, SessionCloseCapabilities, SessionConfigOption,
+    SessionConfigOptionCategory, SessionConfigSelectGroup, SessionConfigSelectOption,
+    SessionForkCapabilities, SessionInfo, SessionListCapabilities, SessionNotification,
+    SessionUpdate, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, StopReason,
+    TextContent, TextResourceContents, ToolCallStatus, ToolCallUpdateFields,
 };
 use agentkit_core::{
     CancellationController, DataRef, FinishReason, Item, ItemKind, MediaPart, MetadataMap,
@@ -57,6 +57,32 @@ const REASONING_EFFORT_CONFIG_ID: &str = "reasoning_effort";
 const SESSION_LIST_PAGE_SIZE: usize = 100;
 const FORK_PARENT_ID_META: &str = "kit.subagent.parent_id";
 const FORK_PARENT_NAME_META: &str = "kit.subagent.parent_name";
+
+fn terminal_auth_methods(capabilities: &agentkit_acp::ClientCapabilities) -> Vec<AuthMethod> {
+    let supports_terminal_auth = capabilities.auth.terminal
+        || capabilities
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.get("terminal-auth"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+    if !supports_terminal_auth {
+        return Vec::new();
+    }
+
+    vec![
+        AuthMethod::Terminal(
+            AuthMethodTerminal::new("openai", "Sign in with ChatGPT")
+                .description("Authenticate Kit with a ChatGPT subscription")
+                .args(vec!["auth".into(), "login".into(), "openai".into()]),
+        ),
+        AuthMethod::Terminal(
+            AuthMethodTerminal::new("openrouter", "Sign in with OpenRouter")
+                .description("Authenticate Kit with OpenRouter")
+                .args(vec!["auth".into(), "login".into(), "openrouter".into()]),
+        ),
+    ]
+}
 
 fn available_commands_update(session_id: agentkit_acp::SessionId) -> SessionNotification {
     SessionNotification::new(
@@ -692,9 +718,10 @@ impl Server {
         }
     }
 
-    async fn initialize(&self, _request: InitializeRequest) -> InitializeResponse {
+    async fn initialize(&self, request: InitializeRequest) -> InitializeResponse {
         InitializeResponse::new(agent_client_protocol::schema::ProtocolVersion::V1)
             .agent_capabilities(capabilities())
+            .auth_methods(terminal_auth_methods(&request.client_capabilities))
             .agent_info(agentkit_acp::Implementation::new(
                 self.integration.name().to_string(),
                 self.integration.version().to_string(),
@@ -2087,6 +2114,28 @@ pub(super) mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn terminal_auth_methods_require_client_support() {
+        assert!(terminal_auth_methods(&agentkit_acp::ClientCapabilities::new()).is_empty());
+
+        let capabilities = agentkit_acp::ClientCapabilities::new()
+            .auth(agentkit_acp::AuthCapabilities::new().terminal(true));
+        let methods = terminal_auth_methods(&capabilities);
+        assert_eq!(methods.len(), 2);
+        assert!(
+            matches!(&methods[0], AuthMethod::Terminal(method) if method.id.0.as_ref() == "openai")
+        );
+    }
+
+    #[test]
+    fn terminal_auth_methods_support_the_legacy_registry_capability() {
+        let mut meta = serde_json::Map::new();
+        meta.insert("terminal-auth".into(), serde_json::Value::Bool(true));
+        let capabilities = agentkit_acp::ClientCapabilities::new().meta(meta);
+
+        assert_eq!(terminal_auth_methods(&capabilities).len(), 2);
+    }
 
     struct CompletionOnDrop(watch::Sender<bool>);
 

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -74,12 +74,12 @@ fn terminal_auth_methods(capabilities: &agentkit_acp::ClientCapabilities) -> Vec
         AuthMethod::Terminal(
             AuthMethodTerminal::new("openai", "Sign in with ChatGPT")
                 .description("Authenticate Kit with a ChatGPT subscription")
-                .args(vec!["auth".into(), "login".into(), "openai".into()]),
+                .args(vec!["--terminal-auth-login".into(), "openai".into()]),
         ),
         AuthMethod::Terminal(
             AuthMethodTerminal::new("openrouter", "Sign in with OpenRouter")
                 .description("Authenticate Kit with OpenRouter")
-                .args(vec!["auth".into(), "login".into(), "openrouter".into()]),
+                .args(vec!["--terminal-auth-login".into(), "openrouter".into()]),
         ),
     ]
 }
@@ -2123,9 +2123,18 @@ pub(super) mod tests {
             .auth(agentkit_acp::AuthCapabilities::new().terminal(true));
         let methods = terminal_auth_methods(&capabilities);
         assert_eq!(methods.len(), 2);
-        assert!(
-            matches!(&methods[0], AuthMethod::Terminal(method) if method.id.0.as_ref() == "openai")
-        );
+        assert!(matches!(
+            &methods[0],
+            AuthMethod::Terminal(method)
+                if method.id.0.as_ref() == "openai"
+                    && method.args == ["--terminal-auth-login", "openai"]
+        ));
+        assert!(matches!(
+            &methods[1],
+            AuthMethod::Terminal(method)
+                if method.id.0.as_ref() == "openrouter"
+                    && method.args == ["--terminal-auth-login", "openrouter"]
+        ));
     }
 
     #[test]

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -39,36 +39,6 @@ use super::{
 
 const PAGE_SIZE: usize = 100;
 
-fn terminal_auth_methods(capabilities: &wire::ClientCapabilities) -> Vec<wire::AuthMethod> {
-    let supports_terminal_auth = capabilities
-        .auth
-        .as_ref()
-        .and_then(|auth| auth.terminal.as_ref())
-        .is_some()
-        || capabilities
-            .meta
-            .as_ref()
-            .and_then(|meta| meta.get("terminal-auth"))
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-    if !supports_terminal_auth {
-        return Vec::new();
-    }
-
-    vec![
-        wire::AuthMethod::Terminal(
-            wire::AuthMethodTerminal::new("openai", "Sign in with ChatGPT")
-                .description("Authenticate Kit with a ChatGPT subscription")
-                .args(vec!["auth".into(), "login".into(), "openai".into()]),
-        ),
-        wire::AuthMethod::Terminal(
-            wire::AuthMethodTerminal::new("openrouter", "Sign in with OpenRouter")
-                .description("Authenticate Kit with OpenRouter")
-                .args(vec!["auth".into(), "login".into(), "openrouter".into()]),
-        ),
-    ]
-}
-
 static NEXT_ERROR_MESSAGE_ID: AtomicU64 = AtomicU64::new(1);
 static NEXT_THOUGHT_MESSAGE_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -530,8 +500,7 @@ impl Server {
             wire::ProtocolVersion::V2,
             wire::Implementation::new("kit", env!("CARGO_PKG_VERSION")),
         )
-        .capabilities(agentkit_acp::v2::agent_capabilities())
-        .auth_methods(terminal_auth_methods(&request.capabilities)))
+        .capabilities(agentkit_acp::v2::agent_capabilities()))
     }
 
     async fn new_session(
@@ -2004,19 +1973,6 @@ mod tests {
     use super::*;
     use crate::protocols::acp::tests::{BlockingTool, ScriptAdapter};
 
-    #[test]
-    fn terminal_auth_methods_require_client_support() {
-        assert!(terminal_auth_methods(&wire::ClientCapabilities::new()).is_empty());
-
-        let capabilities = wire::ClientCapabilities::new()
-            .auth(wire::AuthCapabilities::new().terminal(wire::TerminalAuthCapabilities::new()));
-        let methods = terminal_auth_methods(&capabilities);
-        assert_eq!(methods.len(), 2);
-        assert!(
-            matches!(&methods[0], wire::AuthMethod::Terminal(method) if method.method_id.0.as_ref() == "openai")
-        );
-    }
-
     #[derive(Clone, Default)]
     struct RecordingSink {
         updates: Arc<Mutex<Vec<wire::UpdateSessionNotification>>>,
@@ -3241,13 +3197,19 @@ mod tests {
         let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
         let server = Server::new(runtime, SessionRegistry::new());
         let response = server
-            .initialize(wire::InitializeRequest::new(
-                wire::ProtocolVersion::V2,
-                wire::Implementation::new("test-client", "0"),
-            ))
+            .initialize(
+                wire::InitializeRequest::new(
+                    wire::ProtocolVersion::V2,
+                    wire::Implementation::new("test-client", "0"),
+                )
+                .capabilities(wire::ClientCapabilities::new().auth(
+                    wire::AuthCapabilities::new().terminal(wire::TerminalAuthCapabilities::new()),
+                )),
+            )
             .unwrap();
 
         assert_eq!(response.protocol_version, wire::ProtocolVersion::V2);
+        assert!(response.auth_methods.is_empty());
         let mut newer = wire::InitializeRequest::new(
             wire::ProtocolVersion::V2,
             wire::Implementation::new("newer-client", "0"),

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -38,6 +38,37 @@ use super::{
 };
 
 const PAGE_SIZE: usize = 100;
+
+fn terminal_auth_methods(capabilities: &wire::ClientCapabilities) -> Vec<wire::AuthMethod> {
+    let supports_terminal_auth = capabilities
+        .auth
+        .as_ref()
+        .and_then(|auth| auth.terminal.as_ref())
+        .is_some()
+        || capabilities
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.get("terminal-auth"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+    if !supports_terminal_auth {
+        return Vec::new();
+    }
+
+    vec![
+        wire::AuthMethod::Terminal(
+            wire::AuthMethodTerminal::new("openai", "Sign in with ChatGPT")
+                .description("Authenticate Kit with a ChatGPT subscription")
+                .args(vec!["auth".into(), "login".into(), "openai".into()]),
+        ),
+        wire::AuthMethod::Terminal(
+            wire::AuthMethodTerminal::new("openrouter", "Sign in with OpenRouter")
+                .description("Authenticate Kit with OpenRouter")
+                .args(vec!["auth".into(), "login".into(), "openrouter".into()]),
+        ),
+    ]
+}
+
 static NEXT_ERROR_MESSAGE_ID: AtomicU64 = AtomicU64::new(1);
 static NEXT_THOUGHT_MESSAGE_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -499,7 +530,8 @@ impl Server {
             wire::ProtocolVersion::V2,
             wire::Implementation::new("kit", env!("CARGO_PKG_VERSION")),
         )
-        .capabilities(agentkit_acp::v2::agent_capabilities()))
+        .capabilities(agentkit_acp::v2::agent_capabilities())
+        .auth_methods(terminal_auth_methods(&request.capabilities)))
     }
 
     async fn new_session(
@@ -1971,6 +2003,19 @@ mod tests {
 
     use super::*;
     use crate::protocols::acp::tests::{BlockingTool, ScriptAdapter};
+
+    #[test]
+    fn terminal_auth_methods_require_client_support() {
+        assert!(terminal_auth_methods(&wire::ClientCapabilities::new()).is_empty());
+
+        let capabilities = wire::ClientCapabilities::new()
+            .auth(wire::AuthCapabilities::new().terminal(wire::TerminalAuthCapabilities::new()));
+        let methods = terminal_auth_methods(&capabilities);
+        assert_eq!(methods.len(), 2);
+        assert!(
+            matches!(&methods[0], wire::AuthMethod::Terminal(method) if method.method_id.0.as_ref() == "openai")
+        );
+    }
 
     #[derive(Clone, Default)]
     struct RecordingSink {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,34 @@
 use std::{fs, process::Command};
 
 #[test]
+fn terminal_auth_arguments_run_login_from_acp_server_invocations() {
+    let home = tempfile::tempdir().unwrap();
+
+    for command in ["acp", "serve"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_kit"))
+            .env("HOME", home.path())
+            .args([
+                command,
+                "--credential-store",
+                "memory",
+                "--terminal-auth-login",
+                "openai",
+            ])
+            .output()
+            .unwrap();
+
+        assert!(!output.status.success(), "{command} unexpectedly started");
+        assert!(output.stdout.is_empty());
+        assert!(
+            String::from_utf8_lossy(&output.stderr)
+                .contains("provider login cannot use memory credential storage"),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
 fn sessions_rejects_missing_and_non_directory_roots() {
     let home = tempfile::tempdir().unwrap();
     let missing = home.path().join("missing");


### PR DESCRIPTION
## Summary

Advertise Kit's OpenAI and OpenRouter terminal login flows during ACP v1 and v2 initialization when the client supports terminal authentication. Recognize the ACP Registry validator's legacy terminal-auth capability metadata for compatibility.

## Motivation

This lets ACP clients surface Kit's supported authentication setup and allows Kit releases to satisfy the ACP Registry authentication check.
