### PR TITLE
feat(tui): support ACP terminal login

### DIFF
--- a/src/acp_child.rs
+++ b/src/acp_child.rs
@@ -292,12 +292,7 @@ impl AcpHarnesses {
         if let Some(path) = &config.mcp_config {
             command.arg("--mcp-config").arg(path);
         }
-        command
-            .arg("--credential-store")
-            .arg(config.credential_storage.cli_name());
-        if let Some(path) = config.credential_storage.directory() {
-            command.arg("--credential-dir").arg(path);
-        }
+        config.credential_storage.append_cli_args(&mut command);
         config.telemetry.append_cli_args(&mut command);
         if let Some(api_key) = &config.openrouter_api_key {
             command.env("OPENROUTER_API_KEY", api_key.as_str());

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -77,6 +77,13 @@ impl CredentialStorage {
             Self::Memory | Self::Keychain => None,
         }
     }
+
+    pub(crate) fn append_cli_args(&self, command: &mut tokio::process::Command) {
+        command.arg("--credential-store").arg(self.cli_name());
+        if let Some(directory) = self.directory() {
+            command.arg("--credential-dir").arg(directory);
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -47,6 +47,17 @@ impl CredentialStorage {
         !matches!(self, Self::Memory)
     }
 
+    #[cfg(test)]
+    pub(crate) fn make_entry_undeletable_for_test(&self, namespace: &str, identity: &str) {
+        let entry = self.entry(namespace, identity);
+        entry.save(b"blocked").unwrap();
+        let EntryBackend::Filesystem(path) = entry.backend else {
+            panic!("undeletable credential fixtures require filesystem storage");
+        };
+        fs::remove_file(&path).unwrap();
+        fs::create_dir(&path).unwrap();
+    }
+
     pub(crate) async fn lock_refresh(&self) -> Result<CredentialRefreshLock, CredentialStoreError> {
         let path = match self {
             Self::Memory => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,6 +438,16 @@ enum AuthProvider {
     Speakeasy,
 }
 
+impl AuthProvider {
+    const fn provider_kind(self) -> kit::ProviderKind {
+        match self {
+            Self::Openai => kit::ProviderKind::OpenAiSubscription,
+            Self::Openrouter => kit::ProviderKind::OpenRouter,
+            Self::Speakeasy => kit::ProviderKind::Speakeasy,
+        }
+    }
+}
+
 #[derive(Subcommand)]
 enum AuthAction {
     /// Authenticate a model provider in the configured credential store.
@@ -708,6 +718,7 @@ async fn execute_auth(
         OpenAi(kit::provider::OpenAiAuthCommand),
         OpenRouter(kit::provider::OpenRouterAuthCommand),
         Speakeasy(kit::provider::SpeakeasyAuthCommand),
+        Logout(kit::ProviderKind, bool),
     }
     let command = match action {
         AuthAction::Login { provider } => match provider {
@@ -731,21 +742,7 @@ async fn execute_auth(
         AuthAction::Logout {
             provider,
             local_only,
-        } => match provider {
-            AuthProvider::Openai => Execution::OpenAi(kit::provider::OpenAiAuthCommand::Logout {
-                local_only: *local_only,
-            }),
-            AuthProvider::Openrouter => {
-                Execution::OpenRouter(kit::provider::OpenRouterAuthCommand::Logout {
-                    local_only: *local_only,
-                })
-            }
-            AuthProvider::Speakeasy => {
-                Execution::Speakeasy(kit::provider::SpeakeasyAuthCommand::Logout {
-                    local_only: *local_only,
-                })
-            }
-        },
+        } => Execution::Logout(provider.provider_kind(), *local_only),
     };
     let output = tokio::task::spawn_blocking(move || match command {
         Execution::OpenAi(command) => kit::provider::execute_openai_auth(command, &storage),
@@ -757,6 +754,14 @@ async fn execute_auth(
                 .map(|(key, source)| (key, *source)),
         ),
         Execution::Speakeasy(command) => kit::provider::execute_speakeasy_auth(command, &storage),
+        Execution::Logout(provider, local_only) => kit::provider::execute_provider_logout(
+            provider,
+            &storage,
+            local_only,
+            openrouter_api_key
+                .as_ref()
+                .map(|(key, source)| (key, *source)),
+        ),
     })
     .await
     .map_err(io::Error::other)?

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -41,7 +41,7 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::{
-    sync::{mpsc, oneshot, watch},
+    sync::{Notify, mpsc, oneshot, watch},
     task::{AbortHandle, JoinSet},
     time::timeout,
 };
@@ -63,6 +63,7 @@ const SESSION_LIST_PAGE_SIZE: usize = 100;
 const FORK_PARENT_ID_META: &str = "kit.subagent.parent_id";
 const FORK_PARENT_NAME_META: &str = "kit.subagent.parent_name";
 const AUTH_REQUIRED_KIND: &str = "authentication_required";
+const AUTHENTICATION_RESET_TIMEOUT: Duration = Duration::from_secs(45);
 
 pub(crate) struct AuthenticationRequiredData<'a> {
     pub(crate) method_id: &'a str,
@@ -506,6 +507,7 @@ struct RegistryState {
     accepting: bool,
     permanently_closed: bool,
     generation: u64,
+    pending_attachments: usize,
     sessions: HashMap<u64, RegisteredSession>,
     v2_sessions: HashMap<u64, RegisteredV2Session>,
 }
@@ -513,7 +515,39 @@ struct RegistryState {
 struct SessionRegistryInner {
     next_token: AtomicU64,
     lifecycle: tokio::sync::Mutex<()>,
+    attachments_changed: Notify,
     state: Mutex<RegistryState>,
+}
+
+pub(super) struct SessionAdmission {
+    generation: u64,
+    active: bool,
+    registry: Arc<SessionRegistryInner>,
+}
+
+impl SessionAdmission {
+    fn complete(&mut self, state: &mut RegistryState) {
+        state.pending_attachments = state.pending_attachments.saturating_sub(1);
+        self.active = false;
+        self.registry.attachments_changed.notify_waiters();
+    }
+}
+
+impl Drop for SessionAdmission {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        let registry = Arc::clone(&self.registry);
+        let mut state = registry
+            .state
+            .lock()
+            .expect("ACP session registry poisoned");
+        state.pending_attachments = state.pending_attachments.saturating_sub(1);
+        self.active = false;
+        drop(state);
+        registry.attachments_changed.notify_waiters();
+    }
 }
 
 /// Coordinates shutdown across stdio and all connection-scoped HTTP ACP components.
@@ -528,10 +562,12 @@ impl SessionRegistry {
             inner: Arc::new(SessionRegistryInner {
                 next_token: AtomicU64::new(1),
                 lifecycle: tokio::sync::Mutex::new(()),
+                attachments_changed: Notify::new(),
                 state: Mutex::new(RegistryState {
                     accepting: true,
                     permanently_closed: false,
                     generation: 0,
+                    pending_attachments: 0,
                     sessions: HashMap::new(),
                     v2_sessions: HashMap::new(),
                 }),
@@ -543,31 +579,44 @@ impl SessionRegistry {
         self.inner.next_token.fetch_add(1, Ordering::Relaxed)
     }
 
-    fn begin_attachment(&self) -> Result<u64, ()> {
-        let state = self
-            .inner
-            .state
-            .lock()
-            .expect("ACP session registry poisoned");
-        state.accepting.then_some(state.generation).ok_or(())
-    }
-
-    fn register(&self, admission: u64, session: RegisteredSession) -> Result<(), ()> {
+    fn begin_attachment(&self) -> Result<SessionAdmission, ()> {
         let mut state = self
             .inner
             .state
             .lock()
             .expect("ACP session registry poisoned");
-        if !state.accepting || state.generation != admission {
+        if !state.accepting {
+            return Err(());
+        }
+        state.pending_attachments += 1;
+        Ok(SessionAdmission {
+            generation: state.generation,
+            active: true,
+            registry: Arc::clone(&self.inner),
+        })
+    }
+
+    fn register(
+        &self,
+        admission: &mut SessionAdmission,
+        session: RegisteredSession,
+    ) -> Result<(), ()> {
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .expect("ACP session registry poisoned");
+        if !state.accepting || state.generation != admission.generation {
             return Err(());
         }
         state.sessions.insert(session.token, session);
+        admission.complete(&mut state);
         Ok(())
     }
 
     pub(super) fn register_v2(
         &self,
-        admission: u64,
+        admission: &mut SessionAdmission,
         token: u64,
         interrupt: Arc<dyn Fn() + Send + Sync>,
         close: CloseV2Session,
@@ -579,7 +628,7 @@ impl SessionRegistry {
             .state
             .lock()
             .expect("ACP session registry poisoned");
-        if !state.accepting || state.generation != admission {
+        if !state.accepting || state.generation != admission.generation {
             return Err(());
         }
         state.v2_sessions.insert(
@@ -592,6 +641,7 @@ impl SessionRegistry {
                 completed,
             },
         );
+        admission.complete(&mut state);
         Ok(())
     }
 
@@ -623,23 +673,73 @@ impl SessionRegistry {
         )
     }
 
+    async fn wait_for_pending_attachments(&self) {
+        loop {
+            let changed = self.inner.attachments_changed.notified();
+            if self
+                .inner
+                .state
+                .lock()
+                .expect("ACP session registry poisoned")
+                .pending_attachments
+                == 0
+            {
+                return;
+            }
+            changed.await;
+        }
+    }
+
     pub async fn shutdown(&self) {
-        self.close_sessions_with_timeout(Duration::from_secs(5), false)
+        self.close_sessions_with_timeout(Duration::from_secs(5), false, || async {})
             .await;
     }
 
-    pub(super) async fn reset_authentication(&self) -> bool {
-        self.close_sessions_with_timeout(Duration::from_secs(5), true)
+    #[cfg(test)]
+    async fn reset_authentication(&self) -> bool {
+        self.reset_authentication_with(async {}).await.0
+    }
+
+    async fn reset_authentication_with<T>(
+        &self,
+        reset: impl std::future::Future<Output = T>,
+    ) -> (bool, Option<T>) {
+        self.close_sessions_with_timeout(Duration::from_secs(5), true, || reset)
             .await
     }
 
     #[cfg(test)]
     async fn shutdown_with_timeout(&self, limit: Duration) {
-        self.close_sessions_with_timeout(limit, false).await;
+        self.close_sessions_with_timeout(limit, false, || async {})
+            .await;
     }
 
-    async fn close_sessions_with_timeout(&self, limit: Duration, reopen: bool) -> bool {
-        let _lifecycle = self.inner.lifecycle.lock().await;
+    async fn close_sessions_with_timeout<T, F, Fut>(
+        &self,
+        limit: Duration,
+        reopen: bool,
+        after_close: F,
+    ) -> (bool, Option<T>)
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = T>,
+    {
+        let _lifecycle = match timeout(limit, self.inner.lifecycle.lock()).await {
+            Ok(lifecycle) => lifecycle,
+            Err(_) => {
+                if !reopen {
+                    let mut state = self
+                        .inner
+                        .state
+                        .lock()
+                        .expect("ACP session registry poisoned");
+                    state.accepting = false;
+                    state.permanently_closed = true;
+                    state.generation = state.generation.wrapping_add(1);
+                }
+                return (false, None);
+            }
+        };
         let (sessions, v2_sessions) = self.close_gate_and_snapshot(!reopen);
         for session in &sessions {
             session.background_jobs.cancel_all();
@@ -680,6 +780,7 @@ impl SessionRegistry {
 
         let timed_out = timeout(limit, async {
             while closing.join_next().await.is_some() {}
+            self.wait_for_pending_attachments().await;
         })
         .await
         .is_err();
@@ -707,6 +808,7 @@ impl SessionRegistry {
                         let _ = session.completed.changed().await;
                     }
                 }
+                self.wait_for_pending_attachments().await;
             })
             .await
             .is_ok()
@@ -726,6 +828,11 @@ impl SessionRegistry {
                 .expect("ACP session registry poisoned")
                 .permanently_closed = true;
         }
+        let output = if teardown_complete {
+            Some(after_close().await)
+        } else {
+            None
+        };
         let mut reopened = false;
         if reopen && teardown_complete {
             let mut state = self
@@ -736,7 +843,7 @@ impl SessionRegistry {
             state.accepting = !state.permanently_closed;
             reopened = state.accepting;
         }
-        teardown_complete && (!reopen || reopened)
+        (teardown_complete && (!reopen || reopened), output)
     }
 }
 
@@ -746,29 +853,73 @@ impl Default for SessionRegistry {
     }
 }
 
+enum AuthenticationReset<T> {
+    Completed(bool, Option<T>),
+    TimedOut,
+    Failed(tokio::task::JoinError),
+}
+
+async fn bounded_authentication_reset<T>(
+    registry: SessionRegistry,
+    reset: impl std::future::Future<Output = T> + Send + 'static,
+    limit: Duration,
+) -> AuthenticationReset<T>
+where
+    T: Send + 'static,
+{
+    let task = tokio::spawn(async move { registry.reset_authentication_with(reset).await });
+    match timeout(limit, task).await {
+        Ok(Ok((complete, output))) => AuthenticationReset::Completed(complete, output),
+        Ok(Err(error)) => AuthenticationReset::Failed(error),
+        Err(_) => AuthenticationReset::TimedOut,
+    }
+}
+
 async fn logout_authentication(
     runtime: Arc<Runtime>,
     registry: &SessionRegistry,
 ) -> Result<(), AcpRuntimeError> {
-    let logout = match tokio::task::spawn_blocking(move || runtime.logout_authentication()).await {
-        Ok(Err(error)) if !error.credential_state_may_have_changed() => {
-            return Err(AcpRuntimeError::Loop(error.to_string()));
+    if !runtime.supports_logout_authentication() {
+        return Err(AcpRuntimeError::Loop(
+            "authentication cannot be logged out while credentials are ephemeral or explicitly configured"
+                .into(),
+        ));
+    }
+    let logout = async move {
+        match tokio::task::spawn_blocking(move || runtime.logout_authentication()).await {
+            Ok(result) => result.map_err(|error| error.to_string()),
+            Err(error) => Err(format!("authentication logout task failed: {error}")),
         }
-        Ok(result) => result.map_err(|error| error.to_string()),
-        Err(error) => Err(format!("authentication logout task failed: {error}")),
     };
-    let reset = registry.reset_authentication().await;
-
-    match (logout, reset) {
-        (Ok(()), true) => Ok(()),
-        (Err(error), true) => Err(AcpRuntimeError::Loop(format!(
-            "{error}; active ACP sessions were reset because credential state may have changed"
-        ))),
-        (Ok(()), false) => Err(AcpRuntimeError::Loop(
+    let (reset, logout) = match bounded_authentication_reset(
+        registry.clone(),
+        logout,
+        AUTHENTICATION_RESET_TIMEOUT,
+    )
+    .await
+    {
+        AuthenticationReset::Completed(reset, logout) => (reset, logout),
+        AuthenticationReset::TimedOut => {
+            return Err(AcpRuntimeError::Loop(
+                "authentication logout timed out; session admission remains paused until credential deletion finishes"
+                    .into(),
+            ));
+        }
+        AuthenticationReset::Failed(error) => {
+            return Err(AcpRuntimeError::Loop(format!(
+                "authentication logout task failed: {error}"
+            )));
+        }
+    };
+    if !reset {
+        return Err(AcpRuntimeError::Loop(
             "authentication logout could not finish session teardown".into(),
-        )),
-        (Err(error), false) => Err(AcpRuntimeError::Loop(format!(
-            "{error}; authentication logout could not finish session teardown"
+        ));
+    }
+    match logout.expect("successful teardown runs the authentication reset action") {
+        Ok(()) => Ok(()),
+        Err(error) => Err(AcpRuntimeError::Loop(format!(
+            "{error}; active ACP sessions were reset because credential state may have changed"
         ))),
     }
 }
@@ -1095,7 +1246,7 @@ impl Server {
         mut claim: crate::runtime::SessionClaim,
         forked: Option<AcpForkState>,
     ) -> Result<AttachedSession, AcpRuntimeError> {
-        let admission = self
+        let mut admission = self
             .registry
             .begin_attachment()
             .map_err(|()| AcpRuntimeError::ClientClosed)?;
@@ -1215,7 +1366,7 @@ impl Server {
         // Hold the request-scoped map lock across registration, commit, and publication.
         // Shutdown either closes the gate before this point or snapshots this actor.
         let mut sessions = self.sessions.lock().expect("ACP session map poisoned");
-        if self.registry.register(admission, registered).is_err() {
+        if self.registry.register(&mut admission, registered).is_err() {
             drop(sessions);
             drop(activation);
             actor_task.abort();
@@ -2572,7 +2723,7 @@ pub(super) mod tests {
         });
         registry
             .register(
-                registry.begin_attachment().unwrap(),
+                &mut registry.begin_attachment().unwrap(),
                 RegisteredSession {
                     token,
                     session_id: agentkit_acp::SessionId::new("logout-session"),
@@ -2637,7 +2788,7 @@ pub(super) mod tests {
         });
         registry
             .register(
-                registry.begin_attachment().unwrap(),
+                &mut registry.begin_attachment().unwrap(),
                 RegisteredSession {
                     token,
                     session_id,
@@ -2652,11 +2803,22 @@ pub(super) mod tests {
             .unwrap();
         drop(actor);
 
-        let late_admission = registry.begin_attachment().unwrap();
-        registry.shutdown_with_timeout(Duration::from_secs(1)).await;
-        assert!(closed.load(Ordering::SeqCst));
-        assert!(tasks.list_running().await.is_empty());
-        assert!(!background_jobs.activity().active);
+        let mut late_admission = registry.begin_attachment().unwrap();
+        let shutdown_registry = registry.clone();
+        let shutdown = tokio::spawn(async move {
+            shutdown_registry
+                .shutdown_with_timeout(Duration::from_secs(1))
+                .await;
+        });
+        while registry
+            .inner
+            .state
+            .lock()
+            .expect("ACP session registry poisoned")
+            .accepting
+        {
+            tokio::task::yield_now().await;
+        }
 
         let late_token = registry.next_token();
         let (late_commands, _late_received) = mpsc::channel(1);
@@ -2668,7 +2830,7 @@ pub(super) mod tests {
         assert!(
             registry
                 .register(
-                    late_admission,
+                    &mut late_admission,
                     RegisteredSession {
                         token: late_token,
                         session_id: agentkit_acp::SessionId::new("too-late"),
@@ -2682,6 +2844,11 @@ pub(super) mod tests {
                 )
                 .is_err()
         );
+        drop(late_admission);
+        shutdown.await.unwrap();
+        assert!(closed.load(Ordering::SeqCst));
+        assert!(tasks.list_running().await.is_empty());
+        assert!(!background_jobs.activity().active);
         late_actor.abort();
         late_actor.await.unwrap_err();
     }
@@ -2704,7 +2871,7 @@ pub(super) mod tests {
         let actor = tokio::spawn(std::future::pending::<()>());
         registry
             .register_v2(
-                registry.begin_attachment().unwrap(),
+                &mut registry.begin_attachment().unwrap(),
                 token,
                 Arc::new(|| {}),
                 close,
@@ -2719,7 +2886,16 @@ pub(super) mod tests {
             .lock()
             .expect("ACP session registry poisoned")
             .generation;
-        assert!(registry.reset_authentication().await);
+        let during_reset = registry.clone();
+        let closed_during_reset = Arc::clone(&closed);
+        let (reset, action) = registry
+            .reset_authentication_with(async move {
+                assert!(closed_during_reset.load(Ordering::SeqCst));
+                assert!(during_reset.begin_attachment().is_err());
+            })
+            .await;
+        assert!(reset);
+        assert_eq!(action, Some(()));
 
         assert!(closed.load(Ordering::SeqCst));
         assert_ne!(
@@ -2743,6 +2919,43 @@ pub(super) mod tests {
         actor.await.unwrap_err();
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn timed_out_authentication_reset_stays_closed_until_the_action_finishes() {
+        let registry = SessionRegistry::new();
+        let started = Arc::new(Notify::new());
+        let action_started = Arc::clone(&started);
+        let (release, released) = oneshot::channel();
+        let resetting = registry.clone();
+        let reset = tokio::spawn(async move {
+            bounded_authentication_reset(
+                resetting,
+                async move {
+                    action_started.notify_one();
+                    let _ = released.await;
+                },
+                Duration::from_secs(30),
+            )
+            .await
+        });
+        started.notified().await;
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+        assert!(matches!(
+            reset.await.unwrap(),
+            AuthenticationReset::TimedOut
+        ));
+        assert!(registry.begin_attachment().is_err());
+
+        release.send(()).unwrap();
+        for _ in 0..100 {
+            if registry.begin_attachment().is_ok() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("authentication reset did not reopen admission");
+    }
+
     #[tokio::test]
     async fn failed_authentication_reset_cannot_reopen_on_retry() {
         let registry = SessionRegistry::new();
@@ -2751,7 +2964,7 @@ pub(super) mod tests {
         let actor = tokio::spawn(std::future::pending::<()>());
         registry
             .register_v2(
-                registry.begin_attachment().unwrap(),
+                &mut registry.begin_attachment().unwrap(),
                 token,
                 Arc::new(|| {}),
                 Arc::new(|| Box::pin(std::future::pending())),
@@ -2762,13 +2975,35 @@ pub(super) mod tests {
 
         assert!(
             !registry
-                .close_sessions_with_timeout(Duration::from_millis(10), true)
+                .close_sessions_with_timeout(Duration::from_millis(10), true, || async {})
                 .await
+                .0
         );
         assert!(!registry.reset_authentication().await);
         assert!(registry.begin_attachment().is_err());
         actor.abort();
         let _ = actor.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_is_bounded_while_an_authentication_reset_holds_the_lifecycle_lock() {
+        let registry = SessionRegistry::new();
+        let lifecycle = registry.inner.lifecycle.lock().await;
+
+        registry
+            .shutdown_with_timeout(Duration::from_secs(30))
+            .await;
+
+        assert!(registry.begin_attachment().is_err());
+        assert!(
+            registry
+                .inner
+                .state
+                .lock()
+                .expect("ACP session registry poisoned")
+                .permanently_closed
+        );
+        drop(lifecycle);
     }
 
     #[tokio::test]
@@ -2792,7 +3027,7 @@ pub(super) mod tests {
         let actor = tokio::spawn(std::future::pending::<()>());
         registry
             .register(
-                registry.begin_attachment().unwrap(),
+                &mut registry.begin_attachment().unwrap(),
                 RegisteredSession {
                     token,
                     session_id: agentkit_acp::SessionId::new("stuck"),

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -745,10 +745,13 @@ async fn logout_authentication(
     runtime: Arc<Runtime>,
     registry: &SessionRegistry,
 ) -> Result<(), AcpRuntimeError> {
-    let logout = tokio::task::spawn_blocking(move || runtime.logout_authentication())
-        .await
-        .map_err(|error| format!("authentication logout task failed: {error}"))
-        .and_then(|result| result);
+    let logout = match tokio::task::spawn_blocking(move || runtime.logout_authentication()).await {
+        Ok(Err(error)) if !error.credential_state_may_have_changed() => {
+            return Err(AcpRuntimeError::Loop(error.to_string()));
+        }
+        Ok(result) => result.map_err(|error| error.to_string()),
+        Err(error) => Err(format!("authentication logout task failed: {error}")),
+    };
     let reset = registry.reset_authentication().await;
 
     match (logout, reset) {
@@ -2463,52 +2466,19 @@ pub(super) mod tests {
             .entry("speakeasy", "default")
             .save(b"removed")
             .unwrap();
-        let runtime = Runtime::new_with_provider_and_credentials(
+        let mut runtime = Runtime::new_with_provider_and_credentials(
             root.path(),
             "gpt-5.4",
             crate::ProviderKind::OpenAiSubscription,
             storage.clone(),
         )
         .unwrap();
+        Arc::get_mut(&mut runtime)
+            .unwrap()
+            .set_ambient_openrouter_api_key_for_test(false);
         let registry = SessionRegistry::new();
-        let server = Arc::new(Server::new(
-            runtime,
-            AcpIntegration::builder()
-                .name("logout-test")
-                .approval_resolver(AutoDenyResolver)
-                .build()
-                .unwrap(),
-            registry.clone(),
-        ));
-        let token = registry.next_token();
-        let session_id = agentkit_acp::SessionId::new("logout-session");
-        let (commands, mut received) = mpsc::channel(1);
-        let (completed, completion) = watch::channel(false);
-        let closed = Arc::new(AtomicBool::new(false));
-        let actor_closed = Arc::clone(&closed);
-        let actor = tokio::spawn(async move {
-            let _completion = CompletionOnDrop(completed);
-            if let Some(Command::Close { reply }) = received.recv().await {
-                actor_closed.store(true, Ordering::SeqCst);
-                let _ = reply.send(());
-            }
-        });
-        registry
-            .register(
-                registry.begin_attachment().unwrap(),
-                RegisteredSession {
-                    token,
-                    session_id,
-                    integration: Arc::clone(&server.integration),
-                    background_jobs: BackgroundJobs::default(),
-                    tasks: AsyncTaskManager::new().handle(),
-                    commands: commands.downgrade(),
-                    actor: actor.abort_handle(),
-                    completed: completion,
-                },
-            )
-            .unwrap();
-        drop(actor);
+        let server = logout_test_server(runtime, registry.clone());
+        let (_commands, closed) = register_close_tracking_session(&server, &registry);
 
         let error = server.logout().await.unwrap_err();
 
@@ -2526,6 +2496,79 @@ pub(super) mod tests {
                 .is_none()
         );
         assert!(registry.begin_attachment().is_ok());
+    }
+
+    #[tokio::test]
+    async fn unsupported_logout_preserves_active_sessions() {
+        let root = tempfile::tempdir().unwrap();
+        let credentials = tempfile::tempdir().unwrap();
+        let runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(
+            root.path(),
+            "openrouter:test",
+            crate::ProviderKind::OpenRouter,
+            crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf()),
+            None,
+            Some(crate::provider::OpenRouterApiKey::new("explicit")),
+        )
+        .unwrap();
+        let registry = SessionRegistry::new();
+        let server = logout_test_server(runtime, registry.clone());
+        let (_commands, closed) = register_close_tracking_session(&server, &registry);
+
+        let error = server.logout().await.unwrap_err();
+
+        assert!(error.to_string().contains("cannot be logged out"));
+        assert!(!closed.load(Ordering::SeqCst));
+
+        registry.shutdown().await;
+        assert!(closed.load(Ordering::SeqCst));
+    }
+
+    fn logout_test_server(runtime: Arc<Runtime>, registry: SessionRegistry) -> Arc<Server> {
+        Arc::new(Server::new(
+            runtime,
+            AcpIntegration::builder()
+                .name("logout-test")
+                .approval_resolver(AutoDenyResolver)
+                .build()
+                .unwrap(),
+            registry,
+        ))
+    }
+
+    fn register_close_tracking_session(
+        server: &Arc<Server>,
+        registry: &SessionRegistry,
+    ) -> (mpsc::Sender<Command>, Arc<AtomicBool>) {
+        let token = registry.next_token();
+        let (commands, mut received) = mpsc::channel(1);
+        let (completed, completion) = watch::channel(false);
+        let closed = Arc::new(AtomicBool::new(false));
+        let actor_closed = Arc::clone(&closed);
+        let actor = tokio::spawn(async move {
+            let _completion = CompletionOnDrop(completed);
+            if let Some(Command::Close { reply }) = received.recv().await {
+                actor_closed.store(true, Ordering::SeqCst);
+                let _ = reply.send(());
+            }
+        });
+        registry
+            .register(
+                registry.begin_attachment().unwrap(),
+                RegisteredSession {
+                    token,
+                    session_id: agentkit_acp::SessionId::new("logout-session"),
+                    integration: Arc::clone(&server.integration),
+                    background_jobs: BackgroundJobs::default(),
+                    tasks: AsyncTaskManager::new().handle(),
+                    commands: commands.downgrade(),
+                    actor: actor.abort_handle(),
+                    completed: completion,
+                },
+            )
+            .unwrap();
+        drop(actor);
+        (commands, closed)
     }
 
     #[test]

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -13,17 +13,18 @@ use std::{
 use agent_client_protocol::{Client, ConnectTo, ConnectionTo, Handled};
 use agentkit_acp::{
     AcpClientHandle, AcpClientMessage, AcpIntegration, AcpRuntimeError, AcpSessionBinding,
-    AudioContent, AuthMethod, AuthMethodTerminal, AuthenticateRequest, AuthenticateResponse,
-    AutoDenyResolver, AvailableCommand, AvailableCommandsUpdate, BlobResourceContents,
-    CancelNotification, CloseSessionRequest, CloseSessionResponse, ContentBlock, ContentChunk,
-    EmbeddedResource, EmbeddedResourceResource, ForkSessionRequest, ForkSessionResponse,
-    ImageContent, InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
-    LoadSessionRequest, LoadSessionResponse, LogoutRequest, LogoutResponse, NewSessionRequest,
-    NewSessionResponse, Notice, NoticeSeverity, PromptCapabilities, PromptRequest, PromptResponse,
-    ResourceLink, SessionAdditionalDirectoriesCapabilities, SessionCapabilities,
-    SessionCloseCapabilities, SessionConfigOption, SessionConfigOptionCategory,
-    SessionConfigSelectGroup, SessionConfigSelectOption, SessionForkCapabilities, SessionInfo,
-    SessionListCapabilities, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
+    AgentAuthCapabilities, AudioContent, AuthMethod, AuthMethodTerminal, AuthenticateRequest,
+    AuthenticateResponse, AutoDenyResolver, AvailableCommand, AvailableCommandsUpdate,
+    BlobResourceContents, CancelNotification, CloseSessionRequest, CloseSessionResponse,
+    ContentBlock, ContentChunk, EmbeddedResource, EmbeddedResourceResource, ForkSessionRequest,
+    ForkSessionResponse, ImageContent, InitializeRequest, InitializeResponse, ListSessionsRequest,
+    ListSessionsResponse, LoadSessionRequest, LoadSessionResponse, LogoutCapabilities,
+    LogoutRequest, LogoutResponse, NewSessionRequest, NewSessionResponse, Notice, NoticeSeverity,
+    PromptCapabilities, PromptRequest, PromptResponse, ResourceLink,
+    SessionAdditionalDirectoriesCapabilities, SessionCapabilities, SessionCloseCapabilities,
+    SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectGroup,
+    SessionConfigSelectOption, SessionForkCapabilities, SessionInfo, SessionListCapabilities,
+    SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
     SetSessionConfigOptionResponse, StopReason, TextContent, TextResourceContents, ToolCallStatus,
     ToolCallUpdateFields,
 };
@@ -740,6 +741,30 @@ impl Default for SessionRegistry {
     }
 }
 
+async fn logout_authentication(
+    runtime: Arc<Runtime>,
+    registry: &SessionRegistry,
+) -> Result<(), AcpRuntimeError> {
+    let logout = tokio::task::spawn_blocking(move || runtime.logout_authentication())
+        .await
+        .map_err(|error| format!("authentication logout task failed: {error}"))
+        .and_then(|result| result);
+    let reset = registry.reset_authentication().await;
+
+    match (logout, reset) {
+        (Ok(()), true) => Ok(()),
+        (Err(error), true) => Err(AcpRuntimeError::Loop(format!(
+            "{error}; active ACP sessions were reset because credential state may have changed"
+        ))),
+        (Ok(()), false) => Err(AcpRuntimeError::Loop(
+            "authentication logout could not finish session teardown".into(),
+        )),
+        (Err(error), false) => Err(AcpRuntimeError::Loop(format!(
+            "{error}; authentication logout could not finish session teardown"
+        ))),
+    }
+}
+
 struct AttachedSession {
     session_id: agentkit_acp::SessionId,
     config_options: Vec<SessionConfigOption>,
@@ -888,18 +913,7 @@ impl Server {
     }
 
     async fn logout(self: &Arc<Self>) -> Result<LogoutResponse, AcpRuntimeError> {
-        let runtime = Arc::clone(&self.runtime);
-        tokio::task::spawn_blocking(move || runtime.logout_authentication())
-            .await
-            .map_err(|error| {
-                AcpRuntimeError::Loop(format!("authentication logout task failed: {error}"))
-            })?
-            .map_err(AcpRuntimeError::Loop)?;
-        if !self.registry.reset_authentication().await {
-            return Err(AcpRuntimeError::Loop(
-                "authentication logout could not finish session teardown".into(),
-            ));
-        }
+        logout_authentication(Arc::clone(&self.runtime), &self.registry).await?;
         Ok(LogoutResponse::new())
     }
 
@@ -914,11 +928,12 @@ impl Server {
     }
 
     async fn initialize(&self, request: InitializeRequest) -> InitializeResponse {
+        let terminal_authentication = self.runtime.supports_terminal_authentication();
         InitializeResponse::new(agent_client_protocol::schema::ProtocolVersion::V1)
-            .agent_capabilities(capabilities())
+            .agent_capabilities(capabilities(terminal_authentication))
             .auth_methods(terminal_auth_methods(
                 &request.client_capabilities,
-                self.runtime.supports_terminal_authentication(),
+                terminal_authentication,
             ))
             .agent_info(agentkit_acp::Implementation::new(
                 self.integration.name().to_string(),
@@ -2278,8 +2293,8 @@ fn parse_session_list_cursor(cursor: &str) -> Result<usize, ListSessionsError> {
         .ok_or(ListSessionsError::InvalidCursor)
 }
 
-fn capabilities() -> agentkit_acp::AgentCapabilities {
-    agentkit_acp::AgentCapabilities::new()
+fn capabilities(terminal_authentication: bool) -> agentkit_acp::AgentCapabilities {
+    let capabilities = agentkit_acp::AgentCapabilities::new()
         .load_session(true)
         .prompt_capabilities(
             PromptCapabilities::new()
@@ -2293,7 +2308,12 @@ fn capabilities() -> agentkit_acp::AgentCapabilities {
                 .fork(SessionForkCapabilities::new())
                 .additional_directories(SessionAdditionalDirectoriesCapabilities::new())
                 .close(SessionCloseCapabilities::new()),
-        )
+        );
+    if terminal_authentication {
+        capabilities.auth(AgentAuthCapabilities::new().logout(LogoutCapabilities::new()))
+    } else {
+        capabilities
+    }
 }
 
 async fn drain_turn_states(
@@ -2394,6 +2414,19 @@ pub(super) mod tests {
     }
 
     #[test]
+    fn v1_logout_capability_tracks_terminal_authentication_methods() {
+        let client = agentkit_acp::ClientCapabilities::new()
+            .auth(agentkit_acp::AuthCapabilities::new().terminal(true));
+
+        for enabled in [false, true] {
+            assert_eq!(
+                capabilities(enabled).auth.logout.is_some(),
+                !terminal_auth_methods(&client, enabled).is_empty()
+            );
+        }
+    }
+
+    #[test]
     fn v1_authentication_errors_and_terminal_login_use_protocol_codes() {
         let error = sdk_error(AcpRuntimeError::Loop(
             "speakeasy_auth_required: run `kit auth login speakeasy`".into(),
@@ -2417,6 +2450,82 @@ pub(super) mod tests {
             assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
             assert_eq!(error.data.unwrap()["methodId"], method_id);
         }
+    }
+
+    #[tokio::test]
+    async fn failed_partial_logout_still_resets_active_sessions() {
+        let root = tempfile::tempdir().unwrap();
+        let credentials = tempfile::tempdir().unwrap();
+        let storage =
+            crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf());
+        storage.make_entry_undeletable_for_test("openrouter", "default");
+        storage
+            .entry("speakeasy", "default")
+            .save(b"removed")
+            .unwrap();
+        let runtime = Runtime::new_with_provider_and_credentials(
+            root.path(),
+            "gpt-5.4",
+            crate::ProviderKind::OpenAiSubscription,
+            storage.clone(),
+        )
+        .unwrap();
+        let registry = SessionRegistry::new();
+        let server = Arc::new(Server::new(
+            runtime,
+            AcpIntegration::builder()
+                .name("logout-test")
+                .approval_resolver(AutoDenyResolver)
+                .build()
+                .unwrap(),
+            registry.clone(),
+        ));
+        let token = registry.next_token();
+        let session_id = agentkit_acp::SessionId::new("logout-session");
+        let (commands, mut received) = mpsc::channel(1);
+        let (completed, completion) = watch::channel(false);
+        let closed = Arc::new(AtomicBool::new(false));
+        let actor_closed = Arc::clone(&closed);
+        let actor = tokio::spawn(async move {
+            let _completion = CompletionOnDrop(completed);
+            if let Some(Command::Close { reply }) = received.recv().await {
+                actor_closed.store(true, Ordering::SeqCst);
+                let _ = reply.send(());
+            }
+        });
+        registry
+            .register(
+                registry.begin_attachment().unwrap(),
+                RegisteredSession {
+                    token,
+                    session_id,
+                    integration: Arc::clone(&server.integration),
+                    background_jobs: BackgroundJobs::default(),
+                    tasks: AsyncTaskManager::new().handle(),
+                    commands: commands.downgrade(),
+                    actor: actor.abort_handle(),
+                    completed: completion,
+                },
+            )
+            .unwrap();
+        drop(actor);
+
+        let error = server.logout().await.unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("could not remove OpenRouter credentials")
+        );
+        assert!(closed.load(Ordering::SeqCst));
+        assert!(
+            storage
+                .entry("speakeasy", "default")
+                .load()
+                .unwrap()
+                .is_none()
+        );
+        assert!(registry.begin_attachment().is_ok());
     }
 
     #[test]

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -57,6 +57,60 @@ const REASONING_EFFORT_CONFIG_ID: &str = "reasoning_effort";
 const SESSION_LIST_PAGE_SIZE: usize = 100;
 const FORK_PARENT_ID_META: &str = "kit.subagent.parent_id";
 const FORK_PARENT_NAME_META: &str = "kit.subagent.parent_name";
+const AUTH_REQUIRED_KIND: &str = "authentication_required";
+
+pub(crate) struct AuthenticationRequiredData<'a> {
+    pub(crate) method_id: &'a str,
+    pub(crate) detail: &'a str,
+}
+
+impl<'a> AuthenticationRequiredData<'a> {
+    pub(crate) fn new(method_id: &'a str, detail: &'a str) -> Self {
+        Self { method_id, detail }
+    }
+
+    pub(crate) fn from_value(value: &'a serde_json::Value) -> Option<Self> {
+        let data = value.as_object()?;
+        (data.get("kind")?.as_str()? == AUTH_REQUIRED_KIND).then_some(Self {
+            method_id: data.get("methodId")?.as_str()?,
+            detail: data.get("detail")?.as_str()?,
+        })
+    }
+
+    pub(crate) fn into_value(self) -> serde_json::Value {
+        serde_json::json!({
+            "kind": AUTH_REQUIRED_KIND,
+            "methodId": self.method_id,
+            "detail": self.detail,
+        })
+    }
+}
+
+pub(crate) struct TerminalAuthMethodSpec {
+    pub(crate) method_id: &'static str,
+    pub(crate) name: &'static str,
+    pub(crate) description: &'static str,
+    pub(crate) args: &'static [&'static str],
+}
+
+const TERMINAL_AUTH_METHODS: &[TerminalAuthMethodSpec] = &[
+    TerminalAuthMethodSpec {
+        method_id: "openai",
+        name: "Sign in with ChatGPT",
+        description: "Authenticate Kit with a ChatGPT subscription",
+        args: &["serve", "--terminal-auth-login", "openai"],
+    },
+    TerminalAuthMethodSpec {
+        method_id: "openrouter",
+        name: "Sign in with OpenRouter",
+        description: "Authenticate Kit with OpenRouter",
+        args: &["serve", "--terminal-auth-login", "openrouter"],
+    },
+];
+
+pub(crate) fn terminal_auth_method_specs() -> &'static [TerminalAuthMethodSpec] {
+    TERMINAL_AUTH_METHODS
+}
 
 fn terminal_auth_methods(capabilities: &agentkit_acp::ClientCapabilities) -> Vec<AuthMethod> {
     let supports_terminal_auth = capabilities.auth.terminal
@@ -70,18 +124,16 @@ fn terminal_auth_methods(capabilities: &agentkit_acp::ClientCapabilities) -> Vec
         return Vec::new();
     }
 
-    vec![
-        AuthMethod::Terminal(
-            AuthMethodTerminal::new("openai", "Sign in with ChatGPT")
-                .description("Authenticate Kit with a ChatGPT subscription")
-                .args(vec!["--terminal-auth-login".into(), "openai".into()]),
-        ),
-        AuthMethod::Terminal(
-            AuthMethodTerminal::new("openrouter", "Sign in with OpenRouter")
-                .description("Authenticate Kit with OpenRouter")
-                .args(vec!["--terminal-auth-login".into(), "openrouter".into()]),
-        ),
-    ]
+    terminal_auth_method_specs()
+        .iter()
+        .map(|method| {
+            AuthMethod::Terminal(
+                AuthMethodTerminal::new(method.method_id, method.name)
+                    .description(method.description)
+                    .args(method.args.iter().map(|arg| (*arg).into()).collect()),
+            )
+        })
+        .collect()
 }
 
 fn available_commands_update(session_id: agentkit_acp::SessionId) -> SessionNotification {
@@ -2170,13 +2222,13 @@ pub(super) mod tests {
             &methods[0],
             AuthMethod::Terminal(method)
                 if method.id.0.as_ref() == "openai"
-                    && method.args == ["--terminal-auth-login", "openai"]
+                    && method.args == ["serve", "--terminal-auth-login", "openai"]
         ));
         assert!(matches!(
             &methods[1],
             AuthMethod::Terminal(method)
                 if method.id.0.as_ref() == "openrouter"
-                    && method.args == ["--terminal-auth-login", "openrouter"]
+                    && method.args == ["serve", "--terminal-auth-login", "openrouter"]
         ));
     }
 

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -13,18 +13,19 @@ use std::{
 use agent_client_protocol::{Client, ConnectTo, ConnectionTo, Handled};
 use agentkit_acp::{
     AcpClientHandle, AcpClientMessage, AcpIntegration, AcpRuntimeError, AcpSessionBinding,
-    AudioContent, AuthMethod, AuthMethodTerminal, AutoDenyResolver, AvailableCommand,
-    AvailableCommandsUpdate, BlobResourceContents, CancelNotification, CloseSessionRequest,
-    CloseSessionResponse, ContentBlock, ContentChunk, EmbeddedResource, EmbeddedResourceResource,
-    ForkSessionRequest, ForkSessionResponse, ImageContent, InitializeRequest, InitializeResponse,
-    ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, LoadSessionResponse,
-    NewSessionRequest, NewSessionResponse, Notice, NoticeSeverity, PromptCapabilities,
-    PromptRequest, PromptResponse, ResourceLink, SessionAdditionalDirectoriesCapabilities,
-    SessionCapabilities, SessionCloseCapabilities, SessionConfigOption,
-    SessionConfigOptionCategory, SessionConfigSelectGroup, SessionConfigSelectOption,
-    SessionForkCapabilities, SessionInfo, SessionListCapabilities, SessionNotification,
-    SessionUpdate, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, StopReason,
-    TextContent, TextResourceContents, ToolCallStatus, ToolCallUpdateFields,
+    AudioContent, AuthMethod, AuthMethodTerminal, AuthenticateRequest, AuthenticateResponse,
+    AutoDenyResolver, AvailableCommand, AvailableCommandsUpdate, BlobResourceContents,
+    CancelNotification, CloseSessionRequest, CloseSessionResponse, ContentBlock, ContentChunk,
+    EmbeddedResource, EmbeddedResourceResource, ForkSessionRequest, ForkSessionResponse,
+    ImageContent, InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse,
+    LoadSessionRequest, LoadSessionResponse, LogoutRequest, LogoutResponse, NewSessionRequest,
+    NewSessionResponse, Notice, NoticeSeverity, PromptCapabilities, PromptRequest, PromptResponse,
+    ResourceLink, SessionAdditionalDirectoriesCapabilities, SessionCapabilities,
+    SessionCloseCapabilities, SessionConfigOption, SessionConfigOptionCategory,
+    SessionConfigSelectGroup, SessionConfigSelectOption, SessionForkCapabilities, SessionInfo,
+    SessionListCapabilities, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
+    SetSessionConfigOptionResponse, StopReason, TextContent, TextResourceContents, ToolCallStatus,
+    ToolCallUpdateFields,
 };
 use agentkit_core::{
     CancellationController, DataRef, FinishReason, Item, ItemKind, MediaPart, MetadataMap,
@@ -48,7 +49,10 @@ mod skill_catalog;
 pub mod v2;
 
 use crate::{
-    provider::{ModelGroup, ModelSelection, ReasoningEffort, SelectableAdapter, model_catalog},
+    provider::{
+        ModelGroup, ModelSelection, ReasoningEffort, SelectableAdapter, authentication_method_id,
+        model_catalog,
+    },
     runtime::{AcpDriverContext, AcpForkState, BackgroundJobs, DetachRegistration, Runtime},
 };
 
@@ -90,7 +94,6 @@ pub(crate) struct TerminalAuthMethodSpec {
     pub(crate) method_id: &'static str,
     pub(crate) name: &'static str,
     pub(crate) description: &'static str,
-    pub(crate) args: &'static [&'static str],
 }
 
 const TERMINAL_AUTH_METHODS: &[TerminalAuthMethodSpec] = &[
@@ -98,13 +101,16 @@ const TERMINAL_AUTH_METHODS: &[TerminalAuthMethodSpec] = &[
         method_id: "openai",
         name: "Sign in with ChatGPT",
         description: "Authenticate Kit with a ChatGPT subscription",
-        args: &["serve", "--terminal-auth-login", "openai"],
     },
     TerminalAuthMethodSpec {
         method_id: "openrouter",
         name: "Sign in with OpenRouter",
         description: "Authenticate Kit with OpenRouter",
-        args: &["serve", "--terminal-auth-login", "openrouter"],
+    },
+    TerminalAuthMethodSpec {
+        method_id: "speakeasy",
+        name: "Sign in with Speakeasy",
+        description: "Authenticate Kit with Speakeasy",
     },
 ];
 
@@ -112,7 +118,10 @@ pub(crate) fn terminal_auth_method_specs() -> &'static [TerminalAuthMethodSpec] 
     TERMINAL_AUTH_METHODS
 }
 
-fn terminal_auth_methods(capabilities: &agentkit_acp::ClientCapabilities) -> Vec<AuthMethod> {
+fn terminal_auth_methods(
+    capabilities: &agentkit_acp::ClientCapabilities,
+    persistent_credentials: bool,
+) -> Vec<AuthMethod> {
     let supports_terminal_auth = capabilities.auth.terminal
         || capabilities
             .meta
@@ -120,7 +129,7 @@ fn terminal_auth_methods(capabilities: &agentkit_acp::ClientCapabilities) -> Vec
             .and_then(|meta| meta.get("terminal-auth"))
             .and_then(serde_json::Value::as_bool)
             .unwrap_or(false);
-    if !supports_terminal_auth {
+    if !supports_terminal_auth || !persistent_credentials {
         return Vec::new();
     }
 
@@ -130,7 +139,10 @@ fn terminal_auth_methods(capabilities: &agentkit_acp::ClientCapabilities) -> Vec
             AuthMethod::Terminal(
                 AuthMethodTerminal::new(method.method_id, method.name)
                     .description(method.description)
-                    .args(method.args.iter().map(|arg| (*arg).into()).collect()),
+                    .args(vec![
+                        "--terminal-auth-login".into(),
+                        method.method_id.into(),
+                    ]),
             )
         })
         .collect()
@@ -410,7 +422,12 @@ pub(crate) struct TurnStateNotification {
 }
 
 fn sdk_error(error: AcpRuntimeError) -> agent_client_protocol::Error {
-    agent_client_protocol::util::internal_error(error.to_string())
+    let detail = error.to_string();
+    match authentication_method_id(&detail) {
+        Some(method_id) => agent_client_protocol::Error::auth_required()
+            .data(AuthenticationRequiredData::new(method_id, &detail).into_value()),
+        None => agent_client_protocol::util::internal_error(detail),
+    }
 }
 
 #[derive(Debug)]
@@ -481,12 +498,15 @@ struct RegisteredV2Session {
 
 struct RegistryState {
     accepting: bool,
+    permanently_closed: bool,
+    generation: u64,
     sessions: HashMap<u64, RegisteredSession>,
     v2_sessions: HashMap<u64, RegisteredV2Session>,
 }
 
 struct SessionRegistryInner {
     next_token: AtomicU64,
+    lifecycle: tokio::sync::Mutex<()>,
     state: Mutex<RegistryState>,
 }
 
@@ -501,8 +521,11 @@ impl SessionRegistry {
         Self {
             inner: Arc::new(SessionRegistryInner {
                 next_token: AtomicU64::new(1),
+                lifecycle: tokio::sync::Mutex::new(()),
                 state: Mutex::new(RegistryState {
                     accepting: true,
+                    permanently_closed: false,
+                    generation: 0,
                     sessions: HashMap::new(),
                     v2_sessions: HashMap::new(),
                 }),
@@ -514,13 +537,22 @@ impl SessionRegistry {
         self.inner.next_token.fetch_add(1, Ordering::Relaxed)
     }
 
-    fn register(&self, session: RegisteredSession) -> Result<(), ()> {
+    fn begin_attachment(&self) -> Result<u64, ()> {
+        let state = self
+            .inner
+            .state
+            .lock()
+            .expect("ACP session registry poisoned");
+        state.accepting.then_some(state.generation).ok_or(())
+    }
+
+    fn register(&self, admission: u64, session: RegisteredSession) -> Result<(), ()> {
         let mut state = self
             .inner
             .state
             .lock()
             .expect("ACP session registry poisoned");
-        if !state.accepting {
+        if !state.accepting || state.generation != admission {
             return Err(());
         }
         state.sessions.insert(session.token, session);
@@ -529,6 +561,7 @@ impl SessionRegistry {
 
     pub(super) fn register_v2(
         &self,
+        admission: u64,
         token: u64,
         interrupt: Arc<dyn Fn() + Send + Sync>,
         close: CloseV2Session,
@@ -540,7 +573,7 @@ impl SessionRegistry {
             .state
             .lock()
             .expect("ACP session registry poisoned");
-        if !state.accepting {
+        if !state.accepting || state.generation != admission {
             return Err(());
         }
         state.v2_sessions.insert(
@@ -566,13 +599,18 @@ impl SessionRegistry {
         state.v2_sessions.remove(&token);
     }
 
-    fn close_gate_and_snapshot(&self) -> (Vec<RegisteredSession>, Vec<RegisteredV2Session>) {
+    fn close_gate_and_snapshot(
+        &self,
+        permanently: bool,
+    ) -> (Vec<RegisteredSession>, Vec<RegisteredV2Session>) {
         let mut state = self
             .inner
             .state
             .lock()
             .expect("ACP session registry poisoned");
         state.accepting = false;
+        state.permanently_closed |= permanently;
+        state.generation = state.generation.wrapping_add(1);
         (
             state.sessions.values().cloned().collect(),
             state.v2_sessions.values().cloned().collect(),
@@ -580,11 +618,23 @@ impl SessionRegistry {
     }
 
     pub async fn shutdown(&self) {
-        self.shutdown_with_timeout(Duration::from_secs(5)).await;
+        self.close_sessions_with_timeout(Duration::from_secs(5), false)
+            .await;
     }
 
+    pub(super) async fn reset_authentication(&self) -> bool {
+        self.close_sessions_with_timeout(Duration::from_secs(5), true)
+            .await
+    }
+
+    #[cfg(test)]
     async fn shutdown_with_timeout(&self, limit: Duration) {
-        let (sessions, v2_sessions) = self.close_gate_and_snapshot();
+        self.close_sessions_with_timeout(limit, false).await;
+    }
+
+    async fn close_sessions_with_timeout(&self, limit: Duration, reopen: bool) -> bool {
+        let _lifecycle = self.inner.lifecycle.lock().await;
+        let (sessions, v2_sessions) = self.close_gate_and_snapshot(!reopen);
         for session in &sessions {
             session.background_jobs.cancel_all();
             let _ = session.integration.interrupt_session(&session.session_id);
@@ -622,12 +672,12 @@ impl SessionRegistry {
             });
         }
 
-        if timeout(limit, async {
+        let timed_out = timeout(limit, async {
             while closing.join_next().await.is_some() {}
         })
         .await
-        .is_err()
-        {
+        .is_err();
+        let teardown_complete = if timed_out {
             closing.abort_all();
             for session in &sessions {
                 if !*session.completed.borrow() {
@@ -640,13 +690,47 @@ impl SessionRegistry {
                 }
             }
             while closing.join_next().await.is_some() {}
-            for session in sessions {
-                self.remove(session.token);
-            }
-            for session in v2_sessions {
-                self.remove(session.token);
-            }
+            timeout(limit, async {
+                for mut session in sessions.iter().cloned() {
+                    if !*session.completed.borrow() {
+                        let _ = session.completed.changed().await;
+                    }
+                }
+                for mut session in v2_sessions.iter().cloned() {
+                    if !*session.completed.borrow() {
+                        let _ = session.completed.changed().await;
+                    }
+                }
+            })
+            .await
+            .is_ok()
+        } else {
+            true
+        };
+        for session in &sessions {
+            self.remove(session.token);
         }
+        for session in &v2_sessions {
+            self.remove(session.token);
+        }
+        if !teardown_complete {
+            self.inner
+                .state
+                .lock()
+                .expect("ACP session registry poisoned")
+                .permanently_closed = true;
+        }
+        let mut reopened = false;
+        if reopen && teardown_complete {
+            let mut state = self
+                .inner
+                .state
+                .lock()
+                .expect("ACP session registry poisoned");
+            state.accepting = !state.permanently_closed;
+            reopened = state.accepting;
+        }
+        teardown_complete && (!reopen || reopened)
     }
 }
 
@@ -786,6 +870,39 @@ impl Server {
         .map(|matches| FileSearchResponse { matches })
     }
 
+    fn authenticate(
+        &self,
+        request: AuthenticateRequest,
+    ) -> Result<AuthenticateResponse, agent_client_protocol::Error> {
+        let method_id = request.method_id.0.as_ref();
+        let detail = if terminal_auth_method_specs()
+            .iter()
+            .any(|method| method.method_id == method_id)
+        {
+            "terminal authentication methods must be launched as a separate agent invocation"
+        } else {
+            "authentication method was not advertised by this agent"
+        };
+        Err(agent_client_protocol::Error::invalid_params()
+            .data(serde_json::json!({ "detail": detail, "methodId": method_id })))
+    }
+
+    async fn logout(self: &Arc<Self>) -> Result<LogoutResponse, AcpRuntimeError> {
+        let runtime = Arc::clone(&self.runtime);
+        tokio::task::spawn_blocking(move || runtime.logout_authentication())
+            .await
+            .map_err(|error| {
+                AcpRuntimeError::Loop(format!("authentication logout task failed: {error}"))
+            })?
+            .map_err(AcpRuntimeError::Loop)?;
+        if !self.registry.reset_authentication().await {
+            return Err(AcpRuntimeError::Loop(
+                "authentication logout could not finish session teardown".into(),
+            ));
+        }
+        Ok(LogoutResponse::new())
+    }
+
     fn remove_session(&self, session_id: &agentkit_acp::SessionId, token: u64) {
         let mut sessions = self.sessions.lock().expect("ACP session map poisoned");
         if sessions
@@ -799,7 +916,10 @@ impl Server {
     async fn initialize(&self, request: InitializeRequest) -> InitializeResponse {
         InitializeResponse::new(agent_client_protocol::schema::ProtocolVersion::V1)
             .agent_capabilities(capabilities())
-            .auth_methods(terminal_auth_methods(&request.client_capabilities))
+            .auth_methods(terminal_auth_methods(
+                &request.client_capabilities,
+                self.runtime.supports_terminal_authentication(),
+            ))
             .agent_info(agentkit_acp::Implementation::new(
                 self.integration.name().to_string(),
                 self.integration.version().to_string(),
@@ -952,6 +1072,10 @@ impl Server {
         mut claim: crate::runtime::SessionClaim,
         forked: Option<AcpForkState>,
     ) -> Result<AttachedSession, AcpRuntimeError> {
+        let admission = self
+            .registry
+            .begin_attachment()
+            .map_err(|()| AcpRuntimeError::ClientClosed)?;
         // Claim the durable identity before binding ACP so every layer uses
         // the same id and any bind failure releases the selection or reservation.
         let session_id = agentkit_acp::SessionId::new(claim.id());
@@ -1064,19 +1188,26 @@ impl Server {
             actor: actor_task.abort_handle(),
             completed: completion,
         };
-        drop(actor_task);
 
         // Hold the request-scoped map lock across registration, commit, and publication.
         // Shutdown either closes the gate before this point or snapshots this actor.
         let mut sessions = self.sessions.lock().expect("ACP session map poisoned");
-        self.registry
-            .register(registered)
-            .map_err(|()| AcpRuntimeError::ClientClosed)?;
+        if self.registry.register(admission, registered).is_err() {
+            drop(sessions);
+            drop(activation);
+            actor_task.abort();
+            let _ = actor_task.await;
+            return Err(AcpRuntimeError::ClientClosed);
+        }
         let pending_fork_creation = if claim.is_fork() {
             Some(claim.defer_fork_commit())
         } else {
             if let Err(error) = claim.commit() {
                 self.registry.remove(token);
+                drop(sessions);
+                drop(activation);
+                actor_task.abort();
+                let _ = actor_task.await;
                 return Err(record_acp_runtime_failure(
                     &session_id,
                     "session_commit",
@@ -1099,6 +1230,7 @@ impl Server {
             },
         );
         drop(sessions);
+        drop(actor_task);
         Ok(AttachedSession {
             session_id,
             config_options,
@@ -1911,6 +2043,28 @@ fn component(
         .on_receive_request(
             {
                 let state = Arc::clone(&state);
+                async move |request: AuthenticateRequest, responder, _cx| {
+                    responder.respond_with_result(state.authenticate(request))
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let state = Arc::clone(&state);
+                async move |_request: LogoutRequest, responder, cx| {
+                    let state = Arc::clone(&state);
+                    cx.spawn(async move {
+                        responder.respond_with_result(state.logout().await.map_err(sdk_error))
+                    })?;
+                    Ok(())
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let state = Arc::clone(&state);
                 async move |request: NewSessionRequest, responder, cx| {
                     let state = Arc::clone(&state);
                     let connection = cx.clone();
@@ -2212,24 +2366,57 @@ pub(super) mod tests {
 
     #[test]
     fn terminal_auth_methods_require_client_support() {
-        assert!(terminal_auth_methods(&agentkit_acp::ClientCapabilities::new()).is_empty());
+        assert!(terminal_auth_methods(&agentkit_acp::ClientCapabilities::new(), true).is_empty());
 
         let capabilities = agentkit_acp::ClientCapabilities::new()
             .auth(agentkit_acp::AuthCapabilities::new().terminal(true));
-        let methods = terminal_auth_methods(&capabilities);
-        assert_eq!(methods.len(), 2);
+        assert!(terminal_auth_methods(&capabilities, false).is_empty());
+        let methods = terminal_auth_methods(&capabilities, true);
+        assert_eq!(methods.len(), 3);
         assert!(matches!(
             &methods[0],
             AuthMethod::Terminal(method)
                 if method.id.0.as_ref() == "openai"
-                    && method.args == ["serve", "--terminal-auth-login", "openai"]
+                    && method.args == ["--terminal-auth-login", "openai"]
         ));
         assert!(matches!(
             &methods[1],
             AuthMethod::Terminal(method)
                 if method.id.0.as_ref() == "openrouter"
-                    && method.args == ["serve", "--terminal-auth-login", "openrouter"]
+                    && method.args == ["--terminal-auth-login", "openrouter"]
         ));
+        assert!(matches!(
+            &methods[2],
+            AuthMethod::Terminal(method)
+                if method.id.0.as_ref() == "speakeasy"
+                    && method.args == ["--terminal-auth-login", "speakeasy"]
+        ));
+    }
+
+    #[test]
+    fn v1_authentication_errors_and_terminal_login_use_protocol_codes() {
+        let error = sdk_error(AcpRuntimeError::Loop(
+            "speakeasy_auth_required: run `kit auth login speakeasy`".into(),
+        ));
+        assert_eq!(error.code, agent_client_protocol::ErrorCode::AuthRequired);
+
+        let root = tempfile::tempdir().unwrap();
+        let server = Server::new(
+            Runtime::new(root.path(), "gpt-5.4").unwrap(),
+            AcpIntegration::builder()
+                .name("auth-test")
+                .approval_resolver(AutoDenyResolver)
+                .build()
+                .unwrap(),
+            SessionRegistry::new(),
+        );
+        for method_id in ["openai", "unknown"] {
+            let error = server
+                .authenticate(AuthenticateRequest::new(method_id))
+                .unwrap_err();
+            assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
+            assert_eq!(error.data.unwrap()["methodId"], method_id);
+        }
     }
 
     #[test]
@@ -2238,7 +2425,7 @@ pub(super) mod tests {
         meta.insert("terminal-auth".into(), serde_json::Value::Bool(true));
         let capabilities = agentkit_acp::ClientCapabilities::new().meta(meta);
 
-        assert_eq!(terminal_auth_methods(&capabilities).len(), 2);
+        assert_eq!(terminal_auth_methods(&capabilities, true).len(), 3);
     }
 
     struct CompletionOnDrop(watch::Sender<bool>);
@@ -2279,19 +2466,23 @@ pub(super) mod tests {
             }
         });
         registry
-            .register(RegisteredSession {
-                token,
-                session_id,
-                integration: Arc::clone(&integration),
-                background_jobs: background_jobs.clone(),
-                tasks: tasks.clone(),
-                commands: weak_commands,
-                actor: actor.abort_handle(),
-                completed: completion,
-            })
+            .register(
+                registry.begin_attachment().unwrap(),
+                RegisteredSession {
+                    token,
+                    session_id,
+                    integration: Arc::clone(&integration),
+                    background_jobs: background_jobs.clone(),
+                    tasks: tasks.clone(),
+                    commands: weak_commands,
+                    actor: actor.abort_handle(),
+                    completed: completion,
+                },
+            )
             .unwrap();
         drop(actor);
 
+        let late_admission = registry.begin_attachment().unwrap();
         registry.shutdown_with_timeout(Duration::from_secs(1)).await;
         assert!(closed.load(Ordering::SeqCst));
         assert!(tasks.list_running().await.is_empty());
@@ -2306,20 +2497,120 @@ pub(super) mod tests {
         });
         assert!(
             registry
-                .register(RegisteredSession {
-                    token: late_token,
-                    session_id: agentkit_acp::SessionId::new("too-late"),
-                    integration,
-                    background_jobs: BackgroundJobs::default(),
-                    tasks: AsyncTaskManager::new().handle(),
-                    commands: late_commands.downgrade(),
-                    actor: late_actor.abort_handle(),
-                    completed: late_completion,
-                })
+                .register(
+                    late_admission,
+                    RegisteredSession {
+                        token: late_token,
+                        session_id: agentkit_acp::SessionId::new("too-late"),
+                        integration,
+                        background_jobs: BackgroundJobs::default(),
+                        tasks: AsyncTaskManager::new().handle(),
+                        commands: late_commands.downgrade(),
+                        actor: late_actor.abort_handle(),
+                        completed: late_completion,
+                    }
+                )
                 .is_err()
         );
         late_actor.abort();
         late_actor.await.unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn authentication_reset_closes_shared_v2_sessions_and_reopens_registration() {
+        let registry = SessionRegistry::new();
+        let token = registry.next_token();
+        let closed = Arc::new(AtomicBool::new(false));
+        let close_flag = Arc::clone(&closed);
+        let (completed, completion) = watch::channel(false);
+        let close = Arc::new(move || {
+            let close_flag = Arc::clone(&close_flag);
+            let completed = completed.clone();
+            Box::pin(async move {
+                close_flag.store(true, Ordering::SeqCst);
+                completed.send_replace(true);
+            }) as Pin<Box<dyn Future<Output = ()> + Send>>
+        });
+        let actor = tokio::spawn(std::future::pending::<()>());
+        registry
+            .register_v2(
+                registry.begin_attachment().unwrap(),
+                token,
+                Arc::new(|| {}),
+                close,
+                actor.abort_handle(),
+                completion,
+            )
+            .unwrap();
+
+        let generation = registry
+            .inner
+            .state
+            .lock()
+            .expect("ACP session registry poisoned")
+            .generation;
+        assert!(registry.reset_authentication().await);
+
+        assert!(closed.load(Ordering::SeqCst));
+        assert_ne!(
+            registry
+                .inner
+                .state
+                .lock()
+                .expect("ACP session registry poisoned")
+                .generation,
+            generation
+        );
+        assert!(
+            registry
+                .inner
+                .state
+                .lock()
+                .expect("ACP session registry poisoned")
+                .accepting
+        );
+        actor.abort();
+        actor.await.unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn failed_authentication_reset_cannot_reopen_on_retry() {
+        let registry = SessionRegistry::new();
+        let token = registry.next_token();
+        let (_completed, completion) = watch::channel(false);
+        let actor = tokio::spawn(std::future::pending::<()>());
+        registry
+            .register_v2(
+                registry.begin_attachment().unwrap(),
+                token,
+                Arc::new(|| {}),
+                Arc::new(|| Box::pin(std::future::pending())),
+                actor.abort_handle(),
+                completion,
+            )
+            .unwrap();
+
+        assert!(
+            !registry
+                .close_sessions_with_timeout(Duration::from_millis(10), true)
+                .await
+        );
+        assert!(!registry.reset_authentication().await);
+        assert!(registry.begin_attachment().is_err());
+        actor.abort();
+        let _ = actor.await;
+    }
+
+    #[tokio::test]
+    async fn permanent_shutdown_cannot_be_reopened_by_authentication_reset() {
+        let registry = SessionRegistry::new();
+        let resetting = registry.clone();
+        let reset = tokio::spawn(async move { resetting.reset_authentication().await });
+
+        registry.shutdown().await;
+        let _ = reset.await.unwrap();
+
+        assert!(registry.begin_attachment().is_err());
     }
 
     #[tokio::test]
@@ -2330,16 +2621,19 @@ pub(super) mod tests {
         let (_completed, completion) = watch::channel(false);
         let actor = tokio::spawn(std::future::pending::<()>());
         registry
-            .register(RegisteredSession {
-                token,
-                session_id: agentkit_acp::SessionId::new("stuck"),
-                integration: shutdown_test_integration(),
-                background_jobs: BackgroundJobs::default(),
-                tasks: AsyncTaskManager::new().handle(),
-                commands: commands.downgrade(),
-                actor: actor.abort_handle(),
-                completed: completion,
-            })
+            .register(
+                registry.begin_attachment().unwrap(),
+                RegisteredSession {
+                    token,
+                    session_id: agentkit_acp::SessionId::new("stuck"),
+                    integration: shutdown_test_integration(),
+                    background_jobs: BackgroundJobs::default(),
+                    tasks: AsyncTaskManager::new().handle(),
+                    commands: commands.downgrade(),
+                    actor: actor.abort_handle(),
+                    completed: completion,
+                },
+            )
             .unwrap();
         timeout(
             Duration::from_secs(1),

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -57,8 +57,8 @@ use crate::{
     runtime::{AcpDriverContext, AcpForkState, BackgroundJobs, DetachRegistration, Runtime},
 };
 
-const MODEL_CONFIG_ID: &str = "model";
-const REASONING_EFFORT_CONFIG_ID: &str = "reasoning_effort";
+pub(crate) const MODEL_CONFIG_ID: &str = "model";
+pub(crate) const REASONING_EFFORT_CONFIG_ID: &str = "reasoning_effort";
 const SESSION_LIST_PAGE_SIZE: usize = 100;
 const FORK_PARENT_ID_META: &str = "kit.subagent.parent_id";
 const FORK_PARENT_NAME_META: &str = "kit.subagent.parent_name";

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -51,8 +51,8 @@ pub mod v2;
 
 use crate::{
     provider::{
-        ModelGroup, ModelSelection, ReasoningEffort, SelectableAdapter, authentication_method_id,
-        model_catalog,
+        ModelGroup, ModelSelection, ProviderKind, ReasoningEffort, SelectableAdapter,
+        authentication_method_id, model_catalog,
     },
     runtime::{AcpDriverContext, AcpForkState, BackgroundJobs, DetachRegistration, Runtime},
 };
@@ -95,6 +95,7 @@ pub(crate) struct TerminalAuthMethodSpec {
     pub(crate) method_id: &'static str,
     pub(crate) name: &'static str,
     pub(crate) description: &'static str,
+    pub(crate) provider: ProviderKind,
 }
 
 const TERMINAL_AUTH_METHODS: &[TerminalAuthMethodSpec] = &[
@@ -102,16 +103,19 @@ const TERMINAL_AUTH_METHODS: &[TerminalAuthMethodSpec] = &[
         method_id: "openai",
         name: "Sign in with ChatGPT",
         description: "Authenticate Kit with a ChatGPT subscription",
+        provider: ProviderKind::OpenAiSubscription,
     },
     TerminalAuthMethodSpec {
         method_id: "openrouter",
         name: "Sign in with OpenRouter",
         description: "Authenticate Kit with OpenRouter",
+        provider: ProviderKind::OpenRouter,
     },
     TerminalAuthMethodSpec {
         method_id: "speakeasy",
         name: "Sign in with Speakeasy",
         description: "Authenticate Kit with Speakeasy",
+        provider: ProviderKind::Speakeasy,
     },
 ];
 
@@ -121,7 +125,7 @@ pub(crate) fn terminal_auth_method_specs() -> &'static [TerminalAuthMethodSpec] 
 
 fn terminal_auth_methods(
     capabilities: &agentkit_acp::ClientCapabilities,
-    persistent_credentials: bool,
+    provider_available: impl Fn(ProviderKind) -> bool,
 ) -> Vec<AuthMethod> {
     let supports_terminal_auth = capabilities.auth.terminal
         || capabilities
@@ -130,12 +134,13 @@ fn terminal_auth_methods(
             .and_then(|meta| meta.get("terminal-auth"))
             .and_then(serde_json::Value::as_bool)
             .unwrap_or(false);
-    if !supports_terminal_auth || !persistent_credentials {
+    if !supports_terminal_auth {
         return Vec::new();
     }
 
     terminal_auth_method_specs()
         .iter()
+        .filter(|method| provider_available(method.provider))
         .map(|method| {
             AuthMethod::Terminal(
                 AuthMethodTerminal::new(method.method_id, method.name)
@@ -931,12 +936,12 @@ impl Server {
     }
 
     async fn initialize(&self, request: InitializeRequest) -> InitializeResponse {
-        let terminal_authentication = self.runtime.supports_terminal_authentication();
+        let logout_authentication = self.runtime.supports_logout_authentication();
         InitializeResponse::new(agent_client_protocol::schema::ProtocolVersion::V1)
-            .agent_capabilities(capabilities(terminal_authentication))
+            .agent_capabilities(capabilities(logout_authentication))
             .auth_methods(terminal_auth_methods(
                 &request.client_capabilities,
-                terminal_authentication,
+                |provider| self.runtime.supports_terminal_authentication(provider),
             ))
             .agent_info(agentkit_acp::Implementation::new(
                 self.integration.name().to_string(),
@@ -2296,7 +2301,7 @@ fn parse_session_list_cursor(cursor: &str) -> Result<usize, ListSessionsError> {
         .ok_or(ListSessionsError::InvalidCursor)
 }
 
-fn capabilities(terminal_authentication: bool) -> agentkit_acp::AgentCapabilities {
+fn capabilities(logout_authentication: bool) -> agentkit_acp::AgentCapabilities {
     let capabilities = agentkit_acp::AgentCapabilities::new()
         .load_session(true)
         .prompt_capabilities(
@@ -2312,7 +2317,7 @@ fn capabilities(terminal_authentication: bool) -> agentkit_acp::AgentCapabilitie
                 .additional_directories(SessionAdditionalDirectoriesCapabilities::new())
                 .close(SessionCloseCapabilities::new()),
         );
-    if terminal_authentication {
+    if logout_authentication {
         capabilities.auth(AgentAuthCapabilities::new().logout(LogoutCapabilities::new()))
     } else {
         capabilities
@@ -2389,12 +2394,14 @@ pub(super) mod tests {
 
     #[test]
     fn terminal_auth_methods_require_client_support() {
-        assert!(terminal_auth_methods(&agentkit_acp::ClientCapabilities::new(), true).is_empty());
+        assert!(
+            terminal_auth_methods(&agentkit_acp::ClientCapabilities::new(), |_| true).is_empty()
+        );
 
         let capabilities = agentkit_acp::ClientCapabilities::new()
             .auth(agentkit_acp::AuthCapabilities::new().terminal(true));
-        assert!(terminal_auth_methods(&capabilities, false).is_empty());
-        let methods = terminal_auth_methods(&capabilities, true);
+        assert!(terminal_auth_methods(&capabilities, |_| false).is_empty());
+        let methods = terminal_auth_methods(&capabilities, |_| true);
         assert_eq!(methods.len(), 3);
         assert!(matches!(
             &methods[0],
@@ -2414,19 +2421,30 @@ pub(super) mod tests {
                 if method.id.0.as_ref() == "speakeasy"
                     && method.args == ["--terminal-auth-login", "speakeasy"]
         ));
+
+        let methods = terminal_auth_methods(&capabilities, |provider| {
+            provider != ProviderKind::OpenRouter
+        });
+        let method_ids = methods
+            .iter()
+            .map(|method| match method {
+                AuthMethod::Terminal(method) => method.id.0.as_ref(),
+                _ => unreachable!("only terminal methods are advertised"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(method_ids, ["openai", "speakeasy"]);
     }
 
     #[test]
-    fn v1_logout_capability_tracks_terminal_authentication_methods() {
+    fn v1_logout_capability_is_independent_from_terminal_authentication_methods() {
         let client = agentkit_acp::ClientCapabilities::new()
             .auth(agentkit_acp::AuthCapabilities::new().terminal(true));
 
-        for enabled in [false, true] {
-            assert_eq!(
-                capabilities(enabled).auth.logout.is_some(),
-                !terminal_auth_methods(&client, enabled).is_empty()
-            );
-        }
+        assert!(capabilities(false).auth.logout.is_none());
+        assert!(
+            !terminal_auth_methods(&client, |provider| { provider != ProviderKind::OpenRouter })
+                .is_empty()
+        );
     }
 
     #[test]
@@ -2577,7 +2595,7 @@ pub(super) mod tests {
         meta.insert("terminal-auth".into(), serde_json::Value::Bool(true));
         let capabilities = agentkit_acp::ClientCapabilities::new().meta(meta);
 
-        assert_eq!(terminal_auth_methods(&capabilities, true).len(), 3);
+        assert_eq!(terminal_auth_methods(&capabilities, |_| true).len(), 3);
     }
 
     struct CompletionOnDrop(watch::Sender<bool>);

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -3540,21 +3540,26 @@ mod tests {
     }
 
     #[test]
-    fn explicit_credentials_disable_terminal_authentication_and_logout() {
-        let root = tempfile::tempdir().unwrap();
-        let credentials = tempfile::tempdir().unwrap();
-        let runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(
-            root.path(),
-            "openrouter:test",
-            crate::ProviderKind::OpenRouter,
-            crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf()),
-            None,
-            Some(crate::provider::OpenRouterApiKey::new("explicit")),
-        )
-        .unwrap();
+    fn explicit_openrouter_credentials_disable_agent_wide_authentication_and_logout() {
+        for (model, provider) in [
+            ("openrouter:test", crate::ProviderKind::OpenRouter),
+            ("gpt-5.4", crate::ProviderKind::OpenAiSubscription),
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            let credentials = tempfile::tempdir().unwrap();
+            let runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(
+                root.path(),
+                model,
+                provider,
+                crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf()),
+                None,
+                Some(crate::provider::OpenRouterApiKey::new("explicit")),
+            )
+            .unwrap();
 
-        assert!(!runtime.supports_terminal_authentication());
-        assert!(runtime.logout_authentication().is_err());
+            assert!(!runtime.supports_terminal_authentication());
+            assert!(runtime.logout_authentication().is_err());
+        }
     }
 
     #[test]

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -28,13 +28,14 @@ use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::{
-    provider::{SelectableAdapter, model_catalog},
+    provider::{SelectableAdapter, authentication_method_id, model_catalog},
     runtime::{AcpDriverContext, BackgroundJobs, Runtime},
 };
 
 use super::{
-    CancelBackgroundRequest, CancelBackgroundResponse, DetachComposeRequest, DetachComposeResponse,
-    FileSearchRequest, FileSearchResponse, SessionRegistry, skill_catalog,
+    AuthenticationRequiredData, CancelBackgroundRequest, CancelBackgroundResponse,
+    DetachComposeRequest, DetachComposeResponse, FileSearchRequest, FileSearchResponse,
+    SessionRegistry, skill_catalog, terminal_auth_method_specs,
 };
 
 const PAGE_SIZE: usize = 100;
@@ -64,7 +65,40 @@ fn complete_new_session<E>(
 }
 
 fn sdk_error(error: AcpRuntimeError) -> agent_client_protocol::Error {
-    agent_client_protocol::util::internal_error(error.to_string())
+    let detail = error.to_string();
+    match authentication_method_id(&detail) {
+        Some(method_id) => agent_client_protocol::Error::internal_error()
+            .data(AuthenticationRequiredData::new(method_id, &detail).into_value()),
+        None => agent_client_protocol::util::internal_error(detail),
+    }
+}
+
+fn terminal_auth_methods(capabilities: &wire::ClientCapabilities) -> Vec<wire::AuthMethod> {
+    let supports_terminal_auth = capabilities
+        .auth
+        .as_ref()
+        .and_then(|auth| auth.terminal.as_ref())
+        .is_some()
+        || capabilities
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.get("terminal-auth"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+    if !supports_terminal_auth {
+        return Vec::new();
+    }
+
+    terminal_auth_method_specs()
+        .iter()
+        .map(|method| {
+            wire::AuthMethod::Terminal(
+                wire::AuthMethodTerminal::new(method.method_id, method.name)
+                    .description(method.description)
+                    .args(method.args.iter().map(|arg| (*arg).into()).collect()),
+            )
+        })
+        .collect()
 }
 
 #[derive(Debug)]
@@ -513,7 +547,8 @@ impl Server {
             wire::ProtocolVersion::V2,
             wire::Implementation::new("kit", env!("CARGO_PKG_VERSION")),
         )
-        .capabilities(agentkit_acp::v2::agent_capabilities()))
+        .capabilities(agentkit_acp::v2::agent_capabilities())
+        .auth_methods(terminal_auth_methods(&request.capabilities)))
     }
 
     async fn new_session(
@@ -3222,7 +3257,22 @@ mod tests {
     }
 
     #[test]
-    fn initialize_negotiates_v2_and_advertises_injection() {
+    fn sdk_error_marks_only_missing_credentials_as_authentication_required() {
+        let missing_detail = "openrouter_auth_required: set OPENROUTER_API_KEY or run `kit auth login openrouter` before using the OpenRouter provider";
+        let missing = sdk_error(AcpRuntimeError::Loop(missing_detail.into()));
+        let data = missing.data.unwrap();
+        let required = AuthenticationRequiredData::from_value(&data).unwrap();
+        assert_eq!(required.method_id, "openrouter");
+        assert_eq!(required.detail, format!("loop error: {missing_detail}"));
+
+        let unrelated = sdk_error(AcpRuntimeError::Loop(
+            "stored OpenRouter credentials cannot be used with a noncanonical endpoint".into(),
+        ));
+        assert!(matches!(unrelated.data, Some(serde_json::Value::String(_))));
+    }
+
+    #[test]
+    fn initialize_negotiates_v2_and_advertises_injection_and_authentication() {
         let root = tempfile::tempdir().unwrap();
         let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
         let server = Server::new(runtime, SessionRegistry::new());
@@ -3239,7 +3289,26 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.protocol_version, wire::ProtocolVersion::V2);
-        assert!(response.auth_methods.is_empty());
+        assert_eq!(response.auth_methods.len(), 2);
+        assert!(matches!(
+            &response.auth_methods[0],
+            wire::AuthMethod::Terminal(method)
+                if method.method_id.0.as_ref() == "openai"
+                    && method.args == ["serve", "--terminal-auth-login", "openai"]
+        ));
+        assert!(matches!(
+            &response.auth_methods[1],
+            wire::AuthMethod::Terminal(method)
+                if method.method_id.0.as_ref() == "openrouter"
+                    && method.args == ["serve", "--terminal-auth-login", "openrouter"]
+        ));
+        let unsupported = server
+            .initialize(wire::InitializeRequest::new(
+                wire::ProtocolVersion::V2,
+                wire::Implementation::new("unsupported-client", "0"),
+            ))
+            .unwrap();
+        assert!(unsupported.auth_methods.is_empty());
         let mut newer = wire::InitializeRequest::new(
             wire::ProtocolVersion::V2,
             wire::Implementation::new("newer-client", "0"),

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -67,25 +67,22 @@ fn complete_new_session<E>(
 fn sdk_error(error: AcpRuntimeError) -> agent_client_protocol::Error {
     let detail = error.to_string();
     match authentication_method_id(&detail) {
-        Some(method_id) => agent_client_protocol::Error::internal_error()
+        Some(method_id) => agent_client_protocol::Error::auth_required()
             .data(AuthenticationRequiredData::new(method_id, &detail).into_value()),
         None => agent_client_protocol::util::internal_error(detail),
     }
 }
 
-fn terminal_auth_methods(capabilities: &wire::ClientCapabilities) -> Vec<wire::AuthMethod> {
+fn terminal_auth_methods(
+    capabilities: &wire::ClientCapabilities,
+    persistent_credentials: bool,
+) -> Vec<wire::AuthMethod> {
     let supports_terminal_auth = capabilities
         .auth
         .as_ref()
         .and_then(|auth| auth.terminal.as_ref())
-        .is_some()
-        || capabilities
-            .meta
-            .as_ref()
-            .and_then(|meta| meta.get("terminal-auth"))
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-    if !supports_terminal_auth {
+        .is_some();
+    if !supports_terminal_auth || !persistent_credentials {
         return Vec::new();
     }
 
@@ -95,7 +92,10 @@ fn terminal_auth_methods(capabilities: &wire::ClientCapabilities) -> Vec<wire::A
             wire::AuthMethod::Terminal(
                 wire::AuthMethodTerminal::new(method.method_id, method.name)
                     .description(method.description)
-                    .args(method.args.iter().map(|arg| (*arg).into()).collect()),
+                    .args(vec![
+                        "--terminal-auth-login".into(),
+                        method.method_id.into(),
+                    ]),
             )
         })
         .collect()
@@ -524,6 +524,40 @@ impl Server {
         .map(|matches| FileSearchResponse { matches })
     }
 
+    fn login(
+        &self,
+        request: wire::LoginAuthRequest,
+    ) -> Result<wire::LoginAuthResponse, agent_client_protocol::Error> {
+        let method_id = request.method_id.0.as_ref();
+        let detail = if terminal_auth_method_specs()
+            .iter()
+            .any(|method| method.method_id == method_id)
+        {
+            "terminal authentication methods must be launched as a separate agent invocation"
+        } else {
+            "authentication method was not advertised by this agent"
+        };
+        Err(agent_client_protocol::Error::invalid_params()
+            .data(serde_json::json!({ "detail": detail, "methodId": method_id })))
+    }
+
+    async fn logout(self: &Arc<Self>) -> Result<wire::LogoutAuthResponse, AcpRuntimeError> {
+        let runtime = Arc::clone(&self.runtime);
+        tokio::task::spawn_blocking(move || runtime.logout_authentication())
+            .await
+            .map_err(|error| {
+                AcpRuntimeError::Loop(format!("authentication logout task failed: {error}"))
+            })?
+            .map_err(AcpRuntimeError::Loop)?;
+
+        if !self.registry.reset_authentication().await {
+            return Err(AcpRuntimeError::Loop(
+                "authentication logout could not finish session teardown".into(),
+            ));
+        }
+        Ok(wire::LogoutAuthResponse::new())
+    }
+
     fn remove_session(&self, session_id: &wire::SessionId, token: u64) {
         let mut sessions = self.sessions.lock().expect("ACP v2 session map poisoned");
         if sessions
@@ -548,7 +582,10 @@ impl Server {
             wire::Implementation::new("kit", env!("CARGO_PKG_VERSION")),
         )
         .capabilities(agentkit_acp::v2::agent_capabilities())
-        .auth_methods(terminal_auth_methods(&request.capabilities)))
+        .auth_methods(terminal_auth_methods(
+            &request.capabilities,
+            self.runtime.supports_terminal_authentication(),
+        )))
     }
 
     async fn new_session(
@@ -687,6 +724,10 @@ impl Server {
         connection: V2ConnectionTo<Client>,
         mut claim: crate::runtime::SessionClaim,
     ) -> Result<AttachedSession, AcpRuntimeError> {
+        let admission = self
+            .registry
+            .begin_attachment()
+            .map_err(|()| AcpRuntimeError::ClientClosed)?;
         let session_id = wire::SessionId::new(claim.id());
         let cancellation = CancellationController::new();
         let sink = ResponseReplacementSink::new(ConnectionSink(connection));
@@ -784,18 +825,28 @@ impl Server {
                 }
             }) as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
         });
-        self.registry
+        if self
+            .registry
             .register_v2(
+                admission,
                 token,
                 interrupt,
                 close,
                 actor_task.abort_handle(),
                 completion,
             )
-            .map_err(|()| AcpRuntimeError::ClientClosed)?;
-        drop(actor_task);
+            .is_err()
+        {
+            drop(activation);
+            actor_task.abort();
+            let _ = actor_task.await;
+            return Err(AcpRuntimeError::ClientClosed);
+        }
         if let Err(error) = claim.commit() {
             self.registry.remove(token);
+            drop(activation);
+            actor_task.abort();
+            let _ = actor_task.await;
             return Err(error);
         }
         crate::events::emit(&crate::events::RuntimeEvent::SessionStarted {
@@ -816,6 +867,7 @@ impl Server {
                     tasks,
                 },
             );
+        drop(actor_task);
         Ok(AttachedSession {
             session_id,
             config_options,
@@ -1821,6 +1873,28 @@ pub(crate) fn component(
                 let state = Arc::clone(&state);
                 async move |request: wire::InitializeRequest, responder, _cx| {
                     responder.respond_with_result(state.initialize(request).map_err(sdk_error))
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let state = Arc::clone(&state);
+                async move |request: wire::LoginAuthRequest, responder, _cx| {
+                    responder.respond_with_result(state.login(request))
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let state = Arc::clone(&state);
+                async move |_request: wire::LogoutAuthRequest, responder, cx| {
+                    let state = Arc::clone(&state);
+                    cx.spawn(async move {
+                        responder.respond_with_result(state.logout().await.map_err(sdk_error))
+                    })?;
+                    Ok(())
                 }
             },
             agent_client_protocol::on_receive_request!(),
@@ -3260,10 +3334,25 @@ mod tests {
     fn sdk_error_marks_only_missing_credentials_as_authentication_required() {
         let missing_detail = "openrouter_auth_required: set OPENROUTER_API_KEY or run `kit auth login openrouter` before using the OpenRouter provider";
         let missing = sdk_error(AcpRuntimeError::Loop(missing_detail.into()));
+        assert_eq!(missing.code, agent_client_protocol::ErrorCode::AuthRequired);
         let data = missing.data.unwrap();
         let required = AuthenticationRequiredData::from_value(&data).unwrap();
         assert_eq!(required.method_id, "openrouter");
         assert_eq!(required.detail, format!("loop error: {missing_detail}"));
+
+        let speakeasy = sdk_error(AcpRuntimeError::Loop(
+            "speakeasy_auth_required: run `kit auth login speakeasy`".into(),
+        ));
+        assert_eq!(
+            speakeasy.code,
+            agent_client_protocol::ErrorCode::AuthRequired
+        );
+        assert_eq!(
+            AuthenticationRequiredData::from_value(speakeasy.data.as_ref().unwrap())
+                .unwrap()
+                .method_id,
+            "speakeasy"
+        );
 
         let unrelated = sdk_error(AcpRuntimeError::Loop(
             "stored OpenRouter credentials cannot be used with a noncanonical endpoint".into(),
@@ -3272,9 +3361,96 @@ mod tests {
     }
 
     #[test]
+    fn terminal_auth_login_route_rejects_in_process_login() {
+        let root = tempfile::tempdir().unwrap();
+        let server = Server::new(
+            Runtime::new(root.path(), "gpt-5.4").unwrap(),
+            SessionRegistry::new(),
+        );
+
+        for (method_id, expected_detail) in [
+            (
+                "openai",
+                "terminal authentication methods must be launched as a separate agent invocation",
+            ),
+            (
+                "unknown",
+                "authentication method was not advertised by this agent",
+            ),
+        ] {
+            let error = server
+                .login(wire::LoginAuthRequest::new(method_id))
+                .unwrap_err();
+            let data = error.data.unwrap();
+
+            assert_eq!(error.code, agent_client_protocol::ErrorCode::InvalidParams);
+            assert_eq!(data["methodId"], method_id);
+            assert_eq!(data["detail"], expected_detail);
+        }
+    }
+
+    #[tokio::test]
+    async fn auth_logout_clears_persistent_provider_credentials() {
+        let root = tempfile::tempdir().unwrap();
+        let credentials = tempfile::tempdir().unwrap();
+        let storage =
+            crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf());
+        crate::provider::store_openrouter_test_credentials(&storage);
+        let mut runtime = Runtime::new_with_provider_and_credentials(
+            root.path(),
+            "openrouter:test",
+            crate::ProviderKind::OpenRouter,
+            storage.clone(),
+        )
+        .unwrap();
+        Arc::get_mut(&mut runtime)
+            .unwrap()
+            .set_ambient_openrouter_api_key_for_test(false);
+        let server = Arc::new(Server::new(runtime, SessionRegistry::new()));
+
+        server.logout().await.unwrap();
+
+        assert!(
+            storage
+                .entry("openrouter", "default")
+                .load()
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn explicit_credentials_disable_terminal_authentication_and_logout() {
+        let root = tempfile::tempdir().unwrap();
+        let credentials = tempfile::tempdir().unwrap();
+        let runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(
+            root.path(),
+            "openrouter:test",
+            crate::ProviderKind::OpenRouter,
+            crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf()),
+            None,
+            Some(crate::provider::OpenRouterApiKey::new("explicit")),
+        )
+        .unwrap();
+
+        assert!(!runtime.supports_terminal_authentication());
+        assert!(runtime.logout_authentication().is_err());
+    }
+
+    #[test]
     fn initialize_negotiates_v2_and_advertises_injection_and_authentication() {
         let root = tempfile::tempdir().unwrap();
-        let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
+        let credentials = tempfile::tempdir().unwrap();
+        let mut runtime = Runtime::new_with_provider_and_credentials(
+            root.path(),
+            "gpt-5.4",
+            crate::ProviderKind::OpenAiSubscription,
+            crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf()),
+        )
+        .unwrap();
+        Arc::get_mut(&mut runtime)
+            .unwrap()
+            .set_ambient_openrouter_api_key_for_test(false);
         let server = Server::new(runtime, SessionRegistry::new());
         let response = server
             .initialize(
@@ -3289,18 +3465,24 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.protocol_version, wire::ProtocolVersion::V2);
-        assert_eq!(response.auth_methods.len(), 2);
+        assert_eq!(response.auth_methods.len(), 3);
         assert!(matches!(
             &response.auth_methods[0],
             wire::AuthMethod::Terminal(method)
                 if method.method_id.0.as_ref() == "openai"
-                    && method.args == ["serve", "--terminal-auth-login", "openai"]
+                    && method.args == ["--terminal-auth-login", "openai"]
         ));
         assert!(matches!(
             &response.auth_methods[1],
             wire::AuthMethod::Terminal(method)
                 if method.method_id.0.as_ref() == "openrouter"
-                    && method.args == ["serve", "--terminal-auth-login", "openrouter"]
+                    && method.args == ["--terminal-auth-login", "openrouter"]
+        ));
+        assert!(matches!(
+            &response.auth_methods[2],
+            wire::AuthMethod::Terminal(method)
+                if method.method_id.0.as_ref() == "speakeasy"
+                    && method.args == ["--terminal-auth-login", "speakeasy"]
         ));
         let unsupported = server
             .initialize(wire::InitializeRequest::new(
@@ -3309,6 +3491,14 @@ mod tests {
             ))
             .unwrap();
         assert!(unsupported.auth_methods.is_empty());
+        let terminal_capabilities = wire::ClientCapabilities::new()
+            .auth(wire::AuthCapabilities::new().terminal(wire::TerminalAuthCapabilities::new()));
+        assert!(terminal_auth_methods(&terminal_capabilities, false).is_empty());
+        let metadata_only = wire::ClientCapabilities::new().meta(serde_json::Map::from_iter([(
+            "terminal-auth".into(),
+            serde_json::Value::Bool(true),
+        )]));
+        assert!(terminal_auth_methods(&metadata_only, true).is_empty());
         let mut newer = wire::InitializeRequest::new(
             wire::ProtocolVersion::V2,
             wire::Implementation::new("newer-client", "0"),

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -494,6 +494,22 @@ impl Drop for ActorGuard {
     }
 }
 
+#[derive(Debug)]
+enum SessionPublicationError {
+    AdmissionClosed,
+    Commit(AcpRuntimeError),
+}
+
+struct PendingSessionPublication {
+    token: u64,
+    interrupt: Arc<dyn Fn() + Send + Sync>,
+    close: super::CloseV2Session,
+    actor: tokio::task::AbortHandle,
+    completed: watch::Receiver<bool>,
+    session_id: wire::SessionId,
+    session: SessionHandle,
+}
+
 struct Server {
     runtime: Arc<Runtime>,
     integration: Arc<AcpIntegration>,
@@ -542,20 +558,33 @@ impl Server {
     }
 
     async fn logout(self: &Arc<Self>) -> Result<wire::LogoutAuthResponse, AcpRuntimeError> {
-        let runtime = Arc::clone(&self.runtime);
-        tokio::task::spawn_blocking(move || runtime.logout_authentication())
-            .await
-            .map_err(|error| {
-                AcpRuntimeError::Loop(format!("authentication logout task failed: {error}"))
-            })?
-            .map_err(AcpRuntimeError::Loop)?;
-
-        if !self.registry.reset_authentication().await {
-            return Err(AcpRuntimeError::Loop(
-                "authentication logout could not finish session teardown".into(),
-            ));
-        }
+        super::logout_authentication(Arc::clone(&self.runtime), &self.registry).await?;
         Ok(wire::LogoutAuthResponse::new())
+    }
+
+    fn publish_session(
+        &self,
+        admission: u64,
+        publication: PendingSessionPublication,
+        commit: impl FnOnce() -> Result<(), AcpRuntimeError>,
+    ) -> Result<(), SessionPublicationError> {
+        let mut sessions = self.sessions.lock().expect("ACP v2 session map poisoned");
+        self.registry
+            .register_v2(
+                admission,
+                publication.token,
+                publication.interrupt,
+                publication.close,
+                publication.actor,
+                publication.completed,
+            )
+            .map_err(|()| SessionPublicationError::AdmissionClosed)?;
+        if let Err(error) = commit() {
+            self.registry.remove(publication.token);
+            return Err(SessionPublicationError::Commit(error));
+        }
+        sessions.insert(publication.session_id, publication.session);
+        Ok(())
     }
 
     fn remove_session(&self, session_id: &wire::SessionId, token: u64) {
@@ -825,39 +854,18 @@ impl Server {
                 }
             }) as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
         });
-        if self
-            .registry
-            .register_v2(
-                admission,
+        // Registration, durable identity commit, and local publication are one
+        // critical section so logout cannot reopen admission around a dead actor.
+        let publication = self.publish_session(
+            admission,
+            PendingSessionPublication {
                 token,
                 interrupt,
                 close,
-                actor_task.abort_handle(),
-                completion,
-            )
-            .is_err()
-        {
-            drop(activation);
-            actor_task.abort();
-            let _ = actor_task.await;
-            return Err(AcpRuntimeError::ClientClosed);
-        }
-        if let Err(error) = claim.commit() {
-            self.registry.remove(token);
-            drop(activation);
-            actor_task.abort();
-            let _ = actor_task.await;
-            return Err(error);
-        }
-        crate::events::emit(&crate::events::RuntimeEvent::SessionStarted {
-            session_id: session_id.to_string(),
-        });
-        self.sessions
-            .lock()
-            .expect("ACP v2 session map poisoned")
-            .insert(
-                session_id.clone(),
-                SessionHandle {
+                actor: actor_task.abort_handle(),
+                completed: completion,
+                session_id: session_id.clone(),
+                session: SessionHandle {
                     token,
                     commands: tx,
                     integration: handle,
@@ -866,7 +874,21 @@ impl Server {
                     structured_completion,
                     tasks,
                 },
-            );
+            },
+            || claim.commit(),
+        );
+        if let Err(error) = publication {
+            drop(activation);
+            actor_task.abort();
+            let _ = actor_task.await;
+            return Err(match error {
+                SessionPublicationError::AdmissionClosed => AcpRuntimeError::ClientClosed,
+                SessionPublicationError::Commit(error) => error,
+            });
+        }
+        crate::events::emit(&crate::events::RuntimeEvent::SessionStarted {
+            session_id: session_id.to_string(),
+        });
         drop(actor_task);
         Ok(AttachedSession {
             session_id,
@@ -2092,7 +2114,10 @@ pub(crate) fn component(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::VecDeque, sync::atomic::AtomicUsize};
+    use std::{
+        collections::VecDeque,
+        sync::{atomic::AtomicUsize, mpsc as std_mpsc},
+    };
 
     use serde_json::json;
 
@@ -3387,6 +3412,101 @@ mod tests {
             assert_eq!(data["methodId"], method_id);
             assert_eq!(data["detail"], expected_detail);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn logout_reset_waits_for_registered_session_publication() {
+        let root = tempfile::tempdir().unwrap();
+        let registry = SessionRegistry::new();
+        let server = Arc::new(Server::new(
+            Runtime::new(root.path(), "gpt-5.4").unwrap(),
+            registry.clone(),
+        ));
+        let session_id = wire::SessionId::new("publishing-session");
+        let integration = server
+            .integration
+            .bind_session(AcpSessionBinding::new(
+                session_id.clone(),
+                SessionId::new("publishing-session"),
+                RecordingSink::default(),
+            ))
+            .unwrap();
+        let token = registry.next_token();
+        let (completed, completion) = watch::channel(false);
+        let release = Arc::new(Notify::new());
+        let actor_release = Arc::clone(&release);
+        let dropping = Arc::new(Notify::new());
+        let actor_dropping = Arc::clone(&dropping);
+        let guard = ActorGuard {
+            server: Arc::downgrade(&server),
+            registry: registry.clone(),
+            session_id: session_id.clone(),
+            token,
+            completed,
+        };
+        let actor_task = tokio::spawn(async move {
+            let _guard = guard;
+            actor_release.notified().await;
+            actor_dropping.notify_one();
+        });
+        let close_release = Arc::clone(&release);
+        let close = Arc::new(move || {
+            let close_release = Arc::clone(&close_release);
+            Box::pin(async move { close_release.notify_one() })
+                as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+        });
+        let admission = registry.begin_attachment().unwrap();
+        let actor_abort = actor_task.abort_handle();
+        let (commands, _received) = mpsc::channel(1);
+        let (registered, registered_rx) = std_mpsc::channel();
+        let (continue_publication, continue_publication_rx) = std_mpsc::channel();
+        let publisher_server = Arc::clone(&server);
+        let published_session_id = session_id.clone();
+        let publisher = tokio::task::spawn_blocking(move || {
+            publisher_server.publish_session(
+                admission,
+                PendingSessionPublication {
+                    token,
+                    interrupt: Arc::new(|| {}),
+                    close,
+                    actor: actor_abort,
+                    completed: completion,
+                    session_id: published_session_id,
+                    session: SessionHandle {
+                        token,
+                        commands,
+                        integration,
+                        busy: Arc::new(AtomicBool::new(false)),
+                        background_jobs: BackgroundJobs::default(),
+                        structured_completion: false,
+                        tasks: AsyncTaskManager::new().handle(),
+                    },
+                },
+                || {
+                    registered.send(()).unwrap();
+                    continue_publication_rx.recv().unwrap();
+                    Ok(())
+                },
+            )
+        });
+        tokio::task::spawn_blocking(move || registered_rx.recv().unwrap())
+            .await
+            .unwrap();
+
+        let reset_registry = registry.clone();
+        let mut reset = tokio::spawn(async move { reset_registry.reset_authentication().await });
+        dropping.notified().await;
+        assert!(
+            timeout(Duration::from_millis(20), &mut reset)
+                .await
+                .is_err()
+        );
+        continue_publication.send(()).unwrap();
+
+        publisher.await.unwrap().unwrap();
+        assert!(reset.await.unwrap());
+        actor_task.await.unwrap();
+        assert!(!server.sessions.lock().unwrap().contains_key(&session_id));
     }
 
     #[tokio::test]

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -565,7 +565,7 @@ impl Server {
 
     fn publish_session(
         &self,
-        admission: u64,
+        admission: &mut super::SessionAdmission,
         publication: PendingSessionPublication,
         commit: impl FnOnce() -> Result<(), AcpRuntimeError>,
     ) -> Result<(), SessionPublicationError> {
@@ -612,18 +612,13 @@ impl Server {
             wire::Implementation::new("kit", env!("CARGO_PKG_VERSION")),
         )
         .capabilities(agentkit_acp::v2::agent_capabilities())
-        .auth_methods(
-            if self
-                .runtime
-                .supports_selected_provider_authentication_management()
-            {
-                terminal_auth_methods(&request.capabilities, |provider| {
-                    self.runtime.supports_terminal_authentication(provider)
-                })
-            } else {
-                Vec::new()
-            },
-        ))
+        .auth_methods(if self.runtime.supports_logout_authentication() {
+            terminal_auth_methods(&request.capabilities, |provider| {
+                self.runtime.supports_terminal_authentication(provider)
+            })
+        } else {
+            Vec::new()
+        }))
     }
 
     async fn new_session(
@@ -762,7 +757,7 @@ impl Server {
         connection: V2ConnectionTo<Client>,
         mut claim: crate::runtime::SessionClaim,
     ) -> Result<AttachedSession, AcpRuntimeError> {
-        let admission = self
+        let mut admission = self
             .registry
             .begin_attachment()
             .map_err(|()| AcpRuntimeError::ClientClosed)?;
@@ -866,7 +861,7 @@ impl Server {
         // Registration, durable identity commit, and local publication are one
         // critical section so logout cannot reopen admission around a dead actor.
         let publication = self.publish_session(
-            admission,
+            &mut admission,
             PendingSessionPublication {
                 token,
                 interrupt,
@@ -3486,7 +3481,7 @@ mod tests {
             Box::pin(async move { close_release.notify_one() })
                 as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
         });
-        let admission = registry.begin_attachment().unwrap();
+        let mut admission = registry.begin_attachment().unwrap();
         let actor_abort = actor_task.abort_handle();
         let (commands, _received) = mpsc::channel(1);
         let (registered, registered_rx) = std_mpsc::channel();
@@ -3495,7 +3490,7 @@ mod tests {
         let published_session_id = session_id.clone();
         let publisher = tokio::task::spawn_blocking(move || {
             publisher_server.publish_session(
-                admission,
+                &mut admission,
                 PendingSessionPublication {
                     token,
                     interrupt: Arc::new(|| {}),
@@ -3571,20 +3566,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mixed_openrouter_credentials_keep_v2_auth_consistent_with_selected_provider() {
+    async fn unmanaged_openrouter_credentials_disable_v2_authentication() {
         for (explicit_key, ambient_key) in [(true, false), (false, true)] {
-            for (model, provider, expected_methods) in [
-                ("openrouter:test", crate::ProviderKind::OpenRouter, &[][..]),
-                (
-                    "gpt-5.4",
-                    crate::ProviderKind::OpenAiSubscription,
-                    &["openai", "speakeasy"][..],
-                ),
-                (
-                    "test-model",
-                    crate::ProviderKind::Speakeasy,
-                    &["openai", "speakeasy"][..],
-                ),
+            for (model, provider) in [
+                ("openrouter:test", crate::ProviderKind::OpenRouter),
+                ("gpt-5.4", crate::ProviderKind::OpenAiSubscription),
+                ("test-model", crate::ProviderKind::Speakeasy),
             ] {
                 let root = tempfile::tempdir().unwrap();
                 let credentials = tempfile::tempdir().unwrap();
@@ -3609,9 +3596,8 @@ mod tests {
                     .initialize(terminal_auth_initialize_request())
                     .unwrap();
                 let method_ids = terminal_auth_method_ids(&response.auth_methods);
-                assert_eq!(method_ids, expected_methods);
-
-                assert_eq!(server.logout().await.is_ok(), !method_ids.is_empty());
+                assert!(method_ids.is_empty());
+                assert!(server.logout().await.is_err());
             }
         }
     }

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -28,7 +28,7 @@ use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::{
-    provider::{SelectableAdapter, authentication_method_id, model_catalog},
+    provider::{ProviderKind, SelectableAdapter, authentication_method_id, model_catalog},
     runtime::{AcpDriverContext, BackgroundJobs, Runtime},
 };
 
@@ -75,19 +75,20 @@ fn sdk_error(error: AcpRuntimeError) -> agent_client_protocol::Error {
 
 fn terminal_auth_methods(
     capabilities: &wire::ClientCapabilities,
-    persistent_credentials: bool,
+    provider_available: impl Fn(ProviderKind) -> bool,
 ) -> Vec<wire::AuthMethod> {
     let supports_terminal_auth = capabilities
         .auth
         .as_ref()
         .and_then(|auth| auth.terminal.as_ref())
         .is_some();
-    if !supports_terminal_auth || !persistent_credentials {
+    if !supports_terminal_auth {
         return Vec::new();
     }
 
     terminal_auth_method_specs()
         .iter()
+        .filter(|method| provider_available(method.provider))
         .map(|method| {
             wire::AuthMethod::Terminal(
                 wire::AuthMethodTerminal::new(method.method_id, method.name)
@@ -611,10 +612,9 @@ impl Server {
             wire::Implementation::new("kit", env!("CARGO_PKG_VERSION")),
         )
         .capabilities(agentkit_acp::v2::agent_capabilities())
-        .auth_methods(terminal_auth_methods(
-            &request.capabilities,
-            self.runtime.supports_terminal_authentication(),
-        )))
+        .auth_methods(terminal_auth_methods(&request.capabilities, |provider| {
+            self.runtime.supports_terminal_authentication(provider)
+        })))
     }
 
     async fn new_session(
@@ -3540,7 +3540,7 @@ mod tests {
     }
 
     #[test]
-    fn explicit_openrouter_credentials_disable_agent_wide_authentication_and_logout() {
+    fn explicit_openrouter_credentials_keep_unrelated_authentication_methods() {
         for (model, provider) in [
             ("openrouter:test", crate::ProviderKind::OpenRouter),
             ("gpt-5.4", crate::ProviderKind::OpenAiSubscription),
@@ -3557,8 +3557,38 @@ mod tests {
             )
             .unwrap();
 
-            assert!(!runtime.supports_terminal_authentication());
+            assert!(
+                runtime.supports_terminal_authentication(crate::ProviderKind::OpenAiSubscription)
+            );
+            assert!(!runtime.supports_terminal_authentication(crate::ProviderKind::OpenRouter));
+            assert!(runtime.supports_terminal_authentication(crate::ProviderKind::Speakeasy));
+            assert!(!runtime.supports_logout_authentication());
             assert!(runtime.logout_authentication().is_err());
+
+            let server = Server::new(runtime, SessionRegistry::new());
+            let response = server
+                .initialize(
+                    wire::InitializeRequest::new(
+                        wire::ProtocolVersion::V2,
+                        wire::Implementation::new("test-client", "0"),
+                    )
+                    .capabilities(
+                        wire::ClientCapabilities::new().auth(
+                            wire::AuthCapabilities::new()
+                                .terminal(wire::TerminalAuthCapabilities::new()),
+                        ),
+                    ),
+                )
+                .unwrap();
+            let method_ids = response
+                .auth_methods
+                .iter()
+                .map(|method| match method {
+                    wire::AuthMethod::Terminal(method) => method.method_id.0.as_ref(),
+                    _ => unreachable!("only terminal methods are advertised"),
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(method_ids, ["openai", "speakeasy"]);
         }
     }
 
@@ -3618,12 +3648,24 @@ mod tests {
         assert!(unsupported.auth_methods.is_empty());
         let terminal_capabilities = wire::ClientCapabilities::new()
             .auth(wire::AuthCapabilities::new().terminal(wire::TerminalAuthCapabilities::new()));
-        assert!(terminal_auth_methods(&terminal_capabilities, false).is_empty());
+        assert!(terminal_auth_methods(&terminal_capabilities, |_| false).is_empty());
+        let methods = terminal_auth_methods(&terminal_capabilities, |provider| {
+            provider != ProviderKind::OpenRouter
+        });
+        let method_ids = methods
+            .iter()
+            .map(|method| match method {
+                wire::AuthMethod::Terminal(method) => method.method_id.0.as_ref(),
+                _ => unreachable!("only terminal methods are advertised"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(method_ids, ["openai", "speakeasy"]);
+
         let metadata_only = wire::ClientCapabilities::new().meta(serde_json::Map::from_iter([(
             "terminal-auth".into(),
             serde_json::Value::Bool(true),
         )]));
-        assert!(terminal_auth_methods(&metadata_only, true).is_empty());
+        assert!(terminal_auth_methods(&metadata_only, |_| true).is_empty());
         let mut newer = wire::InitializeRequest::new(
             wire::ProtocolVersion::V2,
             wire::Implementation::new("newer-client", "0"),

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -612,9 +612,18 @@ impl Server {
             wire::Implementation::new("kit", env!("CARGO_PKG_VERSION")),
         )
         .capabilities(agentkit_acp::v2::agent_capabilities())
-        .auth_methods(terminal_auth_methods(&request.capabilities, |provider| {
-            self.runtime.supports_terminal_authentication(provider)
-        })))
+        .auth_methods(
+            if self
+                .runtime
+                .supports_selected_provider_authentication_management()
+            {
+                terminal_auth_methods(&request.capabilities, |provider| {
+                    self.runtime.supports_terminal_authentication(provider)
+                })
+            } else {
+                Vec::new()
+            },
+        ))
     }
 
     async fn new_session(
@@ -2137,6 +2146,28 @@ mod tests {
     use super::*;
     use crate::protocols::acp::tests::{BlockingTool, ScriptAdapter};
 
+    fn terminal_auth_initialize_request() -> wire::InitializeRequest {
+        wire::InitializeRequest::new(
+            wire::ProtocolVersion::V2,
+            wire::Implementation::new("test-client", "0"),
+        )
+        .capabilities(
+            wire::ClientCapabilities::new().auth(
+                wire::AuthCapabilities::new().terminal(wire::TerminalAuthCapabilities::new()),
+            ),
+        )
+    }
+
+    fn terminal_auth_method_ids(methods: &[wire::AuthMethod]) -> Vec<&str> {
+        methods
+            .iter()
+            .map(|method| match method {
+                wire::AuthMethod::Terminal(method) => method.method_id.0.as_ref(),
+                _ => unreachable!("only terminal methods are advertised"),
+            })
+            .collect()
+    }
+
     #[derive(Clone, Default)]
     struct RecordingSink {
         updates: Arc<Mutex<Vec<wire::UpdateSessionNotification>>>,
@@ -3539,56 +3570,49 @@ mod tests {
         );
     }
 
-    #[test]
-    fn explicit_openrouter_credentials_keep_unrelated_authentication_methods() {
-        for (model, provider) in [
-            ("openrouter:test", crate::ProviderKind::OpenRouter),
-            ("gpt-5.4", crate::ProviderKind::OpenAiSubscription),
-        ] {
-            let root = tempfile::tempdir().unwrap();
-            let credentials = tempfile::tempdir().unwrap();
-            let runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(
-                root.path(),
-                model,
-                provider,
-                crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf()),
-                None,
-                Some(crate::provider::OpenRouterApiKey::new("explicit")),
-            )
-            .unwrap();
-
-            assert!(
-                runtime.supports_terminal_authentication(crate::ProviderKind::OpenAiSubscription)
-            );
-            assert!(!runtime.supports_terminal_authentication(crate::ProviderKind::OpenRouter));
-            assert!(runtime.supports_terminal_authentication(crate::ProviderKind::Speakeasy));
-            assert!(!runtime.supports_logout_authentication());
-            assert!(runtime.logout_authentication().is_err());
-
-            let server = Server::new(runtime, SessionRegistry::new());
-            let response = server
-                .initialize(
-                    wire::InitializeRequest::new(
-                        wire::ProtocolVersion::V2,
-                        wire::Implementation::new("test-client", "0"),
-                    )
-                    .capabilities(
-                        wire::ClientCapabilities::new().auth(
-                            wire::AuthCapabilities::new()
-                                .terminal(wire::TerminalAuthCapabilities::new()),
-                        ),
+    #[tokio::test]
+    async fn mixed_openrouter_credentials_keep_v2_auth_consistent_with_selected_provider() {
+        for (explicit_key, ambient_key) in [(true, false), (false, true)] {
+            for (model, provider, expected_methods) in [
+                ("openrouter:test", crate::ProviderKind::OpenRouter, &[][..]),
+                (
+                    "gpt-5.4",
+                    crate::ProviderKind::OpenAiSubscription,
+                    &["openai", "speakeasy"][..],
+                ),
+                (
+                    "test-model",
+                    crate::ProviderKind::Speakeasy,
+                    &["openai", "speakeasy"][..],
+                ),
+            ] {
+                let root = tempfile::tempdir().unwrap();
+                let credentials = tempfile::tempdir().unwrap();
+                let mut runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(
+                    root.path(),
+                    model,
+                    provider,
+                    crate::credentials::CredentialStorage::Filesystem(
+                        credentials.path().to_path_buf(),
                     ),
+                    None,
+                    explicit_key
+                        .then(|| crate::provider::OpenRouterApiKey::new("unrelated explicit key")),
                 )
                 .unwrap();
-            let method_ids = response
-                .auth_methods
-                .iter()
-                .map(|method| match method {
-                    wire::AuthMethod::Terminal(method) => method.method_id.0.as_ref(),
-                    _ => unreachable!("only terminal methods are advertised"),
-                })
-                .collect::<Vec<_>>();
-            assert_eq!(method_ids, ["openai", "speakeasy"]);
+                Arc::get_mut(&mut runtime)
+                    .unwrap()
+                    .set_ambient_openrouter_api_key_for_test(ambient_key);
+                let server = Arc::new(Server::new(runtime, SessionRegistry::new()));
+
+                let response = server
+                    .initialize(terminal_auth_initialize_request())
+                    .unwrap();
+                let method_ids = terminal_auth_method_ids(&response.auth_methods);
+                assert_eq!(method_ids, expected_methods);
+
+                assert_eq!(server.logout().await.is_ok(), !method_ids.is_empty());
+            }
         }
     }
 
@@ -3608,15 +3632,7 @@ mod tests {
             .set_ambient_openrouter_api_key_for_test(false);
         let server = Server::new(runtime, SessionRegistry::new());
         let response = server
-            .initialize(
-                wire::InitializeRequest::new(
-                    wire::ProtocolVersion::V2,
-                    wire::Implementation::new("test-client", "0"),
-                )
-                .capabilities(wire::ClientCapabilities::new().auth(
-                    wire::AuthCapabilities::new().terminal(wire::TerminalAuthCapabilities::new()),
-                )),
-            )
+            .initialize(terminal_auth_initialize_request())
             .unwrap();
 
         assert_eq!(response.protocol_version, wire::ProtocolVersion::V2);
@@ -3652,13 +3668,7 @@ mod tests {
         let methods = terminal_auth_methods(&terminal_capabilities, |provider| {
             provider != ProviderKind::OpenRouter
         });
-        let method_ids = methods
-            .iter()
-            .map(|method| match method {
-                wire::AuthMethod::Terminal(method) => method.method_id.0.as_ref(),
-                _ => unreachable!("only terminal methods are advertised"),
-            })
-            .collect::<Vec<_>>();
+        let method_ids = terminal_auth_method_ids(&methods);
         assert_eq!(method_ids, ["openai", "speakeasy"]);
 
         let metadata_only = wire::ClientCapabilities::new().meta(serde_json::Map::from_iter([(

--- a/src/provider/adapter.rs
+++ b/src/provider/adapter.rs
@@ -155,6 +155,7 @@ impl ReasoningEffort {
 struct SessionSelection {
     model: ModelSelection,
     reasoning_effort: Option<ReasoningEffort>,
+    revision: u64,
 }
 
 /// A per-session adapter whose selection is read only when a new model turn begins.
@@ -208,6 +209,7 @@ impl SelectableAdapter {
             selection: Arc::new(Mutex::new(SessionSelection {
                 model: selection,
                 reasoning_effort,
+                revision: 0,
             })),
             credential_storage,
             openrouter_api_key,
@@ -240,10 +242,12 @@ impl SelectableAdapter {
             reasoning_effort,
             self.openrouter_api_key.as_ref(),
         )?;
-        self.selection
+        let mut current = self
+            .selection
             .lock()
-            .map_err(|_| "session selection lock is poisoned")?
-            .model = selection;
+            .map_err(|_| "session selection lock is poisoned")?;
+        current.model = selection;
+        current.revision = current.revision.wrapping_add(1);
         Ok(())
     }
 
@@ -259,10 +263,12 @@ impl SelectableAdapter {
             reasoning_effort,
             self.openrouter_api_key.as_ref(),
         )?;
-        self.selection
+        let mut current = self
+            .selection
             .lock()
-            .map_err(|_| "session selection lock is poisoned")?
-            .reasoning_effort = reasoning_effort;
+            .map_err(|_| "session selection lock is poisoned")?;
+        current.reasoning_effort = reasoning_effort;
+        current.revision = current.revision.wrapping_add(1);
         Ok(())
     }
 }
@@ -966,9 +972,8 @@ const OPENROUTER_FALLBACK: &[&str] = &[
     "google/gemini-2.5-pro",
 ];
 
-/// Returns a bounded, provider-grouped catalog. Remote discovery is best effort.
-pub async fn model_catalog(current: &ModelSelection) -> Vec<ModelGroup> {
-    let openai = [
+fn openai_models(current: &ModelSelection) -> Vec<String> {
+    let mut models = [
         "gpt-5.6-sol",
         "gpt-5.5",
         "gpt-5.4",
@@ -977,7 +982,16 @@ pub async fn model_catalog(current: &ModelSelection) -> Vec<ModelGroup> {
     ]
     .into_iter()
     .map(str::to_string)
-    .collect();
+    .collect::<Vec<_>>();
+    if current.provider == ProviderKind::OpenAiSubscription && !models.contains(&current.model) {
+        models.push(current.model.clone());
+    }
+    models
+}
+
+/// Returns a bounded, provider-grouped catalog. Remote discovery is best effort.
+pub async fn model_catalog(current: &ModelSelection) -> Vec<ModelGroup> {
+    let openai = openai_models(current);
     let openrouter_url = match std::env::var_os("OPENROUTER_BASE_URL") {
         None => catalog_models_url(None),
         Some(url) => url.to_str().and_then(|url| catalog_models_url(Some(url))),
@@ -1125,7 +1139,7 @@ mod tests {
         OpenRouterKitSession, OpenRouterProvider, ProviderKind, ReasoningEffort, SelectableAdapter,
         SelectableSession, SessionSelection, SpeakeasyKitAdapter, SpeakeasyProvider,
         apply_openrouter_reasoning_effort, catalog_models_url, expose_background_call_ids,
-        gram_chat_id, models_url, openrouter_config_from_env, parse_context_window,
+        gram_chat_id, models_url, openai_models, openrouter_config_from_env, parse_context_window,
         rewrite_openrouter_media, stamp_context_window,
     };
 
@@ -1538,6 +1552,7 @@ mod tests {
         let active = SessionSelection {
             model: active,
             reasoning_effort: None,
+            revision: 0,
         };
         SelectableSession {
             selection: Arc::new(Mutex::new(active.clone())),
@@ -1568,6 +1583,7 @@ mod tests {
                 SessionSelection {
                     model: selected.clone(),
                     reasoning_effort: Some(ReasoningEffort::High),
+                    revision: 1,
                 },
                 Ok(openrouter_session(&selected.model).await),
             )
@@ -1590,6 +1606,7 @@ mod tests {
                     SessionSelection {
                         model: selected,
                         reasoning_effort: None,
+                        revision: 1,
                     },
                     Err(LoopError::Provider("replacement failed".into())),
                 )
@@ -1598,6 +1615,33 @@ mod tests {
 
         assert_eq!(session.provider_name(), Some("openrouter"));
         assert_eq!(session.model_name(), Some("test/initial"));
+    }
+
+    #[test]
+    fn openai_catalog_keeps_the_active_custom_model() {
+        let current = ModelSelection::new(ProviderKind::OpenAiSubscription, "custom-model");
+
+        assert!(openai_models(&current).contains(&current.model));
+    }
+
+    #[test]
+    fn reselecting_the_active_model_refreshes_the_next_turn() {
+        let credentials = crate::credentials::CredentialStorage::Memory;
+        crate::provider::store_openrouter_test_credentials(&credentials);
+        let adapter = SelectableAdapter::new_with_credentials(
+            ProviderKind::OpenRouter,
+            "test-model",
+            credentials,
+        )
+        .unwrap();
+        let before = adapter.selection.lock().unwrap().clone();
+
+        adapter.select(before.model.clone()).unwrap();
+
+        let after = adapter.selection.lock().unwrap().clone();
+        assert_eq!(after.model, before.model);
+        assert_eq!(after.reasoning_effort, before.reasoning_effort);
+        assert_ne!(after.revision, before.revision);
     }
 
     #[test]

--- a/src/provider/adapter.rs
+++ b/src/provider/adapter.rs
@@ -29,11 +29,14 @@ const MAX_MODELS_BYTES: usize = 2 * 1024 * 1024;
 const MAX_MODELS: usize = 10_000;
 const MAX_SELECTOR_MODELS: usize = 2_000;
 const OPENROUTER_AUTH_REQUIRED: &str = "openrouter_auth_required: set OPENROUTER_API_KEY or run `kit auth login openrouter` before using the OpenRouter provider";
+const SPEAKEASY_AUTH_REQUIRED: &str =
+    "speakeasy_auth_required: run `kit auth login speakeasy` before using the Speakeasy provider";
 
 pub(crate) fn authentication_method_id(detail: &str) -> Option<&'static str> {
     [
         ("openai_auth_required:", "openai"),
         ("openrouter_auth_required:", "openrouter"),
+        ("speakeasy_auth_required:", "speakeasy"),
     ]
     .into_iter()
     .find_map(|(code, method_id)| detail.contains(code).then_some(method_id))
@@ -535,9 +538,8 @@ impl KitAdapter {
                 }))
             }
             ProviderKind::Speakeasy => {
-                let credentials = speakeasy_auth::load(&credential_storage)?.ok_or_else(|| {
-                    "run `kit auth login speakeasy` before using the Speakeasy provider".to_string()
-                })?;
+                let credentials = speakeasy_auth::load(&credential_storage)?
+                    .ok_or_else(|| SPEAKEASY_AUTH_REQUIRED.to_string())?;
                 let mut config =
                     OpenRouterConfig::new("unused", model).with_base_url(SPEAKEASY_COMPLETIONS_URL);
                 apply_openrouter_reasoning_effort(&mut config, reasoning_effort);

--- a/src/provider/adapter.rs
+++ b/src/provider/adapter.rs
@@ -28,6 +28,16 @@ use super::{
 const MAX_MODELS_BYTES: usize = 2 * 1024 * 1024;
 const MAX_MODELS: usize = 10_000;
 const MAX_SELECTOR_MODELS: usize = 2_000;
+const OPENROUTER_AUTH_REQUIRED: &str = "openrouter_auth_required: set OPENROUTER_API_KEY or run `kit auth login openrouter` before using the OpenRouter provider";
+
+pub(crate) fn authentication_method_id(detail: &str) -> Option<&'static str> {
+    [
+        ("openai_auth_required:", "openai"),
+        ("openrouter_auth_required:", "openrouter"),
+    ]
+    .into_iter()
+    .find_map(|(code, method_id)| detail.contains(code).then_some(method_id))
+}
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, ValueEnum)]
 pub enum ProviderKind {
@@ -579,9 +589,7 @@ fn openrouter_config_from_env(
             _ => (
                 super::openrouter_auth::load(credential_storage)?
                     .map(|record| record.api_key.clone())
-                    .ok_or_else(|| {
-                        "set OPENROUTER_API_KEY or run `kit auth login openrouter` before using the OpenRouter provider".to_string()
-                    })?,
+                    .ok_or_else(|| OPENROUTER_AUTH_REQUIRED.to_string())?,
                 ResolvedOpenRouterApiKeySource::Stored,
             ),
         },

--- a/src/provider/adapter.rs
+++ b/src/provider/adapter.rs
@@ -191,13 +191,6 @@ impl SelectableAdapter {
         if !valid_model_id(&selection.model) {
             return Err("model name is outside canonical bounds".into());
         }
-        KitAdapter::new_with_credentials_and_effort(
-            selection.provider,
-            selection.model.clone(),
-            credential_storage.clone(),
-            reasoning_effort,
-            openrouter_api_key.as_ref(),
-        )?;
         Ok(Self {
             selection: Arc::new(Mutex::new(SessionSelection {
                 model: selection,
@@ -1250,6 +1243,21 @@ mod tests {
             })
             .unwrap_err();
         assert!(error.contains("cannot be empty"), "{error}");
+    }
+
+    #[test]
+    fn selectable_adapter_defers_openrouter_credentials_until_session_start() {
+        let directory = tempfile::tempdir().unwrap();
+        let storage = CredentialStorage::Filesystem(directory.path().join("credentials"));
+
+        SelectableAdapter::new_with_credentials_effort_and_openrouter_key(
+            ProviderKind::OpenRouter,
+            "test/model",
+            storage,
+            None,
+            None,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -4,6 +4,7 @@ mod openai_auth;
 mod openrouter_auth;
 mod speakeasy_auth;
 
+pub(crate) use adapter::authentication_method_id;
 pub use adapter::{
     KitAdapter, KitSession, ModelGroup, ModelSelection, ProviderKind, ReasoningEffort,
     SelectableAdapter, SelectableSession, model_catalog,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -127,6 +127,28 @@ pub fn execute_openrouter_auth(
     )
 }
 
+#[doc(hidden)]
+pub fn execute_provider_logout(
+    provider: ProviderKind,
+    storage: &crate::credentials::CredentialStorage,
+    local_only: bool,
+    active_openrouter_key: Option<(&OpenRouterApiKey, OpenRouterApiKeySource)>,
+) -> Result<String, String> {
+    match provider {
+        ProviderKind::OpenAiSubscription => {
+            execute_openai_auth(OpenAiAuthCommand::Logout { local_only }, storage)
+        }
+        ProviderKind::OpenRouter => execute_openrouter_auth(
+            OpenRouterAuthCommand::Logout { local_only },
+            storage,
+            active_openrouter_key,
+        ),
+        ProviderKind::Speakeasy => {
+            execute_speakeasy_auth(SpeakeasyAuthCommand::Logout { local_only }, storage)
+        }
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn store_openrouter_test_credentials(storage: &crate::credentials::CredentialStorage) {
     openrouter_auth::store_test_credentials(storage);

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -569,8 +569,12 @@ impl Runtime {
                 || (self.openrouter_api_key.is_none() && !self.ambient_openrouter_api_key))
     }
 
+    pub(crate) fn supports_selected_provider_authentication_management(&self) -> bool {
+        self.supports_terminal_authentication(self.provider)
+    }
+
     pub(crate) fn supports_logout_authentication(&self) -> bool {
-        self.supports_terminal_authentication(ProviderKind::OpenRouter)
+        self.supports_selected_provider_authentication_management()
     }
 
     pub(crate) fn logout_authentication(&self) -> Result<(), LogoutAuthenticationError> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -563,14 +563,18 @@ impl Runtime {
         self.ambient_openrouter_api_key = present;
     }
 
-    pub(crate) fn supports_terminal_authentication(&self) -> bool {
+    pub(crate) fn supports_terminal_authentication(&self, provider: ProviderKind) -> bool {
         self.credential_storage.is_persistent()
-            && self.openrouter_api_key.is_none()
-            && !self.ambient_openrouter_api_key
+            && (provider != ProviderKind::OpenRouter
+                || (self.openrouter_api_key.is_none() && !self.ambient_openrouter_api_key))
+    }
+
+    pub(crate) fn supports_logout_authentication(&self) -> bool {
+        self.supports_terminal_authentication(ProviderKind::OpenRouter)
     }
 
     pub(crate) fn logout_authentication(&self) -> Result<(), LogoutAuthenticationError> {
-        if !self.supports_terminal_authentication() {
+        if !self.supports_logout_authentication() {
             return Err(LogoutAuthenticationError::CredentialStateUnchanged(
                 "authentication cannot be logged out while credentials are ephemeral or explicitly configured"
                     .into(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -287,6 +287,27 @@ struct McpInstallSources {
 pub(crate) const SUBAGENT_SYSTEM_PROMPT_MARKER: &str =
     "This task was delegated to you by the primary agent.";
 
+#[derive(Debug)]
+pub(crate) enum LogoutAuthenticationError {
+    CredentialStateUnchanged(String),
+    CredentialStateMayHaveChanged(String),
+}
+
+impl LogoutAuthenticationError {
+    pub(crate) fn credential_state_may_have_changed(&self) -> bool {
+        matches!(self, Self::CredentialStateMayHaveChanged(_))
+    }
+}
+
+impl std::fmt::Display for LogoutAuthenticationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CredentialStateUnchanged(message)
+            | Self::CredentialStateMayHaveChanged(message) => formatter.write_str(message),
+        }
+    }
+}
+
 pub struct Runtime {
     root: PathBuf,
     adapter: SelectableAdapter,
@@ -544,16 +565,16 @@ impl Runtime {
 
     pub(crate) fn supports_terminal_authentication(&self) -> bool {
         self.credential_storage.is_persistent()
-            && (self.provider != ProviderKind::OpenRouter
-                || (self.openrouter_api_key.is_none() && !self.ambient_openrouter_api_key))
+            && self.openrouter_api_key.is_none()
+            && !self.ambient_openrouter_api_key
     }
 
-    pub(crate) fn logout_authentication(&self) -> Result<(), String> {
+    pub(crate) fn logout_authentication(&self) -> Result<(), LogoutAuthenticationError> {
         if !self.supports_terminal_authentication() {
-            return Err(
+            return Err(LogoutAuthenticationError::CredentialStateUnchanged(
                 "authentication cannot be logged out while credentials are ephemeral or explicitly configured"
                     .into(),
-            );
+            ));
         }
         let failures = [
             ProviderKind::OpenAiSubscription,
@@ -569,9 +590,11 @@ impl Runtime {
         if failures.is_empty() {
             Ok(())
         } else {
-            Err(format!(
-                "could not remove all provider credentials: {}",
-                failures.join("; ")
+            Err(LogoutAuthenticationError::CredentialStateMayHaveChanged(
+                format!(
+                    "could not remove all provider credentials: {}",
+                    failures.join("; ")
+                ),
             ))
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -544,8 +544,8 @@ impl Runtime {
 
     pub(crate) fn supports_terminal_authentication(&self) -> bool {
         self.credential_storage.is_persistent()
-            && self.openrouter_api_key.is_none()
-            && !self.ambient_openrouter_api_key
+            && (self.provider != ProviderKind::OpenRouter
+                || (self.openrouter_api_key.is_none() && !self.ambient_openrouter_api_key))
     }
 
     pub(crate) fn logout_authentication(&self) -> Result<(), String> {
@@ -555,19 +555,25 @@ impl Runtime {
                     .into(),
             );
         }
-        for provider in [
+        let failures = [
             ProviderKind::OpenAiSubscription,
             ProviderKind::OpenRouter,
             ProviderKind::Speakeasy,
-        ] {
-            crate::provider::execute_provider_logout(
-                provider,
-                &self.credential_storage,
-                true,
-                None,
-            )?;
+        ]
+        .into_iter()
+        .filter_map(|provider| {
+            crate::provider::execute_provider_logout(provider, &self.credential_storage, true, None)
+                .err()
+        })
+        .collect::<Vec<_>>();
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "could not remove all provider credentials: {}",
+                failures.join("; ")
+            ))
         }
-        Ok(())
     }
 
     /// Sets private immediate-parent context inherited by this runtime's direct children.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -293,12 +293,6 @@ pub(crate) enum LogoutAuthenticationError {
     CredentialStateMayHaveChanged(String),
 }
 
-impl LogoutAuthenticationError {
-    pub(crate) fn credential_state_may_have_changed(&self) -> bool {
-        matches!(self, Self::CredentialStateMayHaveChanged(_))
-    }
-}
-
 impl std::fmt::Display for LogoutAuthenticationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -569,12 +563,8 @@ impl Runtime {
                 || (self.openrouter_api_key.is_none() && !self.ambient_openrouter_api_key))
     }
 
-    pub(crate) fn supports_selected_provider_authentication_management(&self) -> bool {
-        self.supports_terminal_authentication(self.provider)
-    }
-
     pub(crate) fn supports_logout_authentication(&self) -> bool {
-        self.supports_selected_provider_authentication_management()
+        self.supports_terminal_authentication(ProviderKind::OpenRouter)
     }
 
     pub(crate) fn logout_authentication(&self) -> Result<(), LogoutAuthenticationError> {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -242,6 +242,7 @@ impl SessionClaim {
 impl Drop for SessionClaim {
     fn drop(&mut self) {
         let opened_uncommitted = self.uncommitted_observer.is_some();
+        drop(self.uncommitted_observer.take());
         if !self.committed
             && let Ok(mut selection) = self.runtime.session.lock()
         {
@@ -294,6 +295,7 @@ pub struct Runtime {
     reasoning_effort: Option<crate::provider::ReasoningEffort>,
     credential_storage: crate::credentials::CredentialStorage,
     openrouter_api_key: Option<crate::provider::OpenRouterApiKey>,
+    ambient_openrouter_api_key: bool,
     telemetry: crate::telemetry::Settings,
     max_subagent_depth: usize,
     base_depth: usize,
@@ -411,6 +413,8 @@ impl Runtime {
             reasoning_effort,
             credential_storage,
             openrouter_api_key,
+            ambient_openrouter_api_key: std::env::var_os("OPENROUTER_API_KEY")
+                .is_some_and(|value| !value.is_empty()),
             telemetry: Default::default(),
             max_subagent_depth,
             base_depth: 0,
@@ -531,6 +535,39 @@ impl Runtime {
 
     pub fn root(&self) -> &Path {
         &self.root
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_ambient_openrouter_api_key_for_test(&mut self, present: bool) {
+        self.ambient_openrouter_api_key = present;
+    }
+
+    pub(crate) fn supports_terminal_authentication(&self) -> bool {
+        self.credential_storage.is_persistent()
+            && self.openrouter_api_key.is_none()
+            && !self.ambient_openrouter_api_key
+    }
+
+    pub(crate) fn logout_authentication(&self) -> Result<(), String> {
+        if !self.supports_terminal_authentication() {
+            return Err(
+                "authentication cannot be logged out while credentials are ephemeral or explicitly configured"
+                    .into(),
+            );
+        }
+        for provider in [
+            ProviderKind::OpenAiSubscription,
+            ProviderKind::OpenRouter,
+            ProviderKind::Speakeasy,
+        ] {
+            crate::provider::execute_provider_logout(
+                provider,
+                &self.credential_storage,
+                true,
+                None,
+            )?;
+        }
+        Ok(())
     }
 
     /// Sets private immediate-parent context inherited by this runtime's direct children.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -109,6 +109,7 @@ impl SessionSelection {
         configured: bool,
         succeeded: bool,
         opened_new: bool,
+        opened_uncommitted: bool,
     ) {
         if configured {
             if succeeded {
@@ -119,9 +120,9 @@ impl SessionSelection {
                 request.resume = true;
             }
             self.configured_claimed = false;
-        } else if !succeeded && (request.resume || opened_new) {
+        } else if !succeeded && (request.resume || opened_new || opened_uncommitted) {
             let mut request = request.clone();
-            request.resume = true;
+            request.resume = request.resume || opened_new;
             self.generated_retries.push_back(request);
         }
     }
@@ -167,7 +168,7 @@ pub(crate) struct SessionClaim {
     runtime: Arc<Runtime>,
     request: SessionRequest,
     kind: SessionClaimKind,
-    fork_observer: Option<crate::session::SessionObserver>,
+    uncommitted_observer: Option<crate::session::SessionObserver>,
     committed: bool,
 }
 
@@ -191,10 +192,8 @@ impl SessionClaim {
         }
     }
 
-    fn guard_fork_transcript(&mut self, observer: &crate::session::SessionObserver) {
-        if matches!(self.kind, SessionClaimKind::Fork) {
-            self.fork_observer = Some(observer.clone());
-        }
+    fn guard_uncommitted_transcript(&mut self, observer: &crate::session::SessionObserver) {
+        self.uncommitted_observer = Some(observer.clone());
     }
 
     pub(crate) fn is_fork(&self) -> bool {
@@ -204,19 +203,20 @@ impl SessionClaim {
     pub(crate) fn defer_fork_commit(mut self) -> crate::session::SessionObserver {
         debug_assert!(self.is_fork());
         self.committed = true;
-        self.fork_observer
+        self.uncommitted_observer
             .take()
             .expect("an opened fork claim must retain its transcript observer")
     }
 
     pub(crate) fn commit(mut self) -> Result<(), AcpRuntimeError> {
         if matches!(self.kind, SessionClaimKind::Fork) {
-            if let Some(observer) = self.fork_observer.take() {
+            if let Some(observer) = self.uncommitted_observer.take() {
                 observer.commit_creation();
             }
             self.committed = true;
             return Ok(());
         }
+        self.mark_opened();
         let mut selection =
             self.runtime.session.lock().map_err(|_| {
                 AcpRuntimeError::Loop("runtime session selection is poisoned".into())
@@ -225,11 +225,14 @@ impl SessionClaim {
             SessionClaimKind::New {
                 configured,
                 opened_new,
-            } => selection.finish_new(&self.request, configured, true, opened_new),
+            } => selection.finish_new(&self.request, configured, true, opened_new, false),
             SessionClaimKind::Load { configured } => {
                 selection.finish_load(&self.request, configured, true)
             }
             SessionClaimKind::Fork => unreachable!("fork claims commit before locking selection"),
+        }
+        if let Some(observer) = self.uncommitted_observer.take() {
+            observer.commit_creation();
         }
         self.committed = true;
         Ok(())
@@ -238,6 +241,7 @@ impl SessionClaim {
 
 impl Drop for SessionClaim {
     fn drop(&mut self) {
+        let opened_uncommitted = self.uncommitted_observer.is_some();
         if !self.committed
             && let Ok(mut selection) = self.runtime.session.lock()
         {
@@ -245,7 +249,13 @@ impl Drop for SessionClaim {
                 SessionClaimKind::New {
                     configured,
                     opened_new,
-                } => selection.finish_new(&self.request, configured, false, opened_new),
+                } => selection.finish_new(
+                    &self.request,
+                    configured,
+                    false,
+                    opened_new,
+                    opened_uncommitted,
+                ),
                 SessionClaimKind::Load { configured } => {
                     selection.finish_load(&self.request, configured, false)
                 }
@@ -966,13 +976,11 @@ impl Runtime {
                 )
             })?
         };
-        let opened = crate::session::open(
-            &self.root,
-            &request.id,
-            request.resume,
-            request.force,
-            initial,
-        )
+        let opened = if request.resume {
+            crate::session::open(&self.root, &request.id, true, request.force, initial)
+        } else {
+            crate::session::open_uncommitted(&self.root, &request.id, request.force, initial)
+        }
         .map_err(|error| {
             record_runtime_failure(
                 &session_id,
@@ -981,6 +989,7 @@ impl Runtime {
                 error,
             )
         })?;
+        let pending_creation = (!request.resume).then(|| opened.observer.clone());
         let skills = self.fresh_skills();
         let compactor = crate::compaction::automatic(
             self.adapter.clone(),
@@ -1024,7 +1033,12 @@ impl Runtime {
             .start(SessionConfig::new(session_id.clone()).without_cache())
             .await
         {
-            Ok(driver) => driver,
+            Ok(driver) => {
+                if let Some(observer) = pending_creation {
+                    observer.commit_creation();
+                }
+                driver
+            }
             Err(error) => {
                 return Err(record_loop_failure(
                     &session_id,
@@ -1127,7 +1141,7 @@ impl Runtime {
                 configured,
                 opened_new: false,
             },
-            fork_observer: None,
+            uncommitted_observer: None,
             committed: false,
         })
     }
@@ -1141,7 +1155,7 @@ impl Runtime {
                 force: false,
             },
             kind: SessionClaimKind::Fork,
-            fork_observer: None,
+            uncommitted_observer: None,
             committed: false,
         })
     }
@@ -1159,7 +1173,7 @@ impl Runtime {
             runtime: Arc::clone(self),
             request,
             kind: SessionClaimKind::Load { configured },
-            fork_observer: None,
+            uncommitted_observer: None,
             committed: false,
         })
     }
@@ -1195,7 +1209,7 @@ impl Runtime {
                 self.root.display()
             )));
         }
-        let request = &claim.request;
+        let request = claim.request.clone();
         let session_id = request.id.clone();
         let (forked_transcript, selected, parent_context) = match forked {
             Some(forked) => (
@@ -1224,20 +1238,15 @@ impl Runtime {
                 .map_err(AcpRuntimeError::Loop)?
         };
         let opened = if is_fork {
-            crate::session::open_uncommitted(&self.root, &request.id, initial)
+            crate::session::open_uncommitted(&self.root, &request.id, false, initial)
+        } else if request.resume {
+            crate::session::open(&self.root, &request.id, true, request.force, initial)
         } else {
-            crate::session::open(
-                &self.root,
-                &request.id,
-                request.resume,
-                request.force,
-                initial,
-            )
+            crate::session::open_uncommitted(&self.root, &request.id, request.force, initial)
         }
         .map_err(AcpRuntimeError::Loop)?;
-        claim.mark_opened();
-        if is_fork {
-            claim.guard_fork_transcript(&opened.observer);
+        if is_fork || !request.resume {
+            claim.guard_uncommitted_transcript(&opened.observer);
         }
         // Every ACP route owns its model selection. Changing one session
         // cannot redirect another session served by the same runtime.

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -226,7 +226,7 @@ fn resolved_reasoning_effort_reaches_root_adapter_and_kit_children() {
 }
 
 #[test]
-fn openrouter_keys_only_disable_openrouter_terminal_authentication() {
+fn openrouter_keys_only_disable_openrouter_authentication() {
     for (explicit_key, ambient_key) in [(true, false), (false, true)] {
         let root = tempfile::tempdir().unwrap();
         let credentials = tempfile::tempdir().unwrap();
@@ -246,11 +246,8 @@ fn openrouter_keys_only_disable_openrouter_terminal_authentication() {
         assert!(runtime.supports_terminal_authentication(crate::ProviderKind::OpenAiSubscription));
         assert!(!runtime.supports_terminal_authentication(crate::ProviderKind::OpenRouter));
         assert!(runtime.supports_terminal_authentication(crate::ProviderKind::Speakeasy));
-        assert!(!runtime.supports_logout_authentication());
-        assert!(matches!(
-            runtime.logout_authentication(),
-            Err(LogoutAuthenticationError::CredentialStateUnchanged(_))
-        ));
+        assert!(runtime.supports_logout_authentication());
+        runtime.logout_authentication().unwrap();
     }
 }
 

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -225,6 +225,57 @@ fn resolved_reasoning_effort_reaches_root_adapter_and_kit_children() {
 }
 
 #[test]
+fn unrelated_openrouter_keys_do_not_disable_terminal_authentication() {
+    let root = tempfile::tempdir().unwrap();
+    let credentials = tempfile::tempdir().unwrap();
+    let mut runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(
+        root.path(),
+        "gpt-5.4",
+        crate::ProviderKind::OpenAiSubscription,
+        crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf()),
+        None,
+        Some(crate::provider::OpenRouterApiKey::new("unrelated")),
+    )
+    .unwrap();
+    Arc::get_mut(&mut runtime)
+        .unwrap()
+        .set_ambient_openrouter_api_key_for_test(true);
+
+    assert!(runtime.supports_terminal_authentication());
+}
+
+#[test]
+fn logout_attempts_all_providers_after_a_credential_removal_failure() {
+    let root = tempfile::tempdir().unwrap();
+    let credentials = tempfile::tempdir().unwrap();
+    let storage =
+        crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf());
+    storage.make_entry_undeletable_for_test("openrouter", "default");
+    storage
+        .entry("speakeasy", "default")
+        .save(b"removed")
+        .unwrap();
+    let runtime = Runtime::new_with_provider_and_credentials(
+        root.path(),
+        "gpt-5.4",
+        crate::ProviderKind::OpenAiSubscription,
+        storage.clone(),
+    )
+    .unwrap();
+
+    let error = runtime.logout_authentication().unwrap_err();
+
+    assert!(error.contains("could not remove OpenRouter credentials"));
+    assert!(
+        storage
+            .entry("speakeasy", "default")
+            .load()
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
 fn explicit_openrouter_key_reaches_runtime_adapter_and_kit_children() {
     let root = tempfile::tempdir().unwrap();
     let runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -226,27 +226,32 @@ fn resolved_reasoning_effort_reaches_root_adapter_and_kit_children() {
 }
 
 #[test]
-fn openrouter_keys_disable_agent_wide_terminal_authentication() {
-    let root = tempfile::tempdir().unwrap();
-    let credentials = tempfile::tempdir().unwrap();
-    let mut runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(
-        root.path(),
-        "gpt-5.4",
-        crate::ProviderKind::OpenAiSubscription,
-        crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf()),
-        None,
-        Some(crate::provider::OpenRouterApiKey::new("unrelated")),
-    )
-    .unwrap();
-    Arc::get_mut(&mut runtime)
-        .unwrap()
-        .set_ambient_openrouter_api_key_for_test(true);
+fn openrouter_keys_only_disable_openrouter_terminal_authentication() {
+    for (explicit_key, ambient_key) in [(true, false), (false, true)] {
+        let root = tempfile::tempdir().unwrap();
+        let credentials = tempfile::tempdir().unwrap();
+        let mut runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(
+            root.path(),
+            "gpt-5.4",
+            crate::ProviderKind::OpenAiSubscription,
+            crate::credentials::CredentialStorage::Filesystem(credentials.path().to_path_buf()),
+            None,
+            explicit_key.then(|| crate::provider::OpenRouterApiKey::new("unrelated")),
+        )
+        .unwrap();
+        Arc::get_mut(&mut runtime)
+            .unwrap()
+            .set_ambient_openrouter_api_key_for_test(ambient_key);
 
-    assert!(!runtime.supports_terminal_authentication());
-    assert!(matches!(
-        runtime.logout_authentication(),
-        Err(LogoutAuthenticationError::CredentialStateUnchanged(_))
-    ));
+        assert!(runtime.supports_terminal_authentication(crate::ProviderKind::OpenAiSubscription));
+        assert!(!runtime.supports_terminal_authentication(crate::ProviderKind::OpenRouter));
+        assert!(runtime.supports_terminal_authentication(crate::ProviderKind::Speakeasy));
+        assert!(!runtime.supports_logout_authentication());
+        assert!(matches!(
+            runtime.logout_authentication(),
+            Err(LogoutAuthenticationError::CredentialStateUnchanged(_))
+        ));
+    }
 }
 
 #[test]

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -278,14 +278,14 @@ fn configured_session_is_consumed_only_after_successful_start() {
     let (first, configured) = selection.claim();
     assert_eq!(first.id, "selected");
     assert!(configured);
-    selection.finish_new(&first, configured, false, true);
+    selection.finish_new(&first, configured, false, true, false);
     let (retry, configured) = selection.claim();
     assert_eq!(retry.id, "selected");
     assert!(
         retry.resume,
         "a transcript opened before failure is resumed"
     );
-    selection.finish_new(&retry, configured, true, false);
+    selection.finish_new(&retry, configured, true, false, false);
     assert!(selection.configured.is_none());
 }
 
@@ -355,6 +355,30 @@ fn dropped_generated_session_claim_retries_opened_transcript_with_same_id() {
 }
 
 #[test]
+fn dropped_uncommitted_session_claim_retries_as_new() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
+
+    let mut failed = runtime.claim_session().unwrap();
+    let session_id = failed.id().to_owned();
+    let opened = crate::session::open_uncommitted(
+        root.path(),
+        &session_id,
+        false,
+        vec![agentkit_core::Item::text(ItemKind::System, "system")],
+    )
+    .unwrap();
+    failed.guard_uncommitted_transcript(&opened.observer);
+    drop(opened);
+    drop(failed);
+
+    assert!(crate::session::load(root.path(), &session_id).is_err());
+    let retry = runtime.claim_session().unwrap();
+    assert_eq!(retry.id(), session_id);
+    assert!(!retry.request.resume);
+}
+
+#[test]
 fn dropped_fork_claim_removes_its_uncommitted_transcript() {
     let root = tempfile::tempdir().unwrap();
     let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
@@ -364,10 +388,11 @@ fn dropped_fork_claim_removes_its_uncommitted_transcript() {
     let opened = crate::session::open_uncommitted(
         root.path(),
         &session_id,
+        false,
         vec![agentkit_core::Item::text(ItemKind::System, "system")],
     )
     .unwrap();
-    failed.guard_fork_transcript(&opened.observer);
+    failed.guard_uncommitted_transcript(&opened.observer);
     drop(opened);
     assert!(crate::session::load(root.path(), &session_id).is_ok());
 
@@ -386,10 +411,11 @@ fn dropped_deferred_fork_creation_removes_transcript_before_response() {
     let opened = crate::session::open_uncommitted(
         root.path(),
         &session_id,
+        false,
         vec![agentkit_core::Item::text(ItemKind::System, "system")],
     )
     .unwrap();
-    claim.guard_fork_transcript(&opened.observer);
+    claim.guard_uncommitted_transcript(&opened.observer);
     let creation = claim.defer_fork_commit();
     drop(opened);
     drop(creation);
@@ -1420,6 +1446,55 @@ fn cancel_all_covers_running_and_late_background_registration() {
     jobs.register_foreground_for_test("next-turn");
     assert!(!jobs.is_cancelled_for_test("next-turn"));
     jobs.finish_for_test("next-turn");
+}
+
+#[tokio::test]
+async fn persistent_startup_failure_does_not_commit_new_session() {
+    let root = tempfile::tempdir().unwrap();
+    let session_id = crate::session::new_id();
+    let runtime = Runtime::with_session_provider_credentials_effort_and_openrouter_key(
+        root.path(),
+        "test/model",
+        crate::provider::ProviderKind::OpenRouter,
+        SessionRequest {
+            id: session_id.clone(),
+            resume: false,
+            force: false,
+        },
+        crate::credentials::CredentialStorage::Memory,
+        None,
+        Some(crate::provider::OpenRouterApiKey::new("")),
+    )
+    .unwrap();
+
+    let error = runtime.run_persistent("hello".into()).await.unwrap_err();
+    assert!(
+        error.contains("--openrouter-api-key cannot be empty"),
+        "{error}"
+    );
+    assert!(crate::session::load(root.path(), &session_id).is_err());
+}
+
+#[tokio::test]
+async fn persistent_missing_openai_credentials_do_not_commit_new_session() {
+    let root = tempfile::tempdir().unwrap();
+    let session_id = crate::session::new_id();
+    let runtime = Runtime::with_session_provider_and_credentials(
+        root.path(),
+        "gpt-5.4",
+        crate::provider::ProviderKind::OpenAiSubscription,
+        SessionRequest {
+            id: session_id.clone(),
+            resume: false,
+            force: false,
+        },
+        crate::credentials::CredentialStorage::Memory,
+    )
+    .unwrap();
+
+    let error = runtime.run_persistent("hello".into()).await.unwrap_err();
+    assert!(error.contains("openai_auth_required:"), "{error}");
+    assert!(crate::session::load(root.path(), &session_id).is_err());
 }
 
 #[tokio::test]

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -379,6 +379,46 @@ fn dropped_uncommitted_session_claim_retries_as_new() {
 }
 
 #[test]
+fn uncommitted_claim_rolls_back_before_waiting_to_publish_retry() {
+    let root = tempfile::tempdir().unwrap();
+    let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();
+    let mut failed = runtime.claim_session().unwrap();
+    let session_id = failed.id().to_owned();
+    let opened = crate::session::open_uncommitted(
+        root.path(),
+        &session_id,
+        false,
+        vec![agentkit_core::Item::text(ItemKind::System, "system")],
+    )
+    .unwrap();
+    failed.guard_uncommitted_transcript(&opened.observer);
+    drop(opened);
+
+    let selection = runtime.session.lock().unwrap();
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let dropping = std::thread::spawn(move || {
+        started_tx.send(()).unwrap();
+        drop(failed);
+    });
+    started_rx.recv().unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(1);
+    while crate::session::load(root.path(), &session_id).is_ok()
+        && std::time::Instant::now() < deadline
+    {
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    assert!(
+        crate::session::load(root.path(), &session_id).is_err(),
+        "uncommitted transcript must roll back before the retry mutex is available"
+    );
+
+    drop(selection);
+    dropping.join().unwrap();
+    let retry = runtime.claim_session().unwrap();
+    assert_eq!(retry.id(), session_id);
+}
+
+#[test]
 fn dropped_fork_claim_removes_its_uncommitted_transcript() {
     let root = tempfile::tempdir().unwrap();
     let runtime = Runtime::new(root.path(), "gpt-5.4").unwrap();

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -226,7 +226,7 @@ fn resolved_reasoning_effort_reaches_root_adapter_and_kit_children() {
 }
 
 #[test]
-fn openrouter_keys_only_disable_openrouter_authentication() {
+fn openrouter_keys_disable_openrouter_authentication_and_global_logout() {
     for (explicit_key, ambient_key) in [(true, false), (false, true)] {
         let root = tempfile::tempdir().unwrap();
         let credentials = tempfile::tempdir().unwrap();
@@ -246,8 +246,11 @@ fn openrouter_keys_only_disable_openrouter_authentication() {
         assert!(runtime.supports_terminal_authentication(crate::ProviderKind::OpenAiSubscription));
         assert!(!runtime.supports_terminal_authentication(crate::ProviderKind::OpenRouter));
         assert!(runtime.supports_terminal_authentication(crate::ProviderKind::Speakeasy));
-        assert!(runtime.supports_logout_authentication());
-        runtime.logout_authentication().unwrap();
+        assert!(!runtime.supports_logout_authentication());
+        assert!(matches!(
+            runtime.logout_authentication(),
+            Err(LogoutAuthenticationError::CredentialStateUnchanged(_))
+        ));
     }
 }
 

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -11,8 +11,9 @@ use agentkit_tools_core::{
 use serde_json::{Value, json};
 
 use super::{
-    BackgroundJobs, BackgroundableCompose, DetachRegistration, DynamicSkillTool, Runtime,
-    SessionRequest, SessionSelection, background_route, load_initial_transcript,
+    BackgroundJobs, BackgroundableCompose, DetachRegistration, DynamicSkillTool,
+    LogoutAuthenticationError, Runtime, SessionRequest, SessionSelection, background_route,
+    load_initial_transcript,
 };
 
 #[tokio::test]
@@ -225,7 +226,7 @@ fn resolved_reasoning_effort_reaches_root_adapter_and_kit_children() {
 }
 
 #[test]
-fn unrelated_openrouter_keys_do_not_disable_terminal_authentication() {
+fn openrouter_keys_disable_agent_wide_terminal_authentication() {
     let root = tempfile::tempdir().unwrap();
     let credentials = tempfile::tempdir().unwrap();
     let mut runtime = Runtime::new_with_provider_credentials_effort_and_openrouter_key(
@@ -241,7 +242,11 @@ fn unrelated_openrouter_keys_do_not_disable_terminal_authentication() {
         .unwrap()
         .set_ambient_openrouter_api_key_for_test(true);
 
-    assert!(runtime.supports_terminal_authentication());
+    assert!(!runtime.supports_terminal_authentication());
+    assert!(matches!(
+        runtime.logout_authentication(),
+        Err(LogoutAuthenticationError::CredentialStateUnchanged(_))
+    ));
 }
 
 #[test]
@@ -255,17 +260,23 @@ fn logout_attempts_all_providers_after_a_credential_removal_failure() {
         .entry("speakeasy", "default")
         .save(b"removed")
         .unwrap();
-    let runtime = Runtime::new_with_provider_and_credentials(
+    let mut runtime = Runtime::new_with_provider_and_credentials(
         root.path(),
         "gpt-5.4",
         crate::ProviderKind::OpenAiSubscription,
         storage.clone(),
     )
     .unwrap();
+    Arc::get_mut(&mut runtime)
+        .unwrap()
+        .set_ambient_openrouter_api_key_for_test(false);
 
     let error = runtime.logout_authentication().unwrap_err();
 
-    assert!(error.contains("could not remove OpenRouter credentials"));
+    let LogoutAuthenticationError::CredentialStateMayHaveChanged(message) = error else {
+        panic!("credential removal failure must report possibly changed state");
+    };
+    assert!(message.contains("could not remove OpenRouter credentials"));
     assert!(
         storage
             .entry("speakeasy", "default")

--- a/src/session.rs
+++ b/src/session.rs
@@ -282,6 +282,7 @@ pub(crate) fn open_in(
 pub(crate) fn open_uncommitted(
     root: &Path,
     session_id: &str,
+    force: bool,
     initial: Vec<Item>,
 ) -> Result<OpenSession, String> {
     open_with_initial_timestamps_in(
@@ -289,7 +290,7 @@ pub(crate) fn open_uncommitted(
         &default_directory()?,
         session_id,
         false,
-        false,
+        force,
         initial,
         InitialTranscriptOptions {
             stamp_items: true,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -13,7 +13,7 @@ use std::ffi::OsStr;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::process::{Command, Stdio};
 
-use agent_client_protocol::schema::v2::{StopReason, ToolCallStatus, ToolKind};
+use agent_client_protocol::schema::v2::{AuthMethodTerminal, StopReason, ToolCallStatus, ToolKind};
 #[cfg(test)]
 use agentkit_core::{DataRef, Item, ItemKind, Modality, Part, ToolOutput};
 use crossterm::event::{
@@ -293,6 +293,7 @@ pub enum Action {
         effort: String,
         save_defaults: bool,
     },
+    Login(AuthMethodTerminal),
     Copy(String),
     Cancel,
     DetachCompose(String),
@@ -574,6 +575,7 @@ pub struct App {
     pub session_dialog: Option<SessionDialog>,
     pub file_picker: Option<FilePickerDialog>,
     session_catalog_pending: bool,
+    pub auth_methods: Vec<AuthMethodTerminal>,
     pub available_commands: Vec<SlashCommand>,
     pub command_completion_selected: usize,
     command_completion_query: Option<String>,
@@ -866,6 +868,7 @@ impl App {
             session_dialog: None,
             file_picker: None,
             session_catalog_pending: false,
+            auth_methods: Vec::new(),
             available_commands: Vec::new(),
             command_completion_selected: 0,
             command_completion_query: None,
@@ -947,6 +950,7 @@ impl App {
             self.editor.text(),
             self.editor.cursor(),
             &self.available_commands,
+            !self.auth_methods.is_empty(),
         )
     }
 
@@ -961,6 +965,7 @@ impl App {
             self.editor.text(),
             self.editor.cursor(),
             &self.available_commands,
+            !self.auth_methods.is_empty(),
         )
         .len();
         self.command_completion_selected = self
@@ -2937,8 +2942,15 @@ impl App {
                         return Action::None;
                     }
                     let input = self.editor.text();
-                    if !matches!(parse(input), Parsed::Prompt(_))
-                        || known_token(input, &self.available_commands).is_some()
+                    if !matches!(
+                        parse(input, !self.auth_methods.is_empty()),
+                        Parsed::Prompt(_)
+                    ) || known_token(
+                        input,
+                        &self.available_commands,
+                        !self.auth_methods.is_empty(),
+                    )
+                    .is_some()
                     {
                         self.toast("commands are available only while idle");
                         return Action::None;
@@ -2949,7 +2961,7 @@ impl App {
                     }
                 }
                 let input = self.editor.submit();
-                return match parse(&input) {
+                return match parse(&input, !self.auth_methods.is_empty()) {
                     Parsed::New { prompt } => Action::New(prompt.map(str::to_string)),
                     Parsed::Resume {
                         session_id: Some(session_id),
@@ -2971,6 +2983,30 @@ impl App {
                     Parsed::Agents => {
                         self.toggle_agents();
                         Action::None
+                    }
+                    Parsed::Login { method_id } => {
+                        let method = method_id
+                            .and_then(|method_id| {
+                                self.auth_methods
+                                    .iter()
+                                    .find(|method| method.method_id.0.as_ref() == method_id)
+                            })
+                            .or_else(|| {
+                                (method_id.is_none() && self.auth_methods.len() == 1)
+                                    .then(|| &self.auth_methods[0])
+                            });
+                        if let Some(method) = method {
+                            Action::Login(method.clone())
+                        } else {
+                            let ids = self
+                                .auth_methods
+                                .iter()
+                                .map(|method| method.method_id.0.as_ref())
+                                .collect::<Vec<_>>()
+                                .join("|");
+                            self.toast(format!("usage: /login <{ids}>"));
+                            Action::None
+                        }
                     }
                     Parsed::Model { query: Some(query) } => match self.closest_model(query) {
                         Some(choice) => Action::SelectModel {
@@ -3396,7 +3432,9 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use agent_client_protocol::schema::v2::{StopReason, ToolCallStatus, ToolKind};
+    use agent_client_protocol::schema::v2::{
+        AuthMethodTerminal, StopReason, ToolCallStatus, ToolKind,
+    };
     use agentkit_core::{DataRef, Item, ItemKind, MediaPart, MetadataMap, Modality, Part};
     use crossterm::event::{
         KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
@@ -4364,6 +4402,37 @@ mod tests {
             panic!("expected the prompt to be sent");
         };
         assert_eq!(prompt.text, "first line");
+    }
+
+    #[test]
+    fn login_is_exposed_only_for_advertised_terminal_auth_methods() {
+        let mut unavailable = app();
+        unavailable.paste("/login");
+        unavailable.last_key = Some(Instant::now() - Duration::from_millis(500));
+        let Action::Submit { prompt, .. } = unavailable.handle_key(press(KeyCode::Enter)) else {
+            panic!("expected an ordinary prompt");
+        };
+        assert_eq!(prompt.text, "/login");
+
+        let mut available = app();
+        available.auth_methods = vec![
+            AuthMethodTerminal::new("openai", "ChatGPT").args(vec![
+                "auth".into(),
+                "login".into(),
+                "openai".into(),
+            ]),
+            AuthMethodTerminal::new("openrouter", "OpenRouter").args(vec![
+                "auth".into(),
+                "login".into(),
+                "openrouter".into(),
+            ]),
+        ];
+        available.paste("/login openrouter");
+        available.last_key = Some(Instant::now() - Duration::from_millis(500));
+        assert!(matches!(
+            available.handle_key(press(KeyCode::Enter)),
+            Action::Login(method) if method.method_id.0.as_ref() == "openrouter"
+        ));
     }
 
     #[test]

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -135,7 +135,9 @@ pub fn parse(input: &str, login_available: bool) -> Parsed<'_> {
         Kind::Effort => Parsed::Effort { value: prompt },
         Kind::Agents if prompt.is_none() => Parsed::Agents,
         Kind::Agents => Parsed::Prompt(input),
-        Kind::Login => Parsed::Login { method_id: prompt },
+        Kind::Login => Parsed::Login {
+            method_id: prompt.map(str::trim),
+        },
     }
 }
 
@@ -309,10 +311,18 @@ mod tests {
         assert_eq!(known_token("/login", &[]), None);
         assert!(completions("/log", 4, &[]).is_empty());
 
+        for input in ["/login openai", "/login openai ", "/login openai\t"] {
+            assert_eq!(
+                parse_command(input, true),
+                Parsed::Login {
+                    method_id: Some("openai")
+                }
+            );
+        }
         assert_eq!(
-            parse_command("/login openai", true),
-            Parsed::Login {
-                method_id: Some("openai")
+            parse_command("/new keep trailing ", true),
+            Parsed::New {
+                prompt: Some("keep trailing ")
             }
         );
         assert_eq!(find_known_token("/login", &[], true), Some(0..6));

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -14,6 +14,7 @@ enum Kind {
     Model,
     Effort,
     Agents,
+    Login,
 }
 
 struct Spec {
@@ -82,6 +83,11 @@ const LOCAL_COMMANDS: &[Spec] = &[
         description: "Show the agent roster",
         kind: Kind::Agents,
     },
+    Spec {
+        token: "/login",
+        description: "Authenticate with the agent",
+        kind: Kind::Login,
+    },
 ];
 
 #[derive(Debug, PartialEq, Eq)]
@@ -93,6 +99,7 @@ pub enum Parsed<'a> {
     Model { query: Option<&'a str> },
     Effort { value: Option<&'a str> },
     Agents,
+    Login { method_id: Option<&'a str> },
     Prompt(&'a str),
 }
 
@@ -104,16 +111,17 @@ fn token(input: &str) -> (&str, usize) {
     (&input[..token_end], token_end)
 }
 
-fn recognized_local(input: &str) -> Option<(&Spec, usize)> {
+fn recognized_local(input: &str, login_available: bool) -> Option<(&Spec, usize)> {
     let (token, token_end) = token(input);
     LOCAL_COMMANDS
         .iter()
+        .filter(|spec| login_available || !matches!(spec.kind, Kind::Login))
         .find(|spec| spec.token == token)
         .map(|spec| (spec, token_end))
 }
 
-pub fn parse(input: &str) -> Parsed<'_> {
-    let Some((spec, token_end)) = recognized_local(input) else {
+pub fn parse(input: &str, login_available: bool) -> Parsed<'_> {
+    let Some((spec, token_end)) = recognized_local(input, login_available) else {
         return Parsed::Prompt(input);
     };
     let remainder = input[token_end..].trim_start();
@@ -127,12 +135,17 @@ pub fn parse(input: &str) -> Parsed<'_> {
         Kind::Effort => Parsed::Effort { value: prompt },
         Kind::Agents if prompt.is_none() => Parsed::Agents,
         Kind::Agents => Parsed::Prompt(input),
+        Kind::Login => Parsed::Login { method_id: prompt },
     }
 }
 
 /// Byte range of a local or agent-advertised command token.
-pub fn known_token(input: &str, advertised: &[Command]) -> Option<Range<usize>> {
-    if let Some((spec, token_end)) = recognized_local(input) {
+pub fn known_token(
+    input: &str,
+    advertised: &[Command],
+    login_available: bool,
+) -> Option<Range<usize>> {
+    if let Some((spec, token_end)) = recognized_local(input, login_available) {
         if matches!(spec.kind, Kind::Agents) && !input[token_end..].trim().is_empty() {
             return None;
         }
@@ -165,13 +178,19 @@ pub fn completion_prefix(input: &str, cursor: usize) -> Option<&str> {
     prefix.starts_with('/').then_some(prefix)
 }
 
-pub fn completions(input: &str, cursor: usize, advertised: &[Command]) -> Vec<Command> {
+pub fn completions(
+    input: &str,
+    cursor: usize,
+    advertised: &[Command],
+    login_available: bool,
+) -> Vec<Command> {
     let Some(prefix) = completion_prefix(input, cursor) else {
         return Vec::new();
     };
 
     let mut matches: Vec<Command> = LOCAL_COMMANDS
         .iter()
+        .filter(|spec| login_available || !matches!(spec.kind, Kind::Login))
         .filter(|spec| spec.token.starts_with(prefix))
         .map(|spec| Command::new(spec.token, spec.description))
         .collect();
@@ -190,7 +209,22 @@ pub fn completions(input: &str, cursor: usize, advertised: &[Command]) -> Vec<Co
 
 #[cfg(test)]
 mod tests {
-    use super::{Command, Parsed, completions, known_token, parse};
+    use super::{
+        Command, Parsed, completions as complete_commands, known_token as find_known_token,
+        parse as parse_command,
+    };
+
+    fn parse(input: &str) -> Parsed<'_> {
+        parse_command(input, false)
+    }
+
+    fn known_token(input: &str, advertised: &[Command]) -> Option<std::ops::Range<usize>> {
+        find_known_token(input, advertised, false)
+    }
+
+    fn completions(input: &str, cursor: usize, advertised: &[Command]) -> Vec<Command> {
+        complete_commands(input, cursor, advertised, false)
+    }
 
     #[test]
     fn parses_commands_with_or_without_a_following_prompt() {
@@ -266,6 +300,25 @@ mod tests {
             Parsed::New {
                 prompt: Some("next")
             }
+        );
+    }
+
+    #[test]
+    fn login_is_local_only_when_terminal_auth_is_available() {
+        assert_eq!(parse("/login"), Parsed::Prompt("/login"));
+        assert_eq!(known_token("/login", &[]), None);
+        assert!(completions("/log", 4, &[]).is_empty());
+
+        assert_eq!(
+            parse_command("/login openai", true),
+            Parsed::Login {
+                method_id: Some("openai")
+            }
+        );
+        assert_eq!(find_known_token("/login", &[], true), Some(0..6));
+        assert_eq!(
+            complete_commands("/log", 4, &[], true),
+            [Command::new("/login", "Authenticate with the agent")]
         );
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -261,10 +261,17 @@ fn usable_terminal_auth_methods(methods: &[wire::AuthMethod]) -> Vec<wire::AuthM
         .collect()
 }
 
+#[derive(Clone)]
 struct AgentInvocation {
     program: std::ffi::OsString,
     args: Vec<std::ffi::OsString>,
     env: Vec<(std::ffi::OsString, Option<std::ffi::OsString>)>,
+    current_dir: Option<PathBuf>,
+}
+
+struct ReconnectLaunch {
+    resume_session_id: Option<String>,
+    force: bool,
 }
 
 impl AgentInvocation {
@@ -276,8 +283,62 @@ impl AgentInvocation {
                 .get_envs()
                 .map(|(name, value)| (name.to_owned(), value.map(std::ffi::OsStr::to_owned)))
                 .collect(),
+            current_dir: command.get_current_dir().map(Path::to_path_buf),
         }
     }
+
+    fn command(&self) -> tokio::process::Command {
+        let mut command = tokio::process::Command::new(&self.program);
+        command.args(&self.args);
+        if let Some(current_dir) = &self.current_dir {
+            command.current_dir(current_dir);
+        }
+        for (name, value) in &self.env {
+            match value {
+                Some(value) => command.env(name, value),
+                None => command.env_remove(name),
+            };
+        }
+        command
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn agent_command_for_launch(
+    root: &Path,
+    model: &str,
+    provider: crate::ProviderKind,
+    reasoning_effort: Option<crate::ReasoningEffort>,
+    openrouter_api_key: Option<&crate::provider::OpenRouterApiKey>,
+    a2a: Option<&str>,
+    mcp_config: Option<&Path>,
+    telemetry: &crate::telemetry::Settings,
+    credential_storage: &CredentialStorage,
+    session_id: &str,
+    resume: bool,
+    force: bool,
+) -> std::io::Result<tokio::process::Command> {
+    let mut command = crate::acp_child::serve_command(
+        root,
+        model,
+        provider,
+        reasoning_effort,
+        openrouter_api_key,
+        session_id,
+        resume,
+    )?;
+    if let Some(address) = a2a {
+        command.arg("--a2a").arg(address);
+    }
+    if let Some(path) = mcp_config {
+        command.arg("--mcp-config").arg(path);
+    }
+    telemetry.append_cli_args(&mut command);
+    credential_storage.append_cli_args(&mut command);
+    if force {
+        command.arg("--force");
+    }
+    Ok(command)
 }
 
 fn terminal_auth_command(
@@ -285,20 +346,13 @@ fn terminal_auth_command(
     root: &Path,
     method: &wire::AuthMethodTerminal,
 ) -> tokio::process::Command {
-    let mut command = tokio::process::Command::new(&invocation.program);
+    let mut command = invocation.command();
     command
-        .args(&invocation.args)
         .args(&method.args)
         .current_dir(root)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
-    for (name, value) in &invocation.env {
-        match value {
-            Some(value) => command.env(name, value),
-            None => command.env_remove(name),
-        };
-    }
     for variable in &method.env {
         command.env(&variable.name, &variable.value);
     }
@@ -358,23 +412,6 @@ async fn wait_for_terminal_auth(
             let _ = child.kill().await;
             None
         }
-    }
-}
-
-async fn wait_for_initial_session(
-    connection: &agent_client_protocol::V2ConnectionTo<agent_client_protocol::Agent>,
-    resume_id: Option<&str>,
-    root: &Path,
-    stop: &mut Stop,
-) -> Option<Result<(wire::SessionId, Vec<SessionConfigOption>), agent_client_protocol::Error>> {
-    tokio::select! {
-        session = request_initial_session(connection, resume_id, root) => Some(session),
-        () = stop.requested() => None,
-        () = tokio::time::sleep(HANDSHAKE) => Some(Err(
-            agent_client_protocol::Error::into_internal_error(std::io::Error::other(
-                format!("the agent did not start a session within {} seconds", HANDSHAKE.as_secs())
-            ))
-        )),
     }
 }
 
@@ -565,7 +602,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
     let credential_storage =
         credential_storage_for_launch(credential_storage, &std::env::current_dir()?);
     let credential_storage = &credential_storage;
-    let resume_session_id = resume.map(str::to_string);
+    let mut resume_session_id = resume.map(str::to_string);
     let persisted_session_id = resume_session_id
         .clone()
         .unwrap_or_else(crate::session::new_id);
@@ -573,99 +610,112 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
         id: persisted_session_id.clone(),
         generation: 0,
     }));
-    let mut command = crate::acp_child::serve_command(
-        root,
-        model,
-        provider,
-        reasoning_effort,
-        openrouter_api_key,
-        &persisted_session_id,
-        resume_session_id.is_some(),
-    )?;
-    if let Some(address) = a2a {
-        command.arg("--a2a").arg(address);
-    }
-    if let Some(path) = mcp_config {
-        command.arg("--mcp-config").arg(path);
-    }
-    telemetry.append_cli_args(&mut command);
-    credential_storage.append_cli_args(&mut command);
-    if force {
-        command.arg("--force");
-    }
-    let auth_invocation = AgentInvocation::from_command(command.as_std());
-    detach_from_controlling_terminal(&mut command);
-    let mut child = command
-        .env(EVENTS_ENV, "1")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()?;
-    let stdin = child.stdin.take().ok_or("could not open Kit stdin")?;
-    let stdout = child.stdout.take().ok_or("could not open Kit stdout")?;
-    let stderr = child.stderr.take().ok_or("could not open Kit stderr")?;
-    let transport = ByteStreams::new(stdin.compat_write(), stdout.compat());
     let root = root.to_path_buf();
     let model = model.to_string();
-    let a2a = a2a.unwrap_or("allocating…").to_string();
-    let (updates_tx, mut updates_rx) = mpsc::unbounded_channel();
+    let a2a_address = a2a.map(str::to_string);
+    let a2a = a2a_address.clone().unwrap_or_else(|| "allocating…".into());
+    let mcp_config = mcp_config.map(Path::to_path_buf);
+    let mut launch_force = force;
 
-    // The agent's own diagnostics are the only explanation of a failed start,
-    // so they are kept aside as well as shown in the log pane.
-    let recent: Arc<Mutex<Vec<String>>> = Arc::default();
-    let recorder = Arc::clone(&recent);
-    let diagnostics = updates_tx.clone();
-    let stderr_task = tokio::spawn(async move {
-        let mut lines = BufReader::new(stderr).lines();
-        while let Ok(Some(line)) = lines.next_line().await {
-            let update = match events::parse(&line) {
-                Some(event) => Update::Runtime(event),
-                None if line.starts_with("A2A listening on ") => {
-                    Update::A2aAddress(line.trim_start_matches("A2A listening on ").to_string())
-                }
-                None => {
-                    if let Ok(mut recent) = recorder.lock() {
-                        recent.push(line.clone());
-                        let extra = recent.len().saturating_sub(FAILURE_LINES);
-                        recent.drain(..extra);
+    loop {
+        let launch_session_id = resume_session_id
+            .as_deref()
+            .unwrap_or(&persisted_session_id);
+        let mut command = agent_command_for_launch(
+            &root,
+            &model,
+            provider,
+            reasoning_effort,
+            openrouter_api_key,
+            a2a_address.as_deref(),
+            mcp_config.as_deref(),
+            telemetry,
+            credential_storage,
+            launch_session_id,
+            resume_session_id.is_some(),
+            launch_force,
+        )?;
+        let auth_invocation = AgentInvocation::from_command(command.as_std());
+        detach_from_controlling_terminal(&mut command);
+        let mut child = command
+            .env(EVENTS_ENV, "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
+        let stdin = child.stdin.take().ok_or("could not open Kit stdin")?;
+        let stdout = child.stdout.take().ok_or("could not open Kit stdout")?;
+        let stderr = child.stderr.take().ok_or("could not open Kit stderr")?;
+        let transport = ByteStreams::new(stdin.compat_write(), stdout.compat());
+        let (updates_tx, mut updates_rx) = mpsc::unbounded_channel();
+
+        // The agent's own diagnostics are the only explanation of a failed start,
+        // so they are kept aside as well as shown in the log pane.
+        let recent: Arc<Mutex<Vec<String>>> = Arc::default();
+        let recorder = Arc::clone(&recent);
+        let diagnostics = updates_tx.clone();
+        let stderr_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let update = match events::parse(&line) {
+                    Some(event) => Update::Runtime(event),
+                    None if line.starts_with("A2A listening on ") => {
+                        Update::A2aAddress(line.trim_start_matches("A2A listening on ").to_string())
                     }
-                    Update::Log(line)
+                    None => {
+                        if let Ok(mut recent) = recorder.lock() {
+                            recent.push(line.clone());
+                            let extra = recent.len().saturating_sub(FAILURE_LINES);
+                            recent.drain(..extra);
+                        }
+                        Update::Log(line)
+                    }
+                };
+                if diagnostics.send(QueuedUpdate::global(update)).is_err() {
+                    return;
                 }
-            };
-            if diagnostics.send(QueuedUpdate::global(update)).is_err() {
-                return;
             }
-        }
-        // Stderr closing means the agent process is gone; stop any spinner
-        // waiting on a turn that can no longer finish.
-        let _ = diagnostics.send(QueuedUpdate::global(Update::ProcessExited(
-            "the agent process exited — press ctrl+c to leave".into(),
-        )));
-    });
+            // Stderr closing means the agent process is gone; stop any spinner
+            // waiting on a turn that can no longer finish.
+            let _ = diagnostics.send(QueuedUpdate::global(Update::ProcessExited(
+                "the agent process exited — press ctrl+c to leave".into(),
+            )));
+        });
 
-    // The child is watched from its own task, which also owns it: aborting that
-    // task drops the handle, and `kill_on_drop` takes the process with it.
-    let (exit_tx, mut exit_rx) = oneshot::channel();
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    let watcher = tokio::spawn(async move {
-        tokio::select! {
-            status = child.wait() => {
-                let _ = exit_tx.send(status);
+        // The child is watched from its own task, which also owns it: aborting that
+        // task drops the handle, and `kill_on_drop` takes the process with it.
+        let (exit_tx, mut exit_rx) = oneshot::channel();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let watcher = tokio::spawn(async move {
+            tokio::select! {
+                status = child.wait() => {
+                    let _ = exit_tx.send(status);
+                }
+                _ = shutdown_rx => {
+                    // Unlike dropping a `kill_on_drop` child, `kill().await` waits
+                    // until the process is gone and its OS file locks are released.
+                    let _ = child.kill().await;
+                }
             }
-            _ = shutdown_rx => {
-                // Unlike dropping a `kill_on_drop` child, `kill().await` waits
-                // until the process is gone and its OS file locks are released.
-                let _ = child.kill().await;
-            }
-        }
-    });
+        });
 
-    let notifications = updates_tx.clone();
-    let cleanup_root = root.clone();
-    let transition_session = Arc::clone(&active_persisted_id);
-    let notification_session = Arc::clone(&active_persisted_id);
-    let result = agent_client_protocol::Client
+        let notifications = updates_tx.clone();
+        let cleanup_root = root.clone();
+        let transition_session = Arc::clone(&active_persisted_id);
+        let notification_session = Arc::clone(&active_persisted_id);
+        let reconnect_resume = Arc::new(Mutex::new(None));
+        let result = {
+            let root = root.clone();
+            let model = model.clone();
+            let a2a = a2a.clone();
+            let a2a_address = a2a_address.clone();
+            let mcp_config = mcp_config.clone();
+            let auth_invocation = auth_invocation.clone();
+            let resume_session_id = resume_session_id.clone();
+            let launch_force = launch_force;
+            let reconnect_resume = Arc::clone(&reconnect_resume);
+            agent_client_protocol::Client
         .v2()
         .on_receive_notification(
             async move |notification: UpdateSessionNotification, _cx| {
@@ -785,7 +835,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
             let mut app = App::new(
                 root.clone(),
                 provider.as_str().to_string(),
-                model,
+                model.clone(),
                 a2a,
             );
             app.can_steer = can_steer;
@@ -859,26 +909,19 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     let Some(outcome) = authenticated else {
                                         return Ok(());
                                     };
-                                    let mut started = None;
                                     match outcome {
                                         Ok(status) if status.success() => {
-                                            let session = wait_for_initial_session(
-                                                &connection,
-                                                resume_session_id.as_deref(),
-                                                &root,
-                                                &mut stop,
-                                            )
-                                            .await;
-                                            let Some(session) = session else {
-                                                return Ok(());
-                                            };
-                                            match session {
-                                                Ok(session) => started = Some(session),
-                                                Err(error) => app.note(format!(
-                                                    "authentication completed, but the session still could not start: {}",
-                                                    error_detail(&error)
-                                                )),
-                                            }
+                                            // The running agent can retain stale provider state.
+                                            // Retry only after the outer loop has replaced it and
+                                            // negotiated a new ACP connection.
+                                            *reconnect_resume
+                                                .lock()
+                                                .expect("ACP reconnect state poisoned") =
+                                                Some(ReconnectLaunch {
+                                                    resume_session_id: resume_session_id.clone(),
+                                                    force: launch_force,
+                                                });
+                                            return Ok(());
                                         }
                                         Ok(status) => app.note(format!(
                                             "authentication with {} failed: {status}",
@@ -893,9 +936,6 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                         agent_client_protocol::Error::into_internal_error,
                                     )?;
                                     events = EventStream::new();
-                                    if let Some(session) = started {
-                                        break session;
-                                    }
                                 }
                                 Action::None | Action::Redraw => {}
                                 _ => app.note("authenticate before starting a session"),
@@ -1246,8 +1286,31 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                 }
                                 Action::Login(method) => {
                                     drop(events);
+                                    let refreshed_id = durable_session_id(&session_id)
+                                        .map_err(|error| {
+                                            agent_client_protocol::Error::into_internal_error(
+                                                std::io::Error::other(error),
+                                            )
+                                        })?;
+                                    let current_auth_command = agent_command_for_launch(
+                                        &root,
+                                        &model,
+                                        provider,
+                                        reasoning_effort,
+                                        openrouter_api_key,
+                                        a2a_address.as_deref(),
+                                        mcp_config.as_deref(),
+                                        telemetry,
+                                        credential_storage,
+                                        &refreshed_id,
+                                        true,
+                                        false,
+                                    )
+                                    .map_err(agent_client_protocol::Error::into_internal_error)?;
+                                    let current_auth_invocation =
+                                        AgentInvocation::from_command(current_auth_command.as_std());
                                     let authentication = authenticate_in_terminal(
-                                        &auth_invocation,
+                                        &current_auth_invocation,
                                         &root,
                                         &method,
                                         &mut stop,
@@ -1281,70 +1344,19 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     let Some(outcome) = authenticated else {
                                         return Ok(());
                                     };
-                                    let mut refreshed = None;
                                     match outcome {
                                         Ok(status) if status.success() => {
-                                            let refreshed_id = durable_session_id(&session_id)
-                                                .map_err(|error| {
-                                                    agent_client_protocol::Error::into_internal_error(
-                                                        std::io::Error::other(error),
-                                                    )
-                                                })?;
-                                            let closed = tokio::time::timeout(
-                                                CLOSE_SESSION,
-                                                connection
-                                                    .send_request(CloseSessionRequest::new(
-                                                        session_id.clone(),
-                                                    ))
-                                                    .block_task(),
-                                            )
-                                            .await;
-                                            match closed {
-                                                Ok(Ok(_)) => {
-                                                    transition_route(
-                                                        &transition_session,
-                                                        refreshed_id.clone(),
-                                                    );
-                                                    images.clear();
-                                                    app.start_session(refreshed_id.clone());
-                                                    let resumed = wait_for_initial_session(
-                                                        &connection,
-                                                        Some(&refreshed_id),
-                                                        &root,
-                                                        &mut stop,
-                                                    )
-                                                    .await;
-                                                    let Some(resumed) = resumed else {
-                                                        return Ok(());
-                                                    };
-                                                    match resumed {
-                                                        Ok(session) => refreshed = Some(session),
-                                                        Err(error) => {
-                                                            return Err(agent_client_protocol::Error::into_internal_error(
-                                                                std::io::Error::other(format!(
-                                                                    "authentication completed, but the session could not restart: {}",
-                                                                    error_detail(&error)
-                                                                )),
-                                                            ));
-                                                        }
-                                                    }
-                                                }
-                                                Ok(Err(error)) => {
-                                                    return Err(agent_client_protocol::Error::into_internal_error(
-                                                        std::io::Error::other(format!(
-                                                            "authentication completed, but the session could not close for refresh: {}",
-                                                            error_detail(&error)
-                                                        )),
-                                                    ));
-                                                }
-                                                Err(_) => {
-                                                    return Err(agent_client_protocol::Error::into_internal_error(
-                                                        std::io::Error::other(
-                                                            "authentication completed, but session refresh timed out",
-                                                        ),
-                                                    ));
-                                                }
-                                            }
+                                            // Closing this callback closes the ACP connection;
+                                            // the outer loop then reaps this child before resuming
+                                            // the session on a newly initialized agent.
+                                            *reconnect_resume
+                                                .lock()
+                                                .expect("ACP reconnect state poisoned") =
+                                                Some(ReconnectLaunch {
+                                                    resume_session_id: Some(refreshed_id),
+                                                    force: false,
+                                                });
+                                            return Ok(());
                                         }
                                         Ok(status) => app.note(format!(
                                             "authentication with {} failed: {status}",
@@ -1359,14 +1371,6 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                         agent_client_protocol::Error::into_internal_error,
                                     )?;
                                     events = EventStream::new();
-                                    if let Some((resumed_id, options)) = refreshed {
-                                        session_id = resumed_id;
-                                        refresh_config_state(&mut app, Some(&options));
-                                        app.note(format!(
-                                            "authentication completed with {}",
-                                            method.name
-                                        ));
-                                    }
                                 }
                                 Action::Copy(text) => {
                                     execute!(terminal.backend_mut(), Print(osc52(&text)))
@@ -1465,21 +1469,36 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
             Ok(())
         })
         .await
-        .map_err(explain);
+        .map_err(explain)
+        };
 
-    // The A2A listener keeps the child alive after ACP closes. Stop it only
-    // after CloseSession has unwound the lock owner, then wait for OS locks to
-    // be released rather than relying on `kill_on_drop`.
-    let _ = shutdown_tx.send(());
-    let _ = watcher.await;
-    // If the server failed before acknowledging CloseSession, reclaim only a
-    // lock that is now provably stale; a live owner's OS lock is never stolen.
-    if let Ok(active) = active_persisted_id.lock() {
-        let _ = crate::session::remove_stale_lock(&cleanup_root, &active.id);
+        // The A2A listener keeps the child alive after ACP closes. Stop it only
+        // after CloseSession has unwound the lock owner, then wait for OS locks to
+        // be released rather than relying on `kill_on_drop`.
+        let _ = shutdown_tx.send(());
+        // Keep this await before the reconnect check: a replacement must not
+        // start until the old ACP process has been killed and reaped.
+        let _ = watcher.await;
+        // If the server failed before acknowledging CloseSession, reclaim only a
+        // lock that is now provably stale; a live owner's OS lock is never stolen.
+        if let Ok(active) = active_persisted_id.lock() {
+            let _ = crate::session::remove_stale_lock(&cleanup_root, &active.id);
+        }
+
+        let reconnect = reconnect_resume
+            .lock()
+            .ok()
+            .and_then(|mut reconnect| reconnect.take());
+        if result.is_ok()
+            && let Some(reconnect) = reconnect
+        {
+            resume_session_id = reconnect.resume_session_id;
+            launch_force = reconnect.force;
+            continue;
+        }
+        result?;
+        return Ok(());
     }
-
-    result?;
-    Ok(())
 }
 
 fn save_effort_default(effort: &str) -> Result<(), String> {
@@ -2273,19 +2292,27 @@ mod tests {
 
     use super::{
         ActiveSessionRoute, AgentInvocation, ConnectedAuthentication, MAX_ATTACHMENTS, MAX_BURST,
-        ModelChoice, QueuedUpdate, accept_queued_update, apply_pending_updates,
-        attachments_from_paste, authentication_required, client_capabilities, command,
-        credential_storage_for_launch, current_model_choice, detach_from_controlling_terminal,
-        durable_session_id, effort_state, error_detail, handle, message_of, osc52,
-        previous_session_for_resume, prompt_blocks, readable, refresh_config_state,
-        save_effort_default_to, save_model_defaults_to, terminal_auth_command, transition_route,
-        translate, translate_for_session, usable_terminal_auth_methods, user_message_of,
-        wait_for_connected_authentication, wire,
+        ModelChoice, QueuedUpdate, accept_queued_update, agent_command_for_launch,
+        apply_pending_updates, attachments_from_paste, authentication_required,
+        client_capabilities, command, credential_storage_for_launch, current_model_choice,
+        detach_from_controlling_terminal, durable_session_id, effort_state, error_detail, handle,
+        message_of, osc52, previous_session_for_resume, prompt_blocks, readable,
+        refresh_config_state, save_effort_default_to, save_model_defaults_to,
+        terminal_auth_command, transition_route, translate, translate_for_session,
+        usable_terminal_auth_methods, user_message_of, wait_for_connected_authentication, wire,
     };
     use crate::{
         tools::mcp::CredentialStorage,
         tui::app::{App, SessionDialog, SessionRename, SubmittedPrompt, Update},
     };
+
+    fn command_args(command: &tokio::process::Command) -> Vec<String> {
+        command
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
 
     #[test]
     fn only_authentication_failures_enter_login_recovery() {
@@ -2375,11 +2402,87 @@ mod tests {
     }
 
     #[test]
-    fn terminal_auth_command_appends_to_agent_invocation() {
+    fn reconnect_launch_tracks_transitioned_session_and_preserves_base_options() {
         let root = tempfile::tempdir().unwrap();
+        let mcp_config = root.path().join("mcp.toml");
+        let telemetry = crate::telemetry::Settings::try_new(None, false, 12, 4096).unwrap();
+        let credentials = CredentialStorage::Memory;
+        let resumed = agent_command_for_launch(
+            root.path(),
+            "test",
+            crate::ProviderKind::Speakeasy,
+            None,
+            None,
+            Some("127.0.0.1:0"),
+            Some(&mcp_config),
+            &telemetry,
+            &credentials,
+            "B",
+            true,
+            false,
+        )
+        .unwrap();
+        let resumed_args = command_args(&resumed);
+        assert!(
+            resumed_args
+                .windows(2)
+                .any(|args| args == ["--session-id", "B"])
+        );
+        assert!(resumed_args.iter().any(|arg| arg == "--resume"));
+        assert!(!resumed_args.iter().any(|arg| arg == "A"));
+
+        let invocation = AgentInvocation::from_command(resumed.as_std());
+        let method = AuthMethodTerminal::new("openai", "ChatGPT")
+            .args(vec!["--terminal-auth-login".into(), "openai".into()]);
+        let terminal_auth = terminal_auth_command(&invocation, root.path(), &method);
+        let terminal_auth_args = command_args(&terminal_auth);
+        assert!(
+            terminal_auth_args
+                .windows(2)
+                .any(|args| args == ["--session-id", "B"])
+        );
+        assert!(terminal_auth_args.iter().any(|arg| arg == "--resume"));
+        assert!(!terminal_auth_args.iter().any(|arg| arg == "A"));
+
+        let new_session = agent_command_for_launch(
+            root.path(),
+            "test",
+            crate::ProviderKind::Speakeasy,
+            None,
+            None,
+            Some("127.0.0.1:0"),
+            Some(&mcp_config),
+            &telemetry,
+            &credentials,
+            "C",
+            false,
+            false,
+        )
+        .unwrap();
+        let new_args = command_args(&new_session);
+        assert!(
+            new_args
+                .windows(2)
+                .any(|args| args == ["--session-id", "C"])
+        );
+        assert!(!new_args.iter().any(|arg| arg == "--resume"));
+        assert!(!new_args.iter().any(|arg| matches!(arg.as_str(), "A" | "B")));
+        for args in [&resumed_args, &new_args] {
+            assert!(args.windows(2).any(|args| args == ["--a2a", "127.0.0.1:0"]));
+            assert!(args.windows(2).any(|args| {
+                args[0] == "--mcp-config" && args[1] == mcp_config.to_string_lossy()
+            }));
+        }
+    }
+
+    #[test]
+    fn terminal_auth_preserves_base_invocation_for_reconnect() {
+        let root = tempfile::tempdir().unwrap();
+        let base_root = tempfile::tempdir().unwrap();
         let credentials = root.path().join("credentials");
         let mut base = tokio::process::Command::new("kit-agent");
         base.args(["serve", "--model", "test-model"]);
+        base.current_dir(base_root.path());
         CredentialStorage::Filesystem(credentials.clone()).append_cli_args(&mut base);
         base.env("KIT_BASE_TEST", "base");
         let invocation = AgentInvocation::from_command(base.as_std());
@@ -2387,14 +2490,13 @@ mod tests {
             .args(vec!["--terminal-auth-login".into(), "openai".into()])
             .env(vec![EnvVariable::new("KIT_AUTH_TEST", "set")]);
         let command = terminal_auth_command(&invocation, root.path(), &method);
-        let command = command.as_std();
-        assert_eq!(command.get_program(), std::ffi::OsStr::new("kit-agent"));
-        assert_eq!(command.get_current_dir(), Some(root.path()));
         assert_eq!(
-            command
-                .get_args()
-                .map(|arg| arg.to_string_lossy().into_owned())
-                .collect::<Vec<_>>(),
+            command.as_std().get_program(),
+            std::ffi::OsStr::new("kit-agent")
+        );
+        assert_eq!(command.as_std().get_current_dir(), Some(root.path()));
+        assert_eq!(
+            command_args(&command),
             [
                 "serve",
                 "--model",
@@ -2407,12 +2509,43 @@ mod tests {
                 "openai",
             ]
         );
-        assert!(command.get_envs().any(|(name, value)| {
+        assert!(command.as_std().get_envs().any(|(name, value)| {
             name == "KIT_BASE_TEST" && value == Some(std::ffi::OsStr::new("base"))
         }));
-        assert!(command.get_envs().any(|(name, value)| {
+        assert!(command.as_std().get_envs().any(|(name, value)| {
             name == "KIT_AUTH_TEST" && value == Some(std::ffi::OsStr::new("set"))
         }));
+
+        let replacement = invocation.command();
+        assert_eq!(
+            replacement.as_std().get_program(),
+            std::ffi::OsStr::new("kit-agent")
+        );
+        assert_eq!(
+            replacement.as_std().get_current_dir(),
+            Some(base_root.path())
+        );
+        assert_eq!(
+            command_args(&replacement),
+            [
+                "serve",
+                "--model",
+                "test-model",
+                "--credential-store",
+                "file",
+                "--credential-dir",
+                credentials.to_str().unwrap(),
+            ]
+        );
+        assert!(replacement.as_std().get_envs().any(|(name, value)| {
+            name == "KIT_BASE_TEST" && value == Some(std::ffi::OsStr::new("base"))
+        }));
+        assert!(
+            replacement
+                .as_std()
+                .get_envs()
+                .all(|(name, _)| name != "KIT_AUTH_TEST")
+        );
     }
 
     #[cfg(unix)]
@@ -3080,11 +3213,7 @@ a = [still text]
         .unwrap();
         let mut command = tokio::process::Command::new("kit");
         settings.append_cli_args(&mut command);
-        let args: Vec<_> = command
-            .as_std()
-            .get_args()
-            .map(|value| value.to_string_lossy().into_owned())
-            .collect();
+        let args = command_args(&command);
         assert_eq!(
             args,
             [

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -193,16 +193,18 @@ fn authentication_required(
     error: &agent_client_protocol::Error,
     methods: &[wire::AuthMethodTerminal],
 ) -> bool {
-    let Some(required) = error
+    if error.code != agent_client_protocol::ErrorCode::AuthRequired {
+        return false;
+    }
+    error
         .data
         .as_ref()
         .and_then(crate::protocols::acp::AuthenticationRequiredData::from_value)
-    else {
-        return false;
-    };
-    methods
-        .iter()
-        .any(|method| method.method_id.0.as_ref() == required.method_id)
+        .is_none_or(|required| {
+            methods
+                .iter()
+                .any(|method| method.method_id.0.as_ref() == required.method_id)
+        })
 }
 
 fn credential_storage_for_launch(
@@ -231,9 +233,7 @@ fn usable_terminal_auth_methods(methods: &[wire::AuthMethod]) -> Vec<wire::AuthM
     methods
         .iter()
         .filter_map(|method| match method {
-            wire::AuthMethod::Terminal(method)
-                if !method.method_id.0.is_empty() && !method.args.is_empty() =>
-            {
+            wire::AuthMethod::Terminal(method) if !method.method_id.0.is_empty() => {
                 Some(method.clone())
             }
             _ => None,
@@ -241,20 +241,44 @@ fn usable_terminal_auth_methods(methods: &[wire::AuthMethod]) -> Vec<wire::AuthM
         .collect()
 }
 
+struct AgentInvocation {
+    program: std::ffi::OsString,
+    args: Vec<std::ffi::OsString>,
+    env: Vec<(std::ffi::OsString, Option<std::ffi::OsString>)>,
+}
+
+impl AgentInvocation {
+    fn from_command(command: &std::process::Command) -> Self {
+        Self {
+            program: command.get_program().to_owned(),
+            args: command.get_args().map(std::ffi::OsStr::to_owned).collect(),
+            env: command
+                .get_envs()
+                .map(|(name, value)| (name.to_owned(), value.map(std::ffi::OsStr::to_owned)))
+                .collect(),
+        }
+    }
+}
+
 fn terminal_auth_command(
-    program: &std::ffi::OsStr,
+    invocation: &AgentInvocation,
     root: &Path,
-    credential_storage: &CredentialStorage,
     method: &wire::AuthMethodTerminal,
 ) -> tokio::process::Command {
-    let mut command = tokio::process::Command::new(program);
+    let mut command = tokio::process::Command::new(&invocation.program);
     command
+        .args(&invocation.args)
         .args(&method.args)
         .current_dir(root)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
-    credential_storage.append_cli_args(&mut command);
+    for (name, value) in &invocation.env {
+        match value {
+            Some(value) => command.env(name, value),
+            None => command.env_remove(name),
+        };
+    }
     for variable in &method.env {
         command.env(&variable.name, &variable.value);
     }
@@ -263,19 +287,14 @@ fn terminal_auth_command(
 
 async fn authenticate_in_terminal(
     terminal: &mut DefaultTerminal,
-    program: &std::ffi::OsStr,
+    invocation: &AgentInvocation,
     root: &Path,
-    credential_storage: &CredentialStorage,
     method: &wire::AuthMethodTerminal,
     stop: &mut Stop,
 ) -> Option<std::io::Result<std::process::ExitStatus>> {
     leave(terminal);
     println!("Starting {}…", method.name);
-    wait_for_terminal_auth(
-        terminal_auth_command(program, root, credential_storage, method),
-        stop,
-    )
-    .await
+    wait_for_terminal_auth(terminal_auth_command(invocation, root, method), stop).await
 }
 
 async fn wait_for_terminal_auth(
@@ -527,7 +546,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
     if force {
         command.arg("--force");
     }
-    let auth_program = command.as_std().get_program().to_owned();
+    let auth_invocation = AgentInvocation::from_command(command.as_std());
     detach_from_controlling_terminal(&mut command);
     let mut child = command
         .env(EVENTS_ENV, "1")
@@ -753,9 +772,8 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     drop(events);
                                     let authenticated = authenticate_in_terminal(
                                         &mut terminal,
-                                        &auth_program,
+                                        &auth_invocation,
                                         &root,
-                                        credential_storage,
                                         &method,
                                         &mut stop,
                                     )
@@ -1152,9 +1170,8 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     drop(events);
                                     let authenticated = authenticate_in_terminal(
                                         &mut terminal,
-                                        &auth_program,
+                                        &auth_invocation,
                                         &root,
-                                        credential_storage,
                                         &method,
                                         &mut stop,
                                     )
@@ -2164,13 +2181,14 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        ActiveSessionRoute, MAX_ATTACHMENTS, ModelChoice, QueuedUpdate, accept_queued_update,
-        attachments_from_paste, authentication_required, client_capabilities, command,
-        credential_storage_for_launch, current_model_choice, detach_from_controlling_terminal,
-        durable_session_id, effort_state, error_detail, handle, message_of, osc52,
-        previous_session_for_resume, prompt_blocks, readable, refresh_config_state,
-        save_effort_default_to, save_model_defaults_to, terminal_auth_command, transition_route,
-        translate, translate_for_session, usable_terminal_auth_methods, user_message_of, wire,
+        ActiveSessionRoute, AgentInvocation, MAX_ATTACHMENTS, ModelChoice, QueuedUpdate,
+        accept_queued_update, attachments_from_paste, authentication_required, client_capabilities,
+        command, credential_storage_for_launch, current_model_choice,
+        detach_from_controlling_terminal, durable_session_id, effort_state, error_detail, handle,
+        message_of, osc52, previous_session_for_resume, prompt_blocks, readable,
+        refresh_config_state, save_effort_default_to, save_model_defaults_to,
+        terminal_auth_command, transition_route, translate, translate_for_session,
+        usable_terminal_auth_methods, user_message_of, wire,
     };
     use crate::{
         tools::mcp::CredentialStorage,
@@ -2186,7 +2204,7 @@ mod tests {
                 "openrouter".into(),
             ]),
         ];
-        let required = agent_client_protocol::Error::internal_error().data(
+        let required = agent_client_protocol::Error::auth_required().data(
             crate::protocols::acp::AuthenticationRequiredData::new(
                 "openrouter",
                 "run `kit auth login openrouter` before using OpenRouter",
@@ -2194,6 +2212,14 @@ mod tests {
             .into_value(),
         );
         assert!(authentication_required(&required, &methods));
+        assert!(authentication_required(
+            &agent_client_protocol::Error::auth_required(),
+            &methods,
+        ));
+        assert!(!authentication_required(
+            &agent_client_protocol::Error::internal_error().data(required.data.clone()),
+            &methods,
+        ));
         assert_eq!(
             error_detail(&required),
             "run `kit auth login openrouter` before using OpenRouter"
@@ -2205,9 +2231,9 @@ mod tests {
             &methods,
         ));
         assert!(!authentication_required(
-            &agent_client_protocol::Error::internal_error().data(
+            &agent_client_protocol::Error::auth_required().data(
                 crate::protocols::acp::AuthenticationRequiredData::new(
-                    "speakeasy",
+                    "unadvertised",
                     "authentication required",
                 )
                 .into_value(),
@@ -2251,23 +2277,24 @@ mod tests {
             ])),
         ];
         let usable = usable_terminal_auth_methods(&methods);
-        assert_eq!(usable.len(), 1);
-        assert_eq!(usable[0].method_id.0.as_ref(), "openai");
+        assert_eq!(usable.len(), 2);
+        assert_eq!(usable[0].method_id.0.as_ref(), "empty");
+        assert_eq!(usable[1].method_id.0.as_ref(), "openai");
     }
 
     #[test]
-    fn terminal_auth_command_uses_advertised_args_env_and_credentials() {
+    fn terminal_auth_command_appends_to_agent_invocation() {
         let root = tempfile::tempdir().unwrap();
         let credentials = root.path().join("credentials");
+        let mut base = tokio::process::Command::new("kit-agent");
+        base.args(["serve", "--model", "test-model"]);
+        CredentialStorage::Filesystem(credentials.clone()).append_cli_args(&mut base);
+        base.env("KIT_BASE_TEST", "base");
+        let invocation = AgentInvocation::from_command(base.as_std());
         let method = AuthMethodTerminal::new("openai", "ChatGPT")
-            .args(vec!["auth".into(), "login".into(), "openai".into()])
+            .args(vec!["--terminal-auth-login".into(), "openai".into()])
             .env(vec![EnvVariable::new("KIT_AUTH_TEST", "set")]);
-        let command = terminal_auth_command(
-            std::ffi::OsStr::new("kit-agent"),
-            root.path(),
-            &CredentialStorage::Filesystem(credentials.clone()),
-            &method,
-        );
+        let command = terminal_auth_command(&invocation, root.path(), &method);
         let command = command.as_std();
         assert_eq!(command.get_program(), std::ffi::OsStr::new("kit-agent"));
         assert_eq!(command.get_current_dir(), Some(root.path()));
@@ -2277,15 +2304,20 @@ mod tests {
                 .map(|arg| arg.to_string_lossy().into_owned())
                 .collect::<Vec<_>>(),
             [
-                "auth",
-                "login",
-                "openai",
+                "serve",
+                "--model",
+                "test-model",
                 "--credential-store",
                 "file",
                 "--credential-dir",
                 credentials.to_str().unwrap(),
+                "--terminal-auth-login",
+                "openai",
             ]
         );
+        assert!(command.get_envs().any(|(name, value)| {
+            name == "KIT_BASE_TEST" && value == Some(std::ffi::OsStr::new("base"))
+        }));
         assert!(command.get_envs().any(|(name, value)| {
             name == "KIT_AUTH_TEST" && value == Some(std::ffi::OsStr::new("set"))
         }));

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -39,6 +39,7 @@ use crossterm::{
     },
     execute,
     style::Print,
+    terminal::EnterAlternateScreen,
 };
 use futures_util::StreamExt;
 use ratatui::DefaultTerminal;
@@ -177,6 +178,154 @@ fn detach_from_controlling_terminal(command: &mut tokio::process::Command) {
 
 #[cfg(windows)]
 fn detach_from_controlling_terminal(_command: &mut tokio::process::Command) {}
+
+fn error_detail(error: &agent_client_protocol::Error) -> &str {
+    match error.data.as_ref() {
+        Some(Value::String(detail)) => detail,
+        _ => &error.message,
+    }
+}
+
+fn authentication_required(
+    error: &agent_client_protocol::Error,
+    methods: &[wire::AuthMethodTerminal],
+) -> bool {
+    let detail = error_detail(error).to_ascii_lowercase();
+    methods.iter().any(|method| {
+        let method_id = method.method_id.0.to_ascii_lowercase();
+        !method_id.is_empty() && detail.contains(method_id.as_str())
+    })
+}
+
+fn credential_storage_for_launch(
+    credential_storage: &CredentialStorage,
+    current_dir: &Path,
+) -> CredentialStorage {
+    match credential_storage {
+        CredentialStorage::Filesystem(directory) if directory.is_relative() => {
+            CredentialStorage::Filesystem(current_dir.join(directory))
+        }
+        credential_storage => credential_storage.clone(),
+    }
+}
+
+fn client_capabilities(credential_storage: &CredentialStorage) -> wire::ClientCapabilities {
+    let capabilities = wire::ClientCapabilities::new();
+    if credential_storage.is_persistent() {
+        capabilities
+            .auth(wire::AuthCapabilities::new().terminal(wire::TerminalAuthCapabilities::new()))
+    } else {
+        capabilities
+    }
+}
+
+fn usable_terminal_auth_methods(methods: &[wire::AuthMethod]) -> Vec<wire::AuthMethodTerminal> {
+    methods
+        .iter()
+        .filter_map(|method| match method {
+            wire::AuthMethod::Terminal(method)
+                if !method.method_id.0.is_empty() && !method.args.is_empty() =>
+            {
+                Some(method.clone())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn terminal_auth_command(
+    program: &std::ffi::OsStr,
+    root: &Path,
+    credential_storage: &CredentialStorage,
+    method: &wire::AuthMethodTerminal,
+) -> tokio::process::Command {
+    let mut command = tokio::process::Command::new(program);
+    command
+        .args(&method.args)
+        .current_dir(root)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    credential_storage.append_cli_args(&mut command);
+    for variable in &method.env {
+        command.env(&variable.name, &variable.value);
+    }
+    command
+}
+
+async fn authenticate_in_terminal(
+    terminal: &mut DefaultTerminal,
+    program: &std::ffi::OsStr,
+    root: &Path,
+    credential_storage: &CredentialStorage,
+    method: &wire::AuthMethodTerminal,
+    stop: &mut Stop,
+) -> Option<std::io::Result<std::process::ExitStatus>> {
+    leave(terminal);
+    println!("Starting {}…", method.name);
+    wait_for_terminal_auth(
+        terminal_auth_command(program, root, credential_storage, method),
+        stop,
+    )
+    .await
+}
+
+async fn wait_for_terminal_auth(
+    mut command: tokio::process::Command,
+    stop: &mut Stop,
+) -> Option<std::io::Result<std::process::ExitStatus>> {
+    let child = command.kill_on_drop(true).spawn();
+    let Ok(mut child) = child else {
+        return Some(child.map(|_| unreachable!()));
+    };
+    tokio::select! {
+        status = child.wait() => Some(status),
+        () = stop.requested() => {
+            let _ = child.kill().await;
+            None
+        }
+    }
+}
+
+async fn wait_for_initial_session(
+    connection: &agent_client_protocol::V2ConnectionTo<agent_client_protocol::Agent>,
+    resume_id: Option<&str>,
+    root: &Path,
+    stop: &mut Stop,
+) -> Option<Result<(wire::SessionId, Vec<SessionConfigOption>), agent_client_protocol::Error>> {
+    tokio::select! {
+        session = request_initial_session(connection, resume_id, root) => Some(session),
+        () = stop.requested() => None,
+        () = tokio::time::sleep(HANDSHAKE) => Some(Err(
+            agent_client_protocol::Error::into_internal_error(std::io::Error::other(
+                format!("the agent did not start a session within {} seconds", HANDSHAKE.as_secs())
+            ))
+        )),
+    }
+}
+
+async fn request_initial_session(
+    connection: &agent_client_protocol::V2ConnectionTo<agent_client_protocol::Agent>,
+    resume_id: Option<&str>,
+    root: &Path,
+) -> Result<(wire::SessionId, Vec<SessionConfigOption>), agent_client_protocol::Error> {
+    if let Some(resume_id) = resume_id {
+        let response = connection
+            .send_request(
+                wire::ResumeSessionRequest::new(resume_id, root.to_path_buf())
+                    .replay_from(wire::ReplayFrom::Start(wire::ReplayFromStart::new())),
+            )
+            .block_task()
+            .await?;
+        Ok((wire::SessionId::new(resume_id), response.config_options))
+    } else {
+        let response = connection
+            .send_request(wire::NewSessionRequest::new(root.to_path_buf()))
+            .block_task()
+            .await?;
+        Ok((response.session_id, response.config_options))
+    }
+}
 
 fn current_model_choice(options: Option<&[SessionConfigOption]>) -> Option<ModelChoice> {
     let current = options
@@ -339,6 +488,9 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
     let root = &root
         .canonicalize()
         .map_err(|error| Failure(format!("{}: {error}", root.display())))?;
+    let credential_storage =
+        credential_storage_for_launch(credential_storage, &std::env::current_dir()?);
+    let credential_storage = &credential_storage;
     let resume_session_id = resume.map(str::to_string);
     let persisted_session_id = resume_session_id
         .clone()
@@ -363,15 +515,11 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
         command.arg("--mcp-config").arg(path);
     }
     telemetry.append_cli_args(&mut command);
-    command
-        .arg("--credential-store")
-        .arg(credential_storage.cli_name());
-    if let Some(directory) = credential_storage.directory() {
-        command.arg("--credential-dir").arg(directory);
-    }
+    credential_storage.append_cli_args(&mut command);
     if force {
         command.arg("--force");
     }
+    let auth_program = command.as_std().get_program().to_owned();
     detach_from_controlling_terminal(&mut command);
     let mut child = command
         .env(EVENTS_ENV, "1")
@@ -424,7 +572,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
 
     // The child is watched from its own task, which also owns it: aborting that
     // task drops the handle, and `kill_on_drop` takes the process with it.
-    let (exit_tx, exit_rx) = oneshot::channel();
+    let (exit_tx, mut exit_rx) = oneshot::channel();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let watcher = tokio::spawn(async move {
         tokio::select! {
@@ -470,47 +618,21 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
             // credentials — leaves its half of the handshake unanswered, and
             // waiting on it forever shows the user nothing at all. Its exit and
             // its silence both end the wait with something to read.
-            let handshake = async {
-                let initialized = connection
-                    .send_request(wire::InitializeRequest::new(
+            let initialize = connection
+                .send_request(
+                    wire::InitializeRequest::new(
                         ProtocolVersion::V2,
-                        wire::Implementation::new("kit-tui", env!("CARGO_PKG_VERSION")),
-                    ))
-                    .block_task()
-                    .await?;
-                if initialized.protocol_version != ProtocolVersion::V2 {
-                    return Err(agent_client_protocol::Error::into_internal_error(
-                        std::io::Error::other("the agent did not negotiate ACP v2"),
-                    ));
-                }
-                let can_steer = initialized.capabilities.session.as_ref()
-                    .and_then(|session| session.inject.as_ref())
-                    .is_some_and(|inject| {
-                        inject.modes.contains(&wire::SessionInjectMode::Steer)
-                            && inject.steer_in_stream.as_ref().is_some_and(|modes| {
-                                modes.contains(&wire::SessionInjectSteerInStream::Finish)
-                            })
-                    });
-                if let Some(resume_id) = resume_session_id.clone() {
-                    let response = connection
-                        .send_request(
-                            wire::ResumeSessionRequest::new(resume_id.clone(), root.clone())
-                                .replay_from(wire::ReplayFrom::Start(wire::ReplayFromStart::new())),
-                        )
-                        .block_task()
-                        .await?;
-                    Ok((wire::SessionId::new(resume_id), response.config_options, can_steer))
-                } else {
-                    let response = connection
-                        .send_request(wire::NewSessionRequest::new(root.clone()))
-                        .block_task()
-                        .await?;
-                    Ok((response.session_id, response.config_options, can_steer))
-                }
-            };
-            let session = tokio::select! {
-                session = handshake => session?,
-                status = exit_rx => {
+                        wire::Implementation::new(
+                            "kit-tui",
+                            env!("CARGO_PKG_VERSION"),
+                        ),
+                    )
+                    .capabilities(client_capabilities(credential_storage)),
+                )
+                .block_task();
+            let initialized = tokio::select! {
+                initialized = initialize => initialized?,
+                status = &mut exit_rx => {
                     return Err(agent_client_protocol::Error::into_internal_error(
                         std::io::Error::other(died(status.ok().and_then(Result::ok), stderr_task, &recent).await),
                     ));
@@ -524,10 +646,55 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                     ));
                 }
             };
-            let (mut session_id, config_options, can_steer) = session;
-            let active_session_id = durable_session_id(&session_id).map_err(|error| {
-                agent_client_protocol::Error::into_internal_error(std::io::Error::other(error))
-            })?;
+            if initialized.protocol_version != ProtocolVersion::V2 {
+                return Err(agent_client_protocol::Error::into_internal_error(
+                    std::io::Error::other("the agent did not negotiate ACP v2"),
+                ));
+            }
+            let auth_methods = usable_terminal_auth_methods(&initialized.auth_methods);
+            let can_steer = initialized.capabilities.session.as_ref()
+                .and_then(|session| session.inject.as_ref())
+                .is_some_and(|inject| {
+                    inject.modes.contains(&wire::SessionInjectMode::Steer)
+                        && inject.steer_in_stream.as_ref().is_some_and(|modes| {
+                            modes.contains(&wire::SessionInjectSteerInStream::Finish)
+                        })
+                });
+
+            let initial = tokio::select! {
+                session = request_initial_session(
+                    &connection,
+                    resume_session_id.as_deref(),
+                    &root,
+                ) => session,
+                status = &mut exit_rx => {
+                    return Err(agent_client_protocol::Error::into_internal_error(
+                        std::io::Error::other(died(
+                            status.ok().and_then(Result::ok),
+                            stderr_task,
+                            &recent,
+                        ).await),
+                    ));
+                }
+                () = tokio::time::sleep(HANDSHAKE) => {
+                    return Err(agent_client_protocol::Error::into_internal_error(
+                        std::io::Error::other(format!(
+                            "the agent did not start a session within {} seconds",
+                            HANDSHAKE.as_secs()
+                        )),
+                    ));
+                }
+            };
+            let initial = match initial {
+                Err(error)
+                    if auth_methods.is_empty()
+                        || !authentication_required(&error, &auth_methods) =>
+                {
+                    return Err(error);
+                }
+                result => result,
+            };
+
             // Install every fallible signal handler before changing terminal modes so
             // an installation failure cannot leave the caller's terminal altered.
             let mut stop =
@@ -540,15 +707,126 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                 model,
                 a2a,
             );
-            refresh_config_state(&mut app, Some(&config_options));
             app.can_steer = can_steer;
-            if let Ok(mut active) = transition_session.lock() {
-                active.id = active_session_id.clone();
-            }
-            app.start_session(active_session_id);
+            app.auth_methods = auth_methods;
             let mut events = EventStream::new();
             let mut ticker = tokio::time::interval(TICK);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            let (mut session_id, config_options) = match initial {
+                Ok(session) => session,
+                Err(session_error) => {
+                    app.note(format!(
+                        "could not start the session: {}; use /login to authenticate",
+                        error_detail(&session_error)
+                    ));
+                    loop {
+                    if let Err(error) =
+                        terminal.draw(|frame| ui::draw(frame, &mut app, &mut images))
+                    {
+                        leave(&mut terminal);
+                        return Err(agent_client_protocol::Error::into_internal_error(error));
+                    }
+                    tokio::select! {
+                        event = events.next() => {
+                            let action = match event {
+                                Some(Ok(event)) => handle(&mut app, event),
+                                Some(Err(_)) | None => {
+                                    leave(&mut terminal);
+                                    return Ok(());
+                                }
+                            };
+                            match action {
+                                Action::Quit => {
+                                    leave(&mut terminal);
+                                    return Ok(());
+                                }
+                                Action::Login(method) => {
+                                    drop(events);
+                                    let authenticated = authenticate_in_terminal(
+                                        &mut terminal,
+                                        &auth_program,
+                                        &root,
+                                        credential_storage,
+                                        &method,
+                                        &mut stop,
+                                    )
+                                    .await;
+                                    let Some(outcome) = authenticated else {
+                                        return Ok(());
+                                    };
+                                    let mut started = None;
+                                    match outcome {
+                                        Ok(status) if status.success() => {
+                                            let session = wait_for_initial_session(
+                                                &connection,
+                                                resume_session_id.as_deref(),
+                                                &root,
+                                                &mut stop,
+                                            )
+                                            .await;
+                                            let Some(session) = session else {
+                                                return Ok(());
+                                            };
+                                            match session {
+                                                Ok(session) => started = Some(session),
+                                                Err(error) => app.note(format!(
+                                                    "authentication completed, but the session still could not start: {}",
+                                                    error_detail(&error)
+                                                )),
+                                            }
+                                        }
+                                        Ok(status) => app.note(format!(
+                                            "authentication with {} failed: {status}",
+                                            method.name
+                                        )),
+                                        Err(error) => app.note(format!(
+                                            "could not start authentication with {}: {error}",
+                                            method.name
+                                        )),
+                                    }
+                                    images = resume_terminal(&mut terminal).map_err(
+                                        agent_client_protocol::Error::into_internal_error,
+                                    )?;
+                                    events = EventStream::new();
+                                    if let Some(session) = started {
+                                        break session;
+                                    }
+                                }
+                                Action::None | Action::Redraw => {}
+                                _ => app.note("authenticate before starting a session"),
+                            }
+                        }
+                        update = updates_rx.recv() => match update {
+                            Some(update) => app.apply(update.update),
+                            None => {
+                                leave(&mut terminal);
+                                return Ok(());
+                            }
+                        },
+                        _ = ticker.tick(), if app.needs_redraw_tick() => app.tick(),
+                        () = stop.requested() => {
+                            leave(&mut terminal);
+                            return Ok(());
+                        }
+                    }
+                    }
+                },
+            };
+            let active_session_id = match durable_session_id(&session_id) {
+                Ok(session_id) => session_id,
+                Err(error) => {
+                    leave(&mut terminal);
+                    return Err(agent_client_protocol::Error::into_internal_error(
+                        std::io::Error::other(error),
+                    ));
+                }
+            };
+            refresh_config_state(&mut app, Some(&config_options));
+            if let Ok(mut active) = transition_session.lock() {
+                active.id = active_session_id.clone();
+            }
+            app.start_session(active_session_id.clone());
             let result: Result<(), agent_client_protocol::Error> = async {
                 loop {
                     terminal
@@ -862,6 +1140,107 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                         )),
                                     }
                                 }
+                                Action::Login(method) => {
+                                    drop(events);
+                                    let authenticated = authenticate_in_terminal(
+                                        &mut terminal,
+                                        &auth_program,
+                                        &root,
+                                        credential_storage,
+                                        &method,
+                                        &mut stop,
+                                    )
+                                    .await;
+                                    let Some(outcome) = authenticated else {
+                                        return Ok(());
+                                    };
+                                    let mut refreshed = None;
+                                    match outcome {
+                                        Ok(status) if status.success() => {
+                                            let refreshed_id = durable_session_id(&session_id)
+                                                .map_err(|error| {
+                                                    agent_client_protocol::Error::into_internal_error(
+                                                        std::io::Error::other(error),
+                                                    )
+                                                })?;
+                                            let closed = tokio::time::timeout(
+                                                CLOSE_SESSION,
+                                                connection
+                                                    .send_request(CloseSessionRequest::new(
+                                                        session_id.clone(),
+                                                    ))
+                                                    .block_task(),
+                                            )
+                                            .await;
+                                            match closed {
+                                                Ok(Ok(_)) => {
+                                                    transition_route(
+                                                        &transition_session,
+                                                        refreshed_id.clone(),
+                                                    );
+                                                    images.clear();
+                                                    app.start_session(refreshed_id.clone());
+                                                    let resumed = wait_for_initial_session(
+                                                        &connection,
+                                                        Some(&refreshed_id),
+                                                        &root,
+                                                        &mut stop,
+                                                    )
+                                                    .await;
+                                                    let Some(resumed) = resumed else {
+                                                        return Ok(());
+                                                    };
+                                                    match resumed {
+                                                        Ok(session) => refreshed = Some(session),
+                                                        Err(error) => {
+                                                            return Err(agent_client_protocol::Error::into_internal_error(
+                                                                std::io::Error::other(format!(
+                                                                    "authentication completed, but the session could not restart: {}",
+                                                                    error_detail(&error)
+                                                                )),
+                                                            ));
+                                                        }
+                                                    }
+                                                }
+                                                Ok(Err(error)) => {
+                                                    return Err(agent_client_protocol::Error::into_internal_error(
+                                                        std::io::Error::other(format!(
+                                                            "authentication completed, but the session could not close for refresh: {}",
+                                                            error_detail(&error)
+                                                        )),
+                                                    ));
+                                                }
+                                                Err(_) => {
+                                                    return Err(agent_client_protocol::Error::into_internal_error(
+                                                        std::io::Error::other(
+                                                            "authentication completed, but session refresh timed out",
+                                                        ),
+                                                    ));
+                                                }
+                                            }
+                                        }
+                                        Ok(status) => app.note(format!(
+                                            "authentication with {} failed: {status}",
+                                            method.name
+                                        )),
+                                        Err(error) => app.note(format!(
+                                            "could not start authentication with {}: {error}",
+                                            method.name
+                                        )),
+                                    }
+                                    images = resume_terminal(&mut terminal).map_err(
+                                        agent_client_protocol::Error::into_internal_error,
+                                    )?;
+                                    events = EventStream::new();
+                                    if let Some((resumed_id, options)) = refreshed {
+                                        session_id = resumed_id;
+                                        refresh_config_state(&mut app, Some(&options));
+                                        app.note(format!(
+                                            "authentication completed with {}",
+                                            method.name
+                                        ));
+                                    }
+                                }
                                 Action::Copy(text) => {
                                     execute!(terminal.backend_mut(), Print(osc52(&text)))
                                         .map_err(agent_client_protocol::Error::into_internal_error)?;
@@ -951,7 +1330,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                 }
             }
             .await;
-            leave(terminal);
+            leave(&mut terminal);
             // Closing the ACP session removes its driver from the server,
             // dropping the transcript observer and its filesystem lock. Merely
             // closing stdio does not ask the headless runtime to close sessions.
@@ -1264,18 +1643,9 @@ fn prompt_blocks(prompt: &SubmittedPrompt) -> Result<Vec<ContentBlock>, String> 
     Ok(blocks)
 }
 
-fn enter() -> std::io::Result<(DefaultTerminal, image::ImageRuntime)> {
-    let terminal = ratatui::try_init()?;
-    // Query after entering the alternate screen but before the event stream owns
-    // terminal input, as required by ratatui-image. The query has a short bound.
-    let images = image::ImageRuntime::detect();
+fn enable_tui_modes() {
     let mut stdout = std::io::stdout();
-    // Bracketed paste is what keeps pasted text out of the key stream: without
-    // it every newline in a paste arrives as a return press, which submits the
-    // prompt part-way through.
     let _ = execute!(stdout, EnableBracketedPaste, EnableMouseCapture);
-    // Kitty-protocol terminals report `cmd`, `shift+enter`, and key release
-    // separately; the client falls back to control keys where they do not.
     if crossterm::terminal::supports_keyboard_enhancement().unwrap_or(false) {
         let _ = execute!(
             stdout,
@@ -1283,6 +1653,16 @@ fn enter() -> std::io::Result<(DefaultTerminal, image::ImageRuntime)> {
         );
         ENHANCED.store(true, Ordering::Relaxed);
     }
+}
+
+fn enter() -> std::io::Result<(DefaultTerminal, image::ImageRuntime)> {
+    let terminal = ratatui::try_init()?;
+    // Query after entering the alternate screen but before the event stream owns
+    // terminal input, as required by ratatui-image. The query has a short bound.
+    let images = image::ImageRuntime::detect();
+    // Bracketed paste keeps pasted newlines out of the key stream. Keyboard
+    // enhancement distinguishes command keys, shifted returns, and releases.
+    enable_tui_modes();
     // Ratatui's own hook restores raw mode and the alternate screen, but not
     // the modes turned on above: a panic would otherwise leave the shell
     // reporting every mouse move as text.
@@ -1292,6 +1672,22 @@ fn enter() -> std::io::Result<(DefaultTerminal, image::ImageRuntime)> {
         previous(info);
     }));
     Ok((terminal, images))
+}
+
+fn resume_terminal(terminal: &mut DefaultTerminal) -> std::io::Result<image::ImageRuntime> {
+    let resumed = (|| {
+        crossterm::terminal::enable_raw_mode()?;
+        execute!(std::io::stdout(), EnterAlternateScreen)?;
+        let images = image::ImageRuntime::detect();
+        enable_tui_modes();
+        terminal.clear()?;
+        Ok(images)
+    })();
+    if resumed.is_err() {
+        restore_modes();
+        ratatui::restore();
+    }
+    resumed
 }
 
 /// Whether the keyboard enhancement flags were pushed and still need popping.
@@ -1369,9 +1765,9 @@ async fn bounded_graceful_close<T>(
     }
 }
 
-fn leave(terminal: DefaultTerminal) {
+fn leave(terminal: &mut DefaultTerminal) {
     restore_modes();
-    drop(terminal);
+    let _ = terminal.show_cursor();
     ratatui::restore();
 }
 
@@ -1750,10 +2146,10 @@ mod tests {
     };
 
     use agent_client_protocol::schema::v2::{
-        AgentMessage, AgentThought, AvailableCommand, AvailableCommandsUpdate, ContentBlock,
-        IdleStateUpdate, RunningStateUpdate, SessionConfigOption, SessionConfigSelectGroup,
-        SessionConfigSelectOption, SessionUpdate, StateUpdate, TextContent,
-        UpdateSessionNotification, UserMessage,
+        AgentMessage, AgentThought, AuthMethod, AuthMethodTerminal, AvailableCommand,
+        AvailableCommandsUpdate, ContentBlock, EnvVariable, IdleStateUpdate, RunningStateUpdate,
+        SessionConfigOption, SessionConfigSelectGroup, SessionConfigSelectOption, SessionUpdate,
+        StateUpdate, TextContent, UpdateSessionNotification, UserMessage,
     };
     use crossterm::event::Event;
 
@@ -1761,13 +2157,115 @@ mod tests {
 
     use super::{
         ActiveSessionRoute, MAX_ATTACHMENTS, ModelChoice, QueuedUpdate, accept_queued_update,
-        attachments_from_paste, command, current_model_choice, detach_from_controlling_terminal,
+        attachments_from_paste, authentication_required, client_capabilities, command,
+        credential_storage_for_launch, current_model_choice, detach_from_controlling_terminal,
         durable_session_id, effort_state, handle, message_of, osc52, previous_session_for_resume,
         prompt_blocks, readable, refresh_config_state, save_effort_default_to,
-        save_model_defaults_to, transition_route, translate, translate_for_session,
-        user_message_of, wire,
+        save_model_defaults_to, terminal_auth_command, transition_route, translate,
+        translate_for_session, usable_terminal_auth_methods, user_message_of, wire,
     };
-    use crate::tui::app::{App, SessionDialog, SessionRename, SubmittedPrompt, Update};
+    use crate::{
+        tools::mcp::CredentialStorage,
+        tui::app::{App, SessionDialog, SessionRename, SubmittedPrompt, Update},
+    };
+
+    #[test]
+    fn only_authentication_failures_enter_login_recovery() {
+        let methods = [
+            AuthMethodTerminal::new("openrouter", "OpenRouter").args(vec![
+                "auth".into(),
+                "login".into(),
+                "openrouter".into(),
+            ]),
+        ];
+        assert!(authentication_required(
+            &agent_client_protocol::util::internal_error(
+                "run `kit auth login openrouter` before using OpenRouter",
+            ),
+            &methods,
+        ));
+        assert!(!authentication_required(
+            &agent_client_protocol::util::internal_error(
+                "run `kit auth login speakeasy` before using Speakeasy",
+            ),
+            &methods,
+        ));
+    }
+
+    #[test]
+    fn relative_credential_storage_is_resolved_for_all_child_processes() {
+        assert!(matches!(
+            credential_storage_for_launch(
+                &CredentialStorage::Filesystem(PathBuf::from("credentials")),
+                std::path::Path::new("/caller"),
+            ),
+            CredentialStorage::Filesystem(path) if path == PathBuf::from("/caller/credentials")
+        ));
+    }
+
+    #[test]
+    fn terminal_auth_is_negotiated_and_only_usable_methods_are_exposed() {
+        assert!(
+            client_capabilities(&CredentialStorage::Keychain)
+                .auth
+                .and_then(|auth| auth.terminal)
+                .is_some()
+        );
+
+        assert!(
+            client_capabilities(&CredentialStorage::Memory)
+                .auth
+                .is_none()
+        );
+
+        let methods = vec![
+            AuthMethod::Terminal(AuthMethodTerminal::new("empty", "Empty")),
+            AuthMethod::Terminal(AuthMethodTerminal::new("openai", "ChatGPT").args(vec![
+                "auth".into(),
+                "login".into(),
+                "openai".into(),
+            ])),
+        ];
+        let usable = usable_terminal_auth_methods(&methods);
+        assert_eq!(usable.len(), 1);
+        assert_eq!(usable[0].method_id.0.as_ref(), "openai");
+    }
+
+    #[test]
+    fn terminal_auth_command_uses_advertised_args_env_and_credentials() {
+        let root = tempfile::tempdir().unwrap();
+        let credentials = root.path().join("credentials");
+        let method = AuthMethodTerminal::new("openai", "ChatGPT")
+            .args(vec!["auth".into(), "login".into(), "openai".into()])
+            .env(vec![EnvVariable::new("KIT_AUTH_TEST", "set")]);
+        let command = terminal_auth_command(
+            std::ffi::OsStr::new("kit-agent"),
+            root.path(),
+            &CredentialStorage::Filesystem(credentials.clone()),
+            &method,
+        );
+        let command = command.as_std();
+        assert_eq!(command.get_program(), std::ffi::OsStr::new("kit-agent"));
+        assert_eq!(command.get_current_dir(), Some(root.path()));
+        assert_eq!(
+            command
+                .get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            [
+                "auth",
+                "login",
+                "openai",
+                "--credential-store",
+                "file",
+                "--credential-dir",
+                credentials.to_str().unwrap(),
+            ]
+        );
+        assert!(command.get_envs().any(|(name, value)| {
+            name == "KIT_AUTH_TEST" && value == Some(std::ffi::OsStr::new("set"))
+        }));
+    }
 
     #[cfg(unix)]
     #[tokio::test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -176,6 +176,7 @@ const CLOSE_SESSION: Duration = Duration::from_secs(3);
 const LAST_WORDS: Duration = Duration::from_millis(250);
 /// Diagnostic lines quoted back when the agent dies during the handshake.
 const FAILURE_LINES: usize = 5;
+const OPENROUTER_API_KEY_ENV: &str = "OPENROUTER_API_KEY";
 
 #[cfg(unix)]
 fn detach_from_controlling_terminal(command: &mut tokio::process::Command) {
@@ -229,13 +230,13 @@ fn authentication_required(
 
 fn credential_storage_for_launch(
     credential_storage: &CredentialStorage,
-    current_dir: &Path,
-) -> CredentialStorage {
+    current_dir: impl FnOnce() -> std::io::Result<PathBuf>,
+) -> std::io::Result<CredentialStorage> {
     match credential_storage {
-        CredentialStorage::Filesystem(directory) if directory.is_relative() => {
-            CredentialStorage::Filesystem(current_dir.join(directory))
-        }
-        credential_storage => credential_storage.clone(),
+        CredentialStorage::Filesystem(directory) if directory.is_relative() => Ok(
+            CredentialStorage::Filesystem(current_dir()?.join(directory)),
+        ),
+        credential_storage => Ok(credential_storage.clone()),
     }
 }
 
@@ -276,6 +277,7 @@ impl AgentInvocation {
             args: command.get_args().map(std::ffi::OsStr::to_owned).collect(),
             env: command
                 .get_envs()
+                .filter(|(name, _)| *name != std::ffi::OsStr::new(OPENROUTER_API_KEY_ENV))
                 .map(|(name, value)| (name.to_owned(), value.map(std::ffi::OsStr::to_owned)))
                 .collect(),
             current_dir: command.get_current_dir().map(Path::to_path_buf),
@@ -343,6 +345,7 @@ fn terminal_auth_command(
 ) -> tokio::process::Command {
     let mut command = invocation.command();
     command
+        .env_remove(OPENROUTER_API_KEY_ENV)
         .args(&method.args)
         .current_dir(root)
         .stdin(Stdio::inherit())
@@ -408,6 +411,74 @@ async fn wait_for_terminal_auth(
             None
         }
     }
+}
+
+enum RequestInterrupt {
+    AgentExited(Option<std::process::ExitStatus>),
+    Stopped,
+    TimedOut,
+}
+
+enum RequestFailure {
+    AgentExited(Option<std::process::ExitStatus>),
+    TimedOut,
+}
+
+async fn bounded_agent_request<T>(
+    request: impl std::future::Future<Output = T>,
+    exit: &mut oneshot::Receiver<std::io::Result<std::process::ExitStatus>>,
+    stop: impl std::future::Future<Output = ()>,
+    timeout: Duration,
+) -> Result<T, RequestInterrupt> {
+    tokio::select! {
+        output = request => Ok(output),
+        status = &mut *exit => Err(RequestInterrupt::AgentExited(
+            status.ok().and_then(Result::ok),
+        )),
+        () = stop => Err(RequestInterrupt::Stopped),
+        () = tokio::time::sleep(timeout) => Err(RequestInterrupt::TimedOut),
+    }
+}
+
+async fn bounded_startup_request<T>(
+    request: impl std::future::Future<Output = T>,
+    exit: &mut oneshot::Receiver<std::io::Result<std::process::ExitStatus>>,
+    timeout: Duration,
+) -> Result<T, RequestFailure> {
+    match bounded_agent_request(request, exit, std::future::pending(), timeout).await {
+        Ok(output) => Ok(output),
+        Err(RequestInterrupt::AgentExited(status)) => Err(RequestFailure::AgentExited(status)),
+        Err(RequestInterrupt::TimedOut) => Err(RequestFailure::TimedOut),
+        Err(RequestInterrupt::Stopped) => unreachable!("the stop future is pending"),
+    }
+}
+
+async fn bounded_cancellable_request<T>(
+    request: impl std::future::Future<Output = T>,
+    exit: &mut oneshot::Receiver<std::io::Result<std::process::ExitStatus>>,
+    stop: impl std::future::Future<Output = ()>,
+    timeout: Duration,
+) -> Result<Option<T>, RequestFailure> {
+    match bounded_agent_request(request, exit, stop, timeout).await {
+        Ok(output) => Ok(Some(output)),
+        Err(RequestInterrupt::AgentExited(status)) => Err(RequestFailure::AgentExited(status)),
+        Err(RequestInterrupt::Stopped) => Ok(None),
+        Err(RequestInterrupt::TimedOut) => Err(RequestFailure::TimedOut),
+    }
+}
+
+async fn request_failure(
+    failure: RequestFailure,
+    stderr: tokio::task::JoinHandle<()>,
+    recent: &Mutex<Vec<String>>,
+    when: &str,
+    timeout_message: String,
+) -> agent_client_protocol::Error {
+    let detail = match failure {
+        RequestFailure::AgentExited(status) => died(status, stderr, recent, when).await,
+        RequestFailure::TimedOut => timeout_message,
+    };
+    agent_client_protocol::Error::into_internal_error(std::io::Error::other(detail))
 }
 
 async fn request_initial_session(
@@ -646,7 +717,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
         .canonicalize()
         .map_err(|error| Failure(format!("{}: {error}", root.display())))?;
     let credential_storage =
-        credential_storage_for_launch(credential_storage, &std::env::current_dir()?);
+        credential_storage_for_launch(credential_storage, std::env::current_dir)?;
     let credential_storage = &credential_storage;
     let resume_session_id = resume.map(str::to_string);
     let persisted_session_id = resume_session_id
@@ -794,28 +865,23 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                     .capabilities(client_capabilities(credential_storage)),
                 )
                 .block_task();
-            let initialized = tokio::select! {
-                initialized = initialize => initialized?,
-                status = &mut exit_rx => {
-                    return Err(agent_client_protocol::Error::into_internal_error(
-                        std::io::Error::other(died(
-                            status.ok().and_then(Result::ok),
+            let initialized =
+                match bounded_startup_request(initialize, &mut exit_rx, HANDSHAKE).await {
+                    Ok(initialized) => initialized?,
+                    Err(failure) => {
+                        return Err(request_failure(
+                            failure,
                             stderr_task,
                             &recent,
                             "before the session opened",
+                            format!(
+                                "the agent did not answer the ACP handshake within {} seconds",
+                                HANDSHAKE.as_secs()
+                            ),
                         )
-                        .await),
-                    ));
-                }
-                () = tokio::time::sleep(HANDSHAKE) => {
-                    return Err(agent_client_protocol::Error::into_internal_error(
-                        std::io::Error::other(format!(
-                            "the agent did not answer the ACP handshake within {} seconds",
-                            HANDSHAKE.as_secs()
-                        )),
-                    ));
-                }
-            };
+                        .await);
+                    }
+                };
             if initialized.protocol_version != ProtocolVersion::V2 {
                 return Err(agent_client_protocol::Error::into_internal_error(
                     std::io::Error::other("the agent did not negotiate ACP v2"),
@@ -831,29 +897,30 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                         })
                 });
 
-            let initial = tokio::select! {
-                session = request_initial_session(
+            let initial = match bounded_startup_request(
+                request_initial_session(
                     &connection,
                     resume_session_id.as_deref(),
                     &root,
-                ) => session,
-                status = &mut exit_rx => {
-                    return Err(agent_client_protocol::Error::into_internal_error(
-                        std::io::Error::other(died(
-                            status.ok().and_then(Result::ok),
-                            stderr_task,
-                            &recent,
-                            "before the session opened",
-                        ).await),
-                    ));
-                }
-                () = tokio::time::sleep(HANDSHAKE) => {
-                    return Err(agent_client_protocol::Error::into_internal_error(
-                        std::io::Error::other(format!(
+                ),
+                &mut exit_rx,
+                HANDSHAKE,
+            )
+            .await
+            {
+                Ok(session) => session,
+                Err(failure) => {
+                    return Err(request_failure(
+                        failure,
+                        stderr_task,
+                        &recent,
+                        "before the session opened",
+                        format!(
                             "the agent did not start a session within {} seconds",
                             HANDSHAKE.as_secs()
-                        )),
-                    ));
+                        ),
+                    )
+                    .await);
                 }
             };
             let initial = match initial {
@@ -951,13 +1018,36 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     };
                                     match outcome {
                                         Ok(status) if status.success() => {
-                                            match request_initial_session(
-                                                &connection,
-                                                resume_session_id.as_deref(),
-                                                &root,
+                                            let requested = bounded_cancellable_request(
+                                                request_initial_session(
+                                                    &connection,
+                                                    resume_session_id.as_deref(),
+                                                    &root,
+                                                ),
+                                                &mut exit_rx,
+                                                stop.requested(),
+                                                HANDSHAKE,
                                             )
-                                            .await
-                                            {
+                                            .await;
+                                            let Some(initial) = (match requested {
+                                                Ok(initial) => initial,
+                                                Err(failure) => {
+                                                    return Err(request_failure(
+                                                        failure,
+                                                        stderr_task,
+                                                        &recent,
+                                                        "before the session opened",
+                                                        format!(
+                                                            "the agent did not start a session within {} seconds",
+                                                            HANDSHAKE.as_secs()
+                                                        ),
+                                                    )
+                                                    .await);
+                                                }
+                                            }) else {
+                                                return Ok(());
+                                            };
+                                            match initial {
                                                 Ok(session) => {
                                                     images = resume_terminal(&mut terminal).map_err(
                                                         agent_client_protocol::Error::into_internal_error,
@@ -1378,12 +1468,36 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     };
                                     match outcome {
                                         Ok(status) if status.success() => {
-                                            let options = refresh_session_after_auth(
-                                                &connection,
-                                                session_id.clone(),
-                                                &active_config,
+                                            let refreshed = bounded_cancellable_request(
+                                                refresh_session_after_auth(
+                                                    &connection,
+                                                    session_id.clone(),
+                                                    &active_config,
+                                                ),
+                                                &mut exit_rx,
+                                                stop.requested(),
+                                                HANDSHAKE,
                                             )
-                                            .await?;
+                                            .await;
+                                            let Some(options) = (match refreshed {
+                                                Ok(options) => options,
+                                                Err(failure) => {
+                                                    return Err(request_failure(
+                                                        failure,
+                                                        stderr_task,
+                                                        &recent,
+                                                        "during authentication refresh",
+                                                        format!(
+                                                            "the agent did not refresh the session within {} seconds",
+                                                            HANDSHAKE.as_secs()
+                                                        ),
+                                                    )
+                                                    .await);
+                                                }
+                                            }) else {
+                                                return Ok(());
+                                            };
+                                            let options = options?;
                                             refresh_config_state(&mut app, Some(&options));
                                             app.note(format!(
                                                 "authentication with {} succeeded",
@@ -2312,15 +2426,16 @@ mod tests {
 
     use super::{
         ActiveSessionRoute, AgentInvocation, ConnectedAuthentication, MAX_ATTACHMENTS, MAX_BURST,
-        ModelChoice, ProtocolVersion, QueuedUpdate, accept_queued_update, active_config_matches,
-        active_session_config, agent_command_for_launch, apply_pending_updates,
-        attachments_from_paste, authentication_required, client_capabilities, command,
-        credential_storage_for_launch, current_model_choice, detach_from_controlling_terminal,
-        durable_session_id, effort_state, error_detail, handle, message_of, osc52,
-        previous_session_for_resume, prompt_blocks, readable, refresh_config_state,
-        refresh_session_after_auth, save_effort_default_to, save_model_defaults_to,
-        terminal_auth_command, transition_route, translate, translate_for_session,
-        usable_terminal_auth_methods, user_message_of, wait_for_connected_authentication, wire,
+        ModelChoice, OPENROUTER_API_KEY_ENV, ProtocolVersion, QueuedUpdate, accept_queued_update,
+        active_config_matches, active_session_config, agent_command_for_launch,
+        apply_pending_updates, attachments_from_paste, authentication_required,
+        client_capabilities, command, credential_storage_for_launch, current_model_choice,
+        detach_from_controlling_terminal, durable_session_id, effort_state, error_detail, handle,
+        message_of, osc52, previous_session_for_resume, prompt_blocks, readable,
+        refresh_config_state, refresh_session_after_auth, save_effort_default_to,
+        save_model_defaults_to, terminal_auth_command, transition_route, translate,
+        translate_for_session, usable_terminal_auth_methods, user_message_of,
+        wait_for_connected_authentication, wire,
     };
     use crate::{
         tools::mcp::CredentialStorage,
@@ -2387,9 +2502,17 @@ mod tests {
         assert!(matches!(
             credential_storage_for_launch(
                 &CredentialStorage::Filesystem(PathBuf::from("credentials")),
-                std::path::Path::new("/caller"),
-            ),
+                || Ok(PathBuf::from("/caller")),
+            )
+            .unwrap(),
             CredentialStorage::Filesystem(path) if path == std::path::Path::new("/caller/credentials")
+        ));
+        assert!(matches!(
+            credential_storage_for_launch(&CredentialStorage::Keychain, || {
+                panic!("absolute storage must not query the current directory")
+            })
+            .unwrap(),
+            CredentialStorage::Keychain
         ));
     }
 
@@ -2506,7 +2629,14 @@ mod tests {
         base.current_dir(base_root.path());
         CredentialStorage::Filesystem(credentials.clone()).append_cli_args(&mut base);
         base.env("KIT_BASE_TEST", "base");
+        base.env(OPENROUTER_API_KEY_ENV, "secret");
         let invocation = AgentInvocation::from_command(base.as_std());
+        assert!(
+            invocation
+                .env
+                .iter()
+                .all(|(name, _)| name != OPENROUTER_API_KEY_ENV)
+        );
         let method = AuthMethodTerminal::new("openai", "ChatGPT")
             .args(vec!["--terminal-auth-login".into(), "openai".into()])
             .env(vec![EnvVariable::new("KIT_AUTH_TEST", "set")]);
@@ -2536,6 +2666,12 @@ mod tests {
         assert!(command.as_std().get_envs().any(|(name, value)| {
             name == "KIT_AUTH_TEST" && value == Some(std::ffi::OsStr::new("set"))
         }));
+        assert!(
+            command
+                .as_std()
+                .get_envs()
+                .any(|(name, value)| { name == OPENROUTER_API_KEY_ENV && value.is_none() })
+        );
 
         let replacement = invocation.command();
         assert_eq!(
@@ -3451,7 +3587,55 @@ a = [still text]
 mod signal_tests {
     use std::{future, time::Duration};
 
-    use super::{Stop, bounded_graceful_close};
+    use super::{RequestInterrupt, Stop, bounded_agent_request, bounded_graceful_close};
+
+    #[tokio::test(start_paused = true)]
+    async fn a_stuck_session_request_is_bounded() {
+        let (_exit_tx, mut exit_rx) = tokio::sync::oneshot::channel();
+
+        let result = bounded_agent_request(
+            future::pending::<()>(),
+            &mut exit_rx,
+            future::pending(),
+            Duration::from_secs(30),
+        )
+        .await;
+
+        assert!(matches!(result, Err(RequestInterrupt::TimedOut)));
+    }
+
+    #[tokio::test]
+    async fn agent_exit_cancels_a_session_request() {
+        let (exit_tx, mut exit_rx) = tokio::sync::oneshot::channel();
+        exit_tx
+            .send(Err(std::io::Error::other("agent exited")))
+            .unwrap();
+
+        let result = bounded_agent_request(
+            future::pending::<()>(),
+            &mut exit_rx,
+            future::pending(),
+            Duration::from_secs(30),
+        )
+        .await;
+
+        assert!(matches!(result, Err(RequestInterrupt::AgentExited(None))));
+    }
+
+    #[tokio::test]
+    async fn stop_cancels_a_session_request() {
+        let (_exit_tx, mut exit_rx) = tokio::sync::oneshot::channel();
+
+        let result = bounded_agent_request(
+            future::pending::<()>(),
+            &mut exit_rx,
+            future::ready(()),
+            Duration::from_secs(30),
+        )
+        .await;
+
+        assert!(matches!(result, Err(RequestInterrupt::Stopped)));
+    }
 
     #[tokio::test]
     async fn a_stuck_close_is_bounded() {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -69,7 +69,7 @@ use app::{
 
 /// Animation and elapsed-time refresh interval.
 const TICK: Duration = Duration::from_millis(90);
-/// Terminal events applied per frame, so a paste lands in one redraw.
+/// Terminal events or queued updates applied per frame.
 const MAX_BURST: usize = 4_096;
 const MAX_ATTACHMENTS: usize = 8;
 const MAX_ATTACHMENT_BYTES: u64 = 10 * 1024 * 1024;
@@ -121,6 +121,26 @@ fn accept_queued_update(
             .is_ok_and(|route| route.generation == generation)
     });
     accepted.then_some(queued.update)
+}
+
+fn apply_pending_updates(
+    app: &mut App,
+    route: &Arc<Mutex<ActiveSessionRoute>>,
+    updates: &mut mpsc::UnboundedReceiver<QueuedUpdate>,
+    first: QueuedUpdate,
+) {
+    for queued in std::iter::once(first)
+        .chain(std::iter::from_fn(|| updates.try_recv().ok()))
+        .take(MAX_BURST)
+    {
+        let Some(update) = accept_queued_update(route, queued) else {
+            continue;
+        };
+        if let Update::ConfigOptions(options) = &update {
+            refresh_config_state(app, Some(options));
+        }
+        app.apply(update);
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, agent_client_protocol::JsonRpcRequest)]
@@ -295,6 +315,34 @@ async fn authenticate_in_terminal(
     leave(terminal);
     println!("Starting {}…", method.name);
     wait_for_terminal_auth(terminal_auth_command(invocation, root, method), stop).await
+}
+
+enum ConnectedAuthentication {
+    Completed(Option<std::io::Result<std::process::ExitStatus>>),
+    AgentExited(Result<std::io::Result<std::process::ExitStatus>, oneshot::error::RecvError>),
+    UpdatesClosed,
+}
+
+async fn wait_for_connected_authentication(
+    authentication: impl std::future::Future<Output = Option<std::io::Result<std::process::ExitStatus>>>,
+    app: &mut App,
+    route: &Arc<Mutex<ActiveSessionRoute>>,
+    updates: &mut mpsc::UnboundedReceiver<QueuedUpdate>,
+    exit: &mut oneshot::Receiver<std::io::Result<std::process::ExitStatus>>,
+) -> ConnectedAuthentication {
+    tokio::pin!(authentication);
+    loop {
+        tokio::select! {
+            authenticated = &mut authentication => {
+                return ConnectedAuthentication::Completed(authenticated);
+            }
+            update = updates.recv() => match update {
+                Some(update) => apply_pending_updates(app, route, updates, update),
+                None => return ConnectedAuthentication::UpdatesClosed,
+            },
+            status = &mut *exit => return ConnectedAuthentication::AgentExited(status),
+        }
+    }
 }
 
 async fn wait_for_terminal_auth(
@@ -661,7 +709,13 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                 initialized = initialize => initialized?,
                 status = &mut exit_rx => {
                     return Err(agent_client_protocol::Error::into_internal_error(
-                        std::io::Error::other(died(status.ok().and_then(Result::ok), stderr_task, &recent).await),
+                        std::io::Error::other(died(
+                            status.ok().and_then(Result::ok),
+                            stderr_task,
+                            &recent,
+                            "before the session opened",
+                        )
+                        .await),
                     ));
                 }
                 () = tokio::time::sleep(HANDSHAKE) => {
@@ -700,6 +754,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                             status.ok().and_then(Result::ok),
                             stderr_task,
                             &recent,
+                            "before the session opened",
                         ).await),
                     ));
                 }
@@ -770,14 +825,35 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                 }
                                 Action::Login(method) => {
                                     drop(events);
-                                    let authenticated = authenticate_in_terminal(
+                                    let authentication = authenticate_in_terminal(
                                         &mut terminal,
                                         &auth_invocation,
                                         &root,
                                         &method,
                                         &mut stop,
+                                    );
+                                    let authenticated = wait_for_connected_authentication(
+                                        authentication,
+                                        &mut app,
+                                        &transition_session,
+                                        &mut updates_rx,
+                                        &mut exit_rx,
                                     )
                                     .await;
+                                    let authenticated = match authenticated {
+                                        ConnectedAuthentication::Completed(authenticated) => authenticated,
+                                        ConnectedAuthentication::UpdatesClosed => return Ok(()),
+                                        ConnectedAuthentication::AgentExited(status) => {
+                                            return Err(agent_client_protocol::Error::into_internal_error(
+                                                std::io::Error::other(died(
+                                                    status.ok().and_then(Result::ok),
+                                                    stderr_task,
+                                                    &recent,
+                                                    "before the session opened",
+                                                ).await),
+                                            ));
+                                        }
+                                    };
                                     let Some(outcome) = authenticated else {
                                         return Ok(());
                                     };
@@ -1168,14 +1244,35 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                 }
                                 Action::Login(method) => {
                                     drop(events);
-                                    let authenticated = authenticate_in_terminal(
+                                    let authentication = authenticate_in_terminal(
                                         &mut terminal,
                                         &auth_invocation,
                                         &root,
                                         &method,
                                         &mut stop,
+                                    );
+                                    let authenticated = wait_for_connected_authentication(
+                                        authentication,
+                                        &mut app,
+                                        &transition_session,
+                                        &mut updates_rx,
+                                        &mut exit_rx,
                                     )
                                     .await;
+                                    let authenticated = match authenticated {
+                                        ConnectedAuthentication::Completed(authenticated) => authenticated,
+                                        ConnectedAuthentication::UpdatesClosed => return Ok(()),
+                                        ConnectedAuthentication::AgentExited(status) => {
+                                            return Err(agent_client_protocol::Error::into_internal_error(
+                                                std::io::Error::other(died(
+                                                    status.ok().and_then(Result::ok),
+                                                    stderr_task,
+                                                    &recent,
+                                                    "during authentication",
+                                                ).await),
+                                            ));
+                                        }
+                                    };
                                     let Some(outcome) = authenticated else {
                                         return Ok(());
                                     };
@@ -1330,23 +1427,12 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                             }
                         },
                         update = updates_rx.recv() => match update {
-                            Some(update) => {
-                                if let Some(update) = accept_queued_update(&transition_session, update) {
-                                    if let Update::ConfigOptions(options) = &update {
-                                        refresh_config_state(&mut app, Some(options));
-                                    }
-                                    app.apply(update);
-                                }
-                                while let Ok(update) = updates_rx.try_recv() {
-                                    let Some(update) = accept_queued_update(&transition_session, update) else {
-                                        continue;
-                                    };
-                                    if let Update::ConfigOptions(options) = &update {
-                                        refresh_config_state(&mut app, Some(options));
-                                    }
-                                    app.apply(update);
-                                }
-                            }
+                            Some(update) => apply_pending_updates(
+                                &mut app,
+                                &transition_session,
+                                &mut updates_rx,
+                                update,
+                            ),
                             None => return Ok(()),
                         },
                         _ = ticker.tick(), if app.needs_redraw_tick() => app.tick(),
@@ -1493,12 +1579,12 @@ impl std::fmt::Display for Failure {
 
 impl std::error::Error for Failure {}
 
-/// Explains an agent that exited before the session was open, quoting the last
-/// thing it said.
+/// Explains an agent exit, quoting the last thing it said.
 async fn died(
     status: Option<std::process::ExitStatus>,
     stderr: tokio::task::JoinHandle<()>,
     recent: &Mutex<Vec<String>>,
+    when: &str,
 ) -> String {
     // Its final diagnostics are usually still in flight when it exits, and they
     // are the part worth reading.
@@ -1515,9 +1601,9 @@ async fn died(
         None => "exited".to_string(),
     };
     if said.is_empty() {
-        format!("the agent {how} before the session opened")
+        format!("the agent {how} {when}")
     } else {
-        format!("the agent {how} before the session opened: {said}")
+        format!("the agent {how} {when}: {said}")
     }
 }
 
@@ -2181,14 +2267,15 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        ActiveSessionRoute, AgentInvocation, MAX_ATTACHMENTS, ModelChoice, QueuedUpdate,
-        accept_queued_update, attachments_from_paste, authentication_required, client_capabilities,
-        command, credential_storage_for_launch, current_model_choice,
-        detach_from_controlling_terminal, durable_session_id, effort_state, error_detail, handle,
-        message_of, osc52, previous_session_for_resume, prompt_blocks, readable,
-        refresh_config_state, save_effort_default_to, save_model_defaults_to,
-        terminal_auth_command, transition_route, translate, translate_for_session,
-        usable_terminal_auth_methods, user_message_of, wire,
+        ActiveSessionRoute, AgentInvocation, ConnectedAuthentication, MAX_ATTACHMENTS, MAX_BURST,
+        ModelChoice, QueuedUpdate, accept_queued_update, apply_pending_updates,
+        attachments_from_paste, authentication_required, client_capabilities, command,
+        credential_storage_for_launch, current_model_choice, detach_from_controlling_terminal,
+        durable_session_id, effort_state, error_detail, handle, message_of, osc52,
+        previous_session_for_resume, prompt_blocks, readable, refresh_config_state,
+        save_effort_default_to, save_model_defaults_to, terminal_auth_command, transition_route,
+        translate, translate_for_session, usable_terminal_auth_methods, user_message_of,
+        wait_for_connected_authentication, wire,
     };
     use crate::{
         tools::mcp::CredentialStorage,
@@ -2382,6 +2469,69 @@ mod tests {
             accept_queued_update(&route, QueuedUpdate::global(Update::Log("global".into())))
                 .is_some()
         );
+    }
+
+    #[test]
+    fn queued_updates_are_applied_in_bounded_bursts() {
+        let root = tempfile::tempdir().unwrap();
+        let mut app = App::new(
+            root.path().into(),
+            "provider".into(),
+            "model".into(),
+            "a2a".into(),
+        );
+        let route = Arc::new(Mutex::new(ActiveSessionRoute {
+            id: "session".into(),
+            generation: 0,
+        }));
+        let (updates_tx, mut updates_rx) = tokio::sync::mpsc::unbounded_channel();
+        for index in 0..=MAX_BURST {
+            updates_tx
+                .send(QueuedUpdate::global(Update::Log(index.to_string())))
+                .unwrap();
+        }
+        let first = updates_rx.try_recv().unwrap();
+
+        apply_pending_updates(&mut app, &route, &mut updates_rx, first);
+
+        assert!(updates_rx.try_recv().is_ok());
+        assert!(updates_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn connected_authentication_observes_agent_exit() {
+        let root = tempfile::tempdir().unwrap();
+        let mut app = App::new(
+            root.path().into(),
+            "provider".into(),
+            "model".into(),
+            "a2a".into(),
+        );
+        let route = Arc::new(Mutex::new(ActiveSessionRoute {
+            id: "session".into(),
+            generation: 0,
+        }));
+        let (_updates_tx, mut updates_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (exit_tx, mut exit_rx) = tokio::sync::oneshot::channel();
+        exit_tx
+            .send(Err(std::io::Error::other("agent exited")))
+            .unwrap();
+        let authentication =
+            std::future::pending::<Option<std::io::Result<std::process::ExitStatus>>>();
+
+        let result = wait_for_connected_authentication(
+            authentication,
+            &mut app,
+            &route,
+            &mut updates_rx,
+            &mut exit_rx,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            ConnectedAuthentication::AgentExited(Ok(Err(_)))
+        ));
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2199,7 +2199,7 @@ mod tests {
                 &CredentialStorage::Filesystem(PathBuf::from("credentials")),
                 std::path::Path::new("/caller"),
             ),
-            CredentialStorage::Filesystem(path) if path == PathBuf::from("/caller/credentials")
+            CredentialStorage::Filesystem(path) if path == std::path::Path::new("/caller/credentials")
         ));
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -305,16 +305,13 @@ fn terminal_auth_command(
     command
 }
 
-async fn authenticate_in_terminal(
-    terminal: &mut DefaultTerminal,
+fn authenticate_in_terminal<'a>(
     invocation: &AgentInvocation,
     root: &Path,
     method: &wire::AuthMethodTerminal,
-    stop: &mut Stop,
-) -> Option<std::io::Result<std::process::ExitStatus>> {
-    leave(terminal);
-    println!("Starting {}…", method.name);
-    wait_for_terminal_auth(terminal_auth_command(invocation, root, method), stop).await
+    stop: &'a mut Stop,
+) -> impl std::future::Future<Output = Option<std::io::Result<std::process::ExitStatus>>> + 'a {
+    wait_for_terminal_auth(terminal_auth_command(invocation, root, method), stop)
 }
 
 enum ConnectedAuthentication {
@@ -325,11 +322,13 @@ enum ConnectedAuthentication {
 
 async fn wait_for_connected_authentication(
     authentication: impl std::future::Future<Output = Option<std::io::Result<std::process::ExitStatus>>>,
+    prepare: impl FnOnce(),
     app: &mut App,
     route: &Arc<Mutex<ActiveSessionRoute>>,
     updates: &mut mpsc::UnboundedReceiver<QueuedUpdate>,
     exit: &mut oneshot::Receiver<std::io::Result<std::process::ExitStatus>>,
 ) -> ConnectedAuthentication {
+    prepare();
     tokio::pin!(authentication);
     loop {
         tokio::select! {
@@ -826,7 +825,6 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                 Action::Login(method) => {
                                     drop(events);
                                     let authentication = authenticate_in_terminal(
-                                        &mut terminal,
                                         &auth_invocation,
                                         &root,
                                         &method,
@@ -834,6 +832,10 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     );
                                     let authenticated = wait_for_connected_authentication(
                                         authentication,
+                                        || {
+                                            leave(&mut terminal);
+                                            println!("Starting {}…", method.name);
+                                        },
                                         &mut app,
                                         &transition_session,
                                         &mut updates_rx,
@@ -1245,7 +1247,6 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                 Action::Login(method) => {
                                     drop(events);
                                     let authentication = authenticate_in_terminal(
-                                        &mut terminal,
                                         &auth_invocation,
                                         &root,
                                         &method,
@@ -1253,6 +1254,10 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     );
                                     let authenticated = wait_for_connected_authentication(
                                         authentication,
+                                        || {
+                                            leave(&mut terminal);
+                                            println!("Starting {}…", method.name);
+                                        },
                                         &mut app,
                                         &transition_session,
                                         &mut updates_rx,
@@ -2499,7 +2504,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn connected_authentication_observes_agent_exit() {
+    async fn connected_terminal_authentication_prepares_before_observing_agent_exit() {
         let root = tempfile::tempdir().unwrap();
         let mut app = App::new(
             root.path().into(),
@@ -2518,9 +2523,11 @@ mod tests {
             .unwrap();
         let authentication =
             std::future::pending::<Option<std::io::Result<std::process::ExitStatus>>>();
+        let prepared = std::cell::Cell::new(false);
 
         let result = wait_for_connected_authentication(
             authentication,
+            || prepared.set(true),
             &mut app,
             &route,
             &mut updates_rx,
@@ -2528,6 +2535,7 @@ mod tests {
         )
         .await;
 
+        assert!(prepared.get());
         assert!(matches!(
             result,
             ConnectedAuthentication::AgentExited(Ok(Err(_)))

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -58,7 +58,7 @@ use wire::{
 
 use crate::{
     events::{self, EVENTS_ENV},
-    protocols::acp::FileSearchRequest,
+    protocols::acp::{FileSearchRequest, MODEL_CONFIG_ID, REASONING_EFFORT_CONFIG_ID},
     tools::mcp::CredentialStorage,
 };
 
@@ -269,11 +269,6 @@ struct AgentInvocation {
     current_dir: Option<PathBuf>,
 }
 
-struct ReconnectLaunch {
-    resume_session_id: Option<String>,
-    force: bool,
-}
-
 impl AgentInvocation {
     fn from_command(command: &std::process::Command) -> Self {
         Self {
@@ -439,14 +434,7 @@ async fn request_initial_session(
 }
 
 fn current_model_choice(options: Option<&[SessionConfigOption]>) -> Option<ModelChoice> {
-    let current = options
-        .unwrap_or_default()
-        .iter()
-        .find(|option| option.config_id.to_string() == "model")
-        .and_then(|option| match &option.kind {
-            SessionConfigKind::Select(select) => Some(select.current_value.to_string()),
-            _ => None,
-        })?;
+    let current = current_config_value(options.unwrap_or_default(), MODEL_CONFIG_ID)?;
     model_choices(options)
         .into_iter()
         .find(|choice| choice.id == current)
@@ -458,7 +446,7 @@ fn effort_state(options: Option<&[SessionConfigOption]>) -> Option<(String, Vec<
         ..
     } = options?
         .iter()
-        .find(|option| option.config_id.to_string() == "reasoning_effort")?
+        .find(|option| option.config_id.to_string() == REASONING_EFFORT_CONFIG_ID)?
     else {
         return None;
     };
@@ -474,6 +462,64 @@ fn effort_state(options: Option<&[SessionConfigOption]>) -> Option<(String, Vec<
         _ => return None,
     };
     Some((select.current_value.to_string(), choices))
+}
+
+struct ActiveSessionConfig {
+    model: String,
+    reasoning_effort: Option<String>,
+}
+
+fn active_session_config(app: &App) -> ActiveSessionConfig {
+    ActiveSessionConfig {
+        model: app
+            .model_choices
+            .iter()
+            .find(|choice| choice.provider == app.provider && choice.model == app.model)
+            .map_or_else(
+                || format!("{}:{}", app.provider, app.model),
+                |choice| choice.id.clone(),
+            ),
+        reasoning_effort: (!app.effort_choices.is_empty()).then(|| app.reasoning_effort.clone()),
+    }
+}
+
+fn current_config_value(options: &[SessionConfigOption], config_id: &str) -> Option<String> {
+    options
+        .iter()
+        .find(|option| option.config_id.to_string() == config_id)
+        .and_then(|option| match &option.kind {
+            SessionConfigKind::Select(select) => Some(select.current_value.to_string()),
+            _ => None,
+        })
+}
+
+fn active_config_matches(active: &ActiveSessionConfig, options: &[SessionConfigOption]) -> bool {
+    current_config_value(options, MODEL_CONFIG_ID).as_deref() == Some(active.model.as_str())
+        && active.reasoning_effort.as_deref().is_none_or(|effort| {
+            current_config_value(options, REASONING_EFFORT_CONFIG_ID).as_deref() == Some(effort)
+        })
+}
+
+async fn refresh_session_after_auth(
+    connection: &agent_client_protocol::V2ConnectionTo<agent_client_protocol::Agent>,
+    session_id: wire::SessionId,
+    active: &ActiveSessionConfig,
+) -> Result<Vec<SessionConfigOption>, agent_client_protocol::Error> {
+    let options = connection
+        .send_request(SetSessionConfigOptionRequest::new(
+            session_id,
+            MODEL_CONFIG_ID,
+            active.model.as_str(),
+        ))
+        .block_task()
+        .await?
+        .config_options;
+    if !active_config_matches(active, &options) {
+        return Err(agent_client_protocol::Error::into_internal_error(
+            std::io::Error::other("authentication refresh changed the active session settings"),
+        ));
+    }
+    Ok(options)
 }
 
 fn refresh_config_state(app: &mut App, options: Option<&[SessionConfigOption]>) {
@@ -496,7 +542,7 @@ fn model_choices(options: Option<&[SessionConfigOption]>) -> Vec<ModelChoice> {
     }) = options
         .unwrap_or_default()
         .iter()
-        .find(|option| option.config_id.to_string() == "model")
+        .find(|option| option.config_id.to_string() == MODEL_CONFIG_ID)
     else {
         return Vec::new();
     };
@@ -602,7 +648,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
     let credential_storage =
         credential_storage_for_launch(credential_storage, &std::env::current_dir()?);
     let credential_storage = &credential_storage;
-    let mut resume_session_id = resume.map(str::to_string);
+    let resume_session_id = resume.map(str::to_string);
     let persisted_session_id = resume_session_id
         .clone()
         .unwrap_or_else(crate::session::new_id);
@@ -615,9 +661,8 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
     let a2a_address = a2a.map(str::to_string);
     let a2a = a2a_address.clone().unwrap_or_else(|| "allocating…".into());
     let mcp_config = mcp_config.map(Path::to_path_buf);
-    let mut launch_force = force;
 
-    loop {
+    {
         let launch_session_id = resume_session_id
             .as_deref()
             .unwrap_or(&persisted_session_id);
@@ -633,7 +678,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
             credential_storage,
             launch_session_id,
             resume_session_id.is_some(),
-            launch_force,
+            force,
         )?;
         let auth_invocation = AgentInvocation::from_command(command.as_std());
         detach_from_controlling_terminal(&mut command);
@@ -704,17 +749,12 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
         let cleanup_root = root.clone();
         let transition_session = Arc::clone(&active_persisted_id);
         let notification_session = Arc::clone(&active_persisted_id);
-        let reconnect_resume = Arc::new(Mutex::new(None));
         let result = {
             let root = root.clone();
             let model = model.clone();
             let a2a = a2a.clone();
-            let a2a_address = a2a_address.clone();
-            let mcp_config = mcp_config.clone();
             let auth_invocation = auth_invocation.clone();
             let resume_session_id = resume_session_id.clone();
-            let launch_force = launch_force;
-            let reconnect_resume = Arc::clone(&reconnect_resume);
             agent_client_protocol::Client
         .v2()
         .on_receive_notification(
@@ -911,17 +951,29 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     };
                                     match outcome {
                                         Ok(status) if status.success() => {
-                                            // The running agent can retain stale provider state.
-                                            // Retry only after the outer loop has replaced it and
-                                            // negotiated a new ACP connection.
-                                            *reconnect_resume
-                                                .lock()
-                                                .expect("ACP reconnect state poisoned") =
-                                                Some(ReconnectLaunch {
-                                                    resume_session_id: resume_session_id.clone(),
-                                                    force: launch_force,
-                                                });
-                                            return Ok(());
+                                            match request_initial_session(
+                                                &connection,
+                                                resume_session_id.as_deref(),
+                                                &root,
+                                            )
+                                            .await
+                                            {
+                                                Ok(session) => {
+                                                    images = resume_terminal(&mut terminal).map_err(
+                                                        agent_client_protocol::Error::into_internal_error,
+                                                    )?;
+                                                    events = EventStream::new();
+                                                    break session;
+                                                }
+                                                Err(error) if authentication_required(
+                                                    &error,
+                                                    &app.auth_methods,
+                                                ) => app.note(format!(
+                                                    "could not start the session: {}; use /login to authenticate",
+                                                    error_detail(&error)
+                                                )),
+                                                Err(error) => return Err(error),
+                                            }
                                         }
                                         Ok(status) => app.note(format!(
                                             "authentication with {} failed: {status}",
@@ -1228,7 +1280,9 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                 Action::SelectModel { choice, save_defaults } => {
                                     let response = connection.send_request(
                                         SetSessionConfigOptionRequest::new(
-                                            session_id.clone(), "model", choice.id.as_str(),
+                                            session_id.clone(),
+                                            MODEL_CONFIG_ID,
+                                            choice.id.as_str(),
                                         ),
                                     ).block_task().await;
                                     match response {
@@ -1253,7 +1307,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     let response = connection
                                         .send_request(SetSessionConfigOptionRequest::new(
                                             session_id.clone(),
-                                            "reasoning_effort",
+                                            REASONING_EFFORT_CONFIG_ID,
                                             effort.as_str(),
                                         ))
                                         .block_task()
@@ -1286,31 +1340,9 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                 }
                                 Action::Login(method) => {
                                     drop(events);
-                                    let refreshed_id = durable_session_id(&session_id)
-                                        .map_err(|error| {
-                                            agent_client_protocol::Error::into_internal_error(
-                                                std::io::Error::other(error),
-                                            )
-                                        })?;
-                                    let current_auth_command = agent_command_for_launch(
-                                        &root,
-                                        &model,
-                                        provider,
-                                        reasoning_effort,
-                                        openrouter_api_key,
-                                        a2a_address.as_deref(),
-                                        mcp_config.as_deref(),
-                                        telemetry,
-                                        credential_storage,
-                                        &refreshed_id,
-                                        true,
-                                        false,
-                                    )
-                                    .map_err(agent_client_protocol::Error::into_internal_error)?;
-                                    let current_auth_invocation =
-                                        AgentInvocation::from_command(current_auth_command.as_std());
+                                    let active_config = active_session_config(&app);
                                     let authentication = authenticate_in_terminal(
-                                        &current_auth_invocation,
+                                        &auth_invocation,
                                         &root,
                                         &method,
                                         &mut stop,
@@ -1346,17 +1378,17 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                     };
                                     match outcome {
                                         Ok(status) if status.success() => {
-                                            // Closing this callback closes the ACP connection;
-                                            // the outer loop then reaps this child before resuming
-                                            // the session on a newly initialized agent.
-                                            *reconnect_resume
-                                                .lock()
-                                                .expect("ACP reconnect state poisoned") =
-                                                Some(ReconnectLaunch {
-                                                    resume_session_id: Some(refreshed_id),
-                                                    force: false,
-                                                });
-                                            return Ok(());
+                                            let options = refresh_session_after_auth(
+                                                &connection,
+                                                session_id.clone(),
+                                                &active_config,
+                                            )
+                                            .await?;
+                                            refresh_config_state(&mut app, Some(&options));
+                                            app.note(format!(
+                                                "authentication with {} succeeded",
+                                                method.name
+                                            ));
                                         }
                                         Ok(status) => app.note(format!(
                                             "authentication with {} failed: {status}",
@@ -1476,8 +1508,6 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
         // after CloseSession has unwound the lock owner, then wait for OS locks to
         // be released rather than relying on `kill_on_drop`.
         let _ = shutdown_tx.send(());
-        // Keep this await before the reconnect check: a replacement must not
-        // start until the old ACP process has been killed and reaped.
         let _ = watcher.await;
         // If the server failed before acknowledging CloseSession, reclaim only a
         // lock that is now provably stale; a live owner's OS lock is never stolen.
@@ -1485,19 +1515,8 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
             let _ = crate::session::remove_stale_lock(&cleanup_root, &active.id);
         }
 
-        let reconnect = reconnect_resume
-            .lock()
-            .ok()
-            .and_then(|mut reconnect| reconnect.take());
-        if result.is_ok()
-            && let Some(reconnect) = reconnect
-        {
-            resume_session_id = reconnect.resume_session_id;
-            launch_force = reconnect.force;
-            continue;
-        }
         result?;
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -2286,18 +2305,20 @@ mod tests {
         SessionConfigOption, SessionConfigSelectGroup, SessionConfigSelectOption, SessionUpdate,
         StateUpdate, TextContent, UpdateSessionNotification, UserMessage,
     };
+    use agent_client_protocol::{Channel, ConnectTo};
     use crossterm::event::Event;
 
     use serde_json::json;
 
     use super::{
         ActiveSessionRoute, AgentInvocation, ConnectedAuthentication, MAX_ATTACHMENTS, MAX_BURST,
-        ModelChoice, QueuedUpdate, accept_queued_update, agent_command_for_launch,
-        apply_pending_updates, attachments_from_paste, authentication_required,
-        client_capabilities, command, credential_storage_for_launch, current_model_choice,
-        detach_from_controlling_terminal, durable_session_id, effort_state, error_detail, handle,
-        message_of, osc52, previous_session_for_resume, prompt_blocks, readable,
-        refresh_config_state, save_effort_default_to, save_model_defaults_to,
+        ModelChoice, ProtocolVersion, QueuedUpdate, accept_queued_update, active_config_matches,
+        active_session_config, agent_command_for_launch, apply_pending_updates,
+        attachments_from_paste, authentication_required, client_capabilities, command,
+        credential_storage_for_launch, current_model_choice, detach_from_controlling_terminal,
+        durable_session_id, effort_state, error_detail, handle, message_of, osc52,
+        previous_session_for_resume, prompt_blocks, readable, refresh_config_state,
+        refresh_session_after_auth, save_effort_default_to, save_model_defaults_to,
         terminal_auth_command, transition_route, translate, translate_for_session,
         usable_terminal_auth_methods, user_message_of, wait_for_connected_authentication, wire,
     };
@@ -2402,7 +2423,7 @@ mod tests {
     }
 
     #[test]
-    fn reconnect_launch_tracks_transitioned_session_and_preserves_base_options() {
+    fn agent_launch_tracks_transitioned_session_and_preserves_base_options() {
         let root = tempfile::tempdir().unwrap();
         let mcp_config = root.path().join("mcp.toml");
         let telemetry = crate::telemetry::Settings::try_new(None, false, 12, 4096).unwrap();
@@ -3100,6 +3121,172 @@ a = [still text]
             toml::from_str::<toml::Value>(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert!(saved.get("reasoning_effort").is_none());
         assert_eq!(saved["model"].as_str(), Some("kept"));
+    }
+
+    #[test]
+    fn successful_login_refresh_preserves_active_provider_model_and_effort() {
+        let options = vec![
+            SessionConfigOption::select(
+                "model",
+                "Model",
+                "openrouter:active-model",
+                vec![SessionConfigSelectGroup::new(
+                    "openrouter",
+                    "OpenRouter",
+                    vec![
+                        SessionConfigSelectOption::new("openrouter:old-model", "old-model"),
+                        SessionConfigSelectOption::new("openrouter:active-model", "active-model"),
+                    ],
+                )],
+            ),
+            SessionConfigOption::select(
+                "reasoning_effort",
+                "Reasoning effort",
+                "high",
+                vec![SessionConfigSelectGroup::new(
+                    "reasoning-effort",
+                    "Reasoning effort",
+                    vec![
+                        SessionConfigSelectOption::new("default", "Default"),
+                        SessionConfigSelectOption::new("high", "High"),
+                    ],
+                )],
+            ),
+        ];
+        let mut app = App::new(
+            PathBuf::from("."),
+            "openrouter".into(),
+            "active-model".into(),
+            "127.0.0.1:4321".into(),
+        );
+        app.set_model_choices(super::model_choices(Some(&options)));
+        app.set_effort(
+            "high".into(),
+            vec![
+                crate::tui::app::EffortChoice {
+                    id: "default".into(),
+                    name: "Default".into(),
+                },
+                crate::tui::app::EffortChoice {
+                    id: "high".into(),
+                    name: "High".into(),
+                },
+            ],
+        );
+
+        let active = active_session_config(&app);
+        assert_eq!(active.model, "openrouter:active-model");
+        assert_eq!(active.reasoning_effort.as_deref(), Some("high"));
+        assert!(active_config_matches(&active, &options));
+    }
+
+    #[test]
+    fn successful_login_refresh_preserves_a_custom_model_outside_the_catalog() {
+        let mut app = App::new(
+            PathBuf::from("."),
+            "openai-subscription".into(),
+            "custom-model".into(),
+            "a2a".into(),
+        );
+        app.set_model_choices(vec![ModelChoice {
+            id: "openai-subscription:gpt-5.4".into(),
+            provider: "openai-subscription".into(),
+            model: "gpt-5.4".into(),
+        }]);
+
+        assert_eq!(
+            active_session_config(&app).model,
+            "openai-subscription:custom-model"
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_login_refresh_is_scoped_to_the_active_session() {
+        let mut app = App::new(
+            PathBuf::from("."),
+            "openrouter".into(),
+            "same-model".into(),
+            "127.0.0.1:4321".into(),
+        );
+        let options = vec![SessionConfigOption::select(
+            "model",
+            "Model",
+            "openrouter:same-model",
+            vec![SessionConfigSelectGroup::new(
+                "openrouter",
+                "OpenRouter",
+                vec![SessionConfigSelectOption::new(
+                    "openrouter:same-model",
+                    "same-model",
+                )],
+            )],
+        )];
+        app.set_model_choices(super::model_choices(Some(&options)));
+        let active = active_session_config(&app);
+
+        let root = tempfile::tempdir().unwrap();
+        let credentials = crate::credentials::CredentialStorage::Memory;
+        crate::provider::store_openrouter_test_credentials(&credentials);
+        let runtime = crate::runtime::Runtime::new_with_provider_credentials_and_effort(
+            root.path(),
+            "same-model",
+            crate::ProviderKind::OpenRouter,
+            credentials,
+            None,
+        )
+        .unwrap();
+        let registry = crate::protocols::acp::SessionRegistry::new();
+        let agent = crate::protocols::acp::v2::component(runtime, registry).unwrap();
+        let (client_transport, agent_transport) = Channel::duplex();
+        let server = tokio::spawn(async move { agent.connect_to(agent_transport).await });
+        let workspace = root.path().to_path_buf();
+
+        agent_client_protocol::Client
+            .v2()
+            .connect_with(client_transport, async move |connection| {
+                connection
+                    .send_request(wire::InitializeRequest::new(
+                        ProtocolVersion::V2,
+                        wire::Implementation::new("test", "0"),
+                    ))
+                    .block_task()
+                    .await?;
+                let active_session = connection
+                    .send_request(wire::NewSessionRequest::new(workspace.clone()))
+                    .block_task()
+                    .await?;
+                let unrelated_session = connection
+                    .send_request(wire::NewSessionRequest::new(workspace.clone()))
+                    .block_task()
+                    .await?;
+
+                refresh_session_after_auth(&connection, active_session.session_id.clone(), &active)
+                    .await?;
+
+                // This request proves that refreshing the TUI route left another
+                // route in the shared serve runtime active.
+                connection
+                    .send_request(wire::SetSessionConfigOptionRequest::new(
+                        unrelated_session.session_id.clone(),
+                        "reasoning_effort",
+                        "high",
+                    ))
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(wire::CloseSessionRequest::new(active_session.session_id))
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(wire::CloseSessionRequest::new(unrelated_session.session_id))
+                    .block_task()
+                    .await?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        server.abort();
+        let _ = server.await;
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -182,6 +182,9 @@ fn detach_from_controlling_terminal(_command: &mut tokio::process::Command) {}
 fn error_detail(error: &agent_client_protocol::Error) -> &str {
     match error.data.as_ref() {
         Some(Value::String(detail)) => detail,
+        Some(data) => crate::protocols::acp::AuthenticationRequiredData::from_value(data)
+            .map(|required| required.detail)
+            .unwrap_or(&error.message),
         _ => &error.message,
     }
 }
@@ -190,11 +193,16 @@ fn authentication_required(
     error: &agent_client_protocol::Error,
     methods: &[wire::AuthMethodTerminal],
 ) -> bool {
-    let detail = error_detail(error).to_ascii_lowercase();
-    methods.iter().any(|method| {
-        let method_id = method.method_id.0.to_ascii_lowercase();
-        !method_id.is_empty() && detail.contains(method_id.as_str())
-    })
+    let Some(required) = error
+        .data
+        .as_ref()
+        .and_then(crate::protocols::acp::AuthenticationRequiredData::from_value)
+    else {
+        return false;
+    };
+    methods
+        .iter()
+        .any(|method| method.method_id.0.as_ref() == required.method_id)
 }
 
 fn credential_storage_for_launch(
@@ -2159,10 +2167,10 @@ mod tests {
         ActiveSessionRoute, MAX_ATTACHMENTS, ModelChoice, QueuedUpdate, accept_queued_update,
         attachments_from_paste, authentication_required, client_capabilities, command,
         credential_storage_for_launch, current_model_choice, detach_from_controlling_terminal,
-        durable_session_id, effort_state, handle, message_of, osc52, previous_session_for_resume,
-        prompt_blocks, readable, refresh_config_state, save_effort_default_to,
-        save_model_defaults_to, terminal_auth_command, transition_route, translate,
-        translate_for_session, usable_terminal_auth_methods, user_message_of, wire,
+        durable_session_id, effort_state, error_detail, handle, message_of, osc52,
+        previous_session_for_resume, prompt_blocks, readable, refresh_config_state,
+        save_effort_default_to, save_model_defaults_to, terminal_auth_command, transition_route,
+        translate, translate_for_session, usable_terminal_auth_methods, user_message_of, wire,
     };
     use crate::{
         tools::mcp::CredentialStorage,
@@ -2178,15 +2186,31 @@ mod tests {
                 "openrouter".into(),
             ]),
         ];
-        assert!(authentication_required(
-            &agent_client_protocol::util::internal_error(
+        let required = agent_client_protocol::Error::internal_error().data(
+            crate::protocols::acp::AuthenticationRequiredData::new(
+                "openrouter",
                 "run `kit auth login openrouter` before using OpenRouter",
+            )
+            .into_value(),
+        );
+        assert!(authentication_required(&required, &methods));
+        assert_eq!(
+            error_detail(&required),
+            "run `kit auth login openrouter` before using OpenRouter"
+        );
+        assert!(!authentication_required(
+            &agent_client_protocol::util::internal_error(
+                "stored OpenRouter credentials cannot be used with a noncanonical endpoint",
             ),
             &methods,
         ));
         assert!(!authentication_required(
-            &agent_client_protocol::util::internal_error(
-                "run `kit auth login speakeasy` before using Speakeasy",
+            &agent_client_protocol::Error::internal_error().data(
+                crate::protocols::acp::AuthenticationRequiredData::new(
+                    "speakeasy",
+                    "authentication required",
+                )
+                .into_value(),
             ),
             &methods,
         ));

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1947,11 +1947,16 @@ fn draw_prompt_editor(frame: &mut Frame<'_>, app: &App, area: Rect, placeholder_
             placeholder_style,
         ))]
     } else {
-        prompt_lines(rows, app.editor.text(), &app.available_commands)
-            .into_iter()
-            .skip(first)
-            .take(height)
-            .collect()
+        prompt_lines(
+            rows,
+            app.editor.text(),
+            &app.available_commands,
+            !app.auth_methods.is_empty(),
+        )
+        .into_iter()
+        .skip(first)
+        .take(height)
+        .collect()
     };
     frame.render_widget(Paragraph::new(lines), field);
     frame.set_cursor_position(Position::new(
@@ -1967,8 +1972,9 @@ fn prompt_lines(
     rows: Vec<String>,
     input: &str,
     available_commands: &[command::Command],
+    login_available: bool,
 ) -> Vec<Line<'static>> {
-    let mut highlights = command::known_token(input, available_commands)
+    let mut highlights = command::known_token(input, available_commands, login_available)
         .into_iter()
         .collect::<Vec<_>>();
     highlights.extend(input.char_indices().filter_map(|(start, character)| {
@@ -3547,12 +3553,12 @@ mod tests {
 
     #[test]
     fn highlights_only_the_known_new_token() {
-        let known = prompt_lines(vec!["/new prompt".into()], "/new prompt", &[]);
+        let known = prompt_lines(vec!["/new prompt".into()], "/new prompt", &[], false);
         assert_eq!(known[0].spans[0].content, "/new");
         assert_eq!(known[0].spans[0].style, crate::tui::theme::accent());
         assert_eq!(known[0].spans[1].content, " prompt");
 
-        let unknown = prompt_lines(vec!["/newer prompt".into()], "/newer prompt", &[]);
+        let unknown = prompt_lines(vec!["/newer prompt".into()], "/newer prompt", &[], false);
         assert_eq!(unknown[0].spans.len(), 1);
         assert_eq!(unknown[0].spans[0].style, crate::tui::theme::text());
 
@@ -3564,6 +3570,7 @@ mod tests {
             vec!["/compact prompt".into()],
             "/compact prompt",
             &advertised,
+            false,
         );
         assert_eq!(dynamic[0].spans[0].content, "/compact");
         assert_eq!(dynamic[0].spans[0].style, crate::tui::theme::accent());
@@ -3574,7 +3581,7 @@ mod tests {
         let mut editor = crate::tui::editor::Editor::default();
         editor.insert_str("/new prompt");
         let (rows, _) = editor.wrapped(2);
-        let lines = prompt_lines(rows, editor.text(), &[]);
+        let lines = prompt_lines(rows, editor.text(), &[], false);
         let highlighted = lines
             .iter()
             .flat_map(|line| &line.spans)

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3596,7 +3596,7 @@ mod tests {
     #[test]
     fn highlights_file_paths_in_the_prompt() {
         let input = "review @src/tui/app.rs and name@example.com";
-        let lines = prompt_lines(vec![input.into()], input, &[]);
+        let lines = prompt_lines(vec![input.into()], input, &[], false);
         let highlighted = lines[0]
             .spans
             .iter()


### PR DESCRIPTION
## Summary

Surface a `/login` command only when the connected ACP agent advertises usable terminal authentication methods. Run the selected method outside TUI terminal modes with inherited interactive I/O, then restore or bootstrap the ACP session with clear status and errors.

## Technical details

Terminal auth capability negotiation is limited to persistent credential stores. OpenRouter credential resolution is deferred until ACP session startup so unauthenticated agents can complete initialization and advertise login methods.
