### PR TITLE
fix(release): ignore merge commit subjects

### DIFF
--- a/scripts/next-release-version.sh
+++ b/scripts/next-release-version.sh
@@ -44,11 +44,11 @@ git rev-parse --verify "$to_ref^{commit}" >/dev/null 2>&1 ||
 git merge-base --is-ancestor "$from_ref" "$to_ref" ||
   die "release ref $from_ref is not an ancestor of $to_ref"
 
-commit_count=$(git rev-list --count "$from_ref..$to_ref")
+commit_count=$(git rev-list --no-merges --count "$from_ref..$to_ref")
 [ "$commit_count" -gt 0 ] || die "no commits to release"
 
 invalid_commits=$(
-  git log --format='%h %s' "$from_ref..$to_ref" |
+  git log --no-merges --format='%h %s' "$from_ref..$to_ref" |
     grep -Ev '^[0-9a-f]+ [a-z][a-z0-9-]*(\([^()]+\))?!?: .+' || true
 )
 if [ -n "$invalid_commits" ]; then
@@ -57,10 +57,10 @@ $invalid_commits"
 fi
 
 bump=patch
-if git log --format='%s' "$from_ref..$to_ref" |
+if git log --no-merges --format='%s' "$from_ref..$to_ref" |
     grep -Eq '^[a-z][a-z0-9-]*(\([^()]+\))?!: .+'; then
   bump=minor
-elif git log --format='%b' "$from_ref..$to_ref" |
+elif git log --no-merges --format='%b' "$from_ref..$to_ref" |
     grep -Eq '^BREAKING CHANGE:($|[[:space:]])'; then
   bump=minor
 fi

--- a/scripts/tests/test_next_release_version.sh
+++ b/scripts/tests/test_next_release_version.sh
@@ -18,6 +18,7 @@ new_repo() {
   git -C "$repo" add changes
   git -C "$repo" commit -qm 'chore: release 1.2.3'
   git -C "$repo" tag v1.2.3
+  base_branch=$(git -C "$repo" branch --show-current)
 }
 
 commit_change() {
@@ -79,5 +80,12 @@ expect_failure 1.2.3 HEAD v1.2.3
 new_repo
 commit_change 'update documentation'
 expect_failure 1.2.3 v1.2.3 HEAD
+
+new_repo
+git -C "$repo" switch -qc topic
+commit_change 'feat: add merged behavior'
+git -C "$repo" switch -q "$base_branch"
+git -C "$repo" merge --no-ff -qm 'Merge pull request #1 from example/topic' topic
+expect_version 1.2.4
 
 printf 'next release version tests passed\n'


### PR DESCRIPTION
## Summary

Exclude merge commits when validating Conventional Commit subjects and calculating the next release version. Add coverage for repositories that retain non-Conventional merge subjects around otherwise valid commits.

## Motivation

The release workflow currently rejects merge commits generated by GitHub even when every authored change uses a Conventional Commit subject, blocking releases from `main`.
