### PR TITLE
feat(compose): add intent and tool call details

### DIFF
--- a/macos/KitDesktop/Models/AppState.swift
+++ b/macos/KitDesktop/Models/AppState.swift
@@ -161,10 +161,21 @@ enum ComposeBackgroundRequest: Equatable {
 }
 
 struct ComposePresentation: Equatable {
+    let intent: String?
     let script: String
     let input: PresentationJSON?
     let background: ComposeBackgroundRequest?
     var output: PresentationJSON?
+
+    static func childToolSummary(_ toolNames: [String], maximumDistinctTools: Int = 4) -> String {
+        let counts = Dictionary(toolNames.map { ($0, 1) }, uniquingKeysWith: +)
+        return counts.sorted { lhs, rhs in
+            lhs.value == rhs.value ? lhs.key < rhs.key : lhs.value > rhs.value
+        }
+        .prefix(max(0, maximumDistinctTools))
+        .map { name, count in count > 1 ? "\(name) x \(count)" : name }
+        .joined(separator: ", ")
+    }
 }
 
 struct ToolPresentation: Equatable {

--- a/macos/KitDesktop/Models/ConversationController.swift
+++ b/macos/KitDesktop/Models/ConversationController.swift
@@ -1109,27 +1109,34 @@ final class ConversationController: ObservableObject {
         if let content = update.content { dictionary["content"] = content.anyValue }
         if let rawInput = update.rawInput { dictionary["rawInput"] = rawInput.anyValue }
         if let rawOutput = update.rawOutput { dictionary["rawOutput"] = rawOutput.anyValue }
+        if let name = update.name { dictionary["name"] = name }
         return dictionary
     }
 
     static func toolPresentation(_ update: [String: Any]) -> ToolPresentation {
         let rawInput = update["rawInput"] as? [String: Any]
         let detail = toolDetail(update)
-        let allowedComposeKeys: Set<String> = ["script", "input", "background"]
-        let isComposeInput = rawInput.map { Set($0.keys).isSubset(of: allowedComposeKeys) } == true
+        let allowedComposeKeys: Set<String> = ["intent", "script", "input", "background"]
+        let toolName = update["name"] as? String
+        let hasComposeShape = rawInput.map { Set($0.keys).isSubset(of: allowedComposeKeys) } == true
+        let isComposeInput = toolName == "compose" || (toolName == nil && hasComposeShape)
         let compose = isComposeInput ? rawInput?["script"].flatMap { $0 as? String }.map { script in
             let background: ComposeBackgroundRequest? = switch rawInput?["background"] {
             case let value as Bool: .immediate(value)
             case let value as NSNumber: .delay(seconds: value.intValue)
             default: nil
             }
+            let intent = (rawInput?["intent"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let contentOutput: PresentationJSON? = update["content"] == nil || detail.isEmpty ? nil : .string(detail)
+            let output = contentOutput ?? update["rawOutput"].flatMap(PresentationJSON.init)
             return ComposePresentation(
-                script: script, input: rawInput?["input"].flatMap(PresentationJSON.init),
-                background: background, output: update["rawOutput"].flatMap(PresentationJSON.init)
+                intent: intent?.isEmpty == false ? intent : nil, script: script,
+                input: rawInput?["input"].flatMap(PresentationJSON.init),
+                background: background, output: output
             )
         } : nil
         return ToolPresentation(
-            title: update["title"] as? String ?? "Tool",
+            title: compose.map { $0.intent ?? "Running tools." } ?? (update["title"] as? String ?? "Tool"),
             status: (update["status"] as? String).map(ToolPresentationStatus.init) ?? .inProgress,
             detail: detail, compose: compose
         )

--- a/macos/KitDesktop/Views/ContentView.swift
+++ b/macos/KitDesktop/Views/ContentView.swift
@@ -1119,18 +1119,41 @@ private struct ThoughtCard: View {
 }
 
 private struct ComposePresentationView: View {
+    private enum Tab: Hashable { case script, output }
+
     let compose: ComposePresentation
+    @State private var selectedTab: Tab = .output
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            section("Program", text: compose.script)
-            if let input = compose.input { section("Input", text: input.formatted) }
-            if let background = compose.background {
-                Label(backgroundLabel(background), systemImage: "clock.arrow.circlepath")
-                    .font(.caption).foregroundStyle(.secondary)
+            Picker("Compose details", selection: $selectedTab) {
+                Text("Script").tag(Tab.script)
+                Text("Output").tag(Tab.output)
             }
-            if let output = compose.output { section("Output", text: output.formatted) }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            switch selectedTab {
+            case .script:
+                section("Program", text: compose.script)
+                if let input = compose.input { section("Input", text: input.formatted) }
+                if let background = compose.background {
+                    Label(backgroundLabel(background), systemImage: "clock.arrow.circlepath")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            case .output:
+                if let output = compose.output {
+                    section("Output", text: outputText(output))
+                } else {
+                    Text("No output yet.").font(.caption).foregroundStyle(.secondary)
+                }
+            }
         }
+    }
+
+    private func outputText(_ output: PresentationJSON) -> String {
+        if case .string(let text) = output { return text }
+        return output.formatted
     }
 
     private func backgroundLabel(_ background: ComposeBackgroundRequest) -> String {
@@ -1180,7 +1203,12 @@ private struct ToolCard: View {
                     Text(tool.status.label)
                         .brandMicroLabel().foregroundStyle(.secondary)
                     Spacer()
-                    if !entry.children.isEmpty { Text("\(entry.children.count) calls").brandMeta().foregroundStyle(.tertiary) }
+                    if !entry.children.isEmpty {
+                        let summary = tool.compose != nil && !entry.isStreaming
+                            ? ComposePresentation.childToolSummary(entry.children.map(\.tool))
+                            : "\(entry.children.count) calls"
+                        Text(summary).brandMeta().foregroundStyle(.tertiary).lineLimit(1)
+                    }
                     Image(systemName: expanded ? "chevron.up" : "chevron.down").font(.caption2).foregroundStyle(.tertiary)
                 }.contentShape(Rectangle())
             }.buttonStyle(.plain).pointingHandCursor().padding(.horizontal, 14).padding(.vertical, 12)

--- a/macos/KitDesktop/Views/ContentView.swift
+++ b/macos/KitDesktop/Views/ContentView.swift
@@ -1122,7 +1122,12 @@ private struct ComposePresentationView: View {
     private enum Tab: Hashable { case script, output }
 
     let compose: ComposePresentation
-    @State private var selectedTab: Tab = .output
+    @State private var selectedTab: Tab
+
+    init(compose: ComposePresentation) {
+        self.compose = compose
+        _selectedTab = State(initialValue: compose.output == nil ? .script : .output)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/macos/KitDesktopTests/ACPProtocolTests.swift
+++ b/macos/KitDesktopTests/ACPProtocolTests.swift
@@ -161,17 +161,35 @@ final class ACPProtocolTests: XCTestCase {
         let tool = ConversationController.toolPresentation([
             "title": "Run program", "status": "pending",
             "rawInput": [
+                "intent": "  Check the workspace  ",
                 "script": "return shell({ command: \"pwd\" })",
                 "input": ["root": "/tmp"], "background": 5,
             ],
             "rawOutput": ["text": "done"],
         ])
-        XCTAssertEqual(tool.title, "Run program")
+        XCTAssertEqual(tool.title, "Check the workspace")
         XCTAssertEqual(tool.status, .pending)
+        XCTAssertEqual(tool.compose?.intent, "Check the workspace")
         XCTAssertEqual(tool.compose?.script, "return shell({ command: \"pwd\" })")
         XCTAssertEqual(tool.compose?.input, .object(["root": .string("/tmp")]))
         XCTAssertEqual(tool.compose?.background, .delay(seconds: 5))
         XCTAssertEqual(tool.compose?.output, .object(["text": .string("done")]))
+
+        let untitled = ConversationController.toolPresentation([
+            "title": "compose",
+            "rawInput": ["intent": " \n\t ", "script": "return 1"],
+            "content": [["content": ["type": "text", "text": "fallback result"]]],
+            "rawOutput": ["machine": true],
+        ])
+        XCTAssertNil(untitled.compose?.intent)
+        XCTAssertEqual(untitled.title, "Running tools.")
+        XCTAssertEqual(untitled.compose?.output, .string("fallback result"))
+
+        XCTAssertNil(ConversationController.toolPresentation([
+            "name": "other-tool",
+            "rawInput": ["intent": "Not compose", "script": "return 1"],
+        ]).compose)
+
         XCTAssertNil(ConversationController.toolPresentation([
             "rawInput": ["script": "not compose", "command": "other schema"],
         ]).compose)
@@ -189,6 +207,14 @@ final class ACPProtocolTests: XCTestCase {
             "name": "diagram", "uri": "file:///tmp/diagram.webp",
         ])
         XCTAssertEqual(linked.media.first?.url, URL(fileURLWithPath: "/tmp/diagram.webp"))
+    }
+
+    func testComposeChildToolSummaryGroupsSortsAndCapsNames() {
+        let summary = ComposePresentation.childToolSummary([
+            "shell", "edit", "shell", "tool", "edit", "docs", "auth", "docs", "a2a",
+        ])
+
+        XCTAssertEqual(summary, "docs x 2, edit x 2, shell x 2, a2a")
     }
 
     func testLargeInlineUserMediaSurvivesTransportCapping() {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2000,6 +2000,12 @@ impl BackgroundableCompose {
                 )));
             }
         }
+        if object
+            .remove("intent")
+            .is_some_and(|intent| !intent.is_string())
+        {
+            return Err(ToolError::InvalidInput("intent must be a string".into()));
+        }
         Ok(request)
     }
 }
@@ -2158,6 +2164,13 @@ fn backgroundable_spec(mut spec: ToolSpec) -> ToolSpec {
         .get_mut("properties")
         .and_then(Value::as_object_mut)
     {
+        properties.insert(
+            "intent".into(),
+            json!({
+                "type": "string",
+                "description": "A short user-facing sentence explaining what the script is doing."
+            }),
+        );
         properties.insert(
             "background".into(),
             json!({

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2168,7 +2168,7 @@ fn backgroundable_spec(mut spec: ToolSpec) -> ToolSpec {
             "intent".into(),
             json!({
                 "type": "string",
-                "description": "A brief user-facing status sentence, preferably 3–10 words. Start with an -ing verb; omit first-person language, rationale, and implementation details. Example: \"Checking AgentKit's telemetry for useful metrics.\""
+                "description": "A brief user-facing status sentence, preferably 3–10 words. Start with an -ing verb; omit first-person language, rationale, and implementation details."
             }),
         );
         properties.insert(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2168,7 +2168,7 @@ fn backgroundable_spec(mut spec: ToolSpec) -> ToolSpec {
             "intent".into(),
             json!({
                 "type": "string",
-                "description": "A short user-facing sentence explaining what the script is doing."
+                "description": "A brief user-facing status sentence, preferably 3–10 words. Start with an -ing verb; omit first-person language, rationale, and implementation details. Example: \"Checking AgentKit's telemetry for useful metrics.\""
             }),
         );
         properties.insert(

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -1071,6 +1071,20 @@ fn compose_is_the_only_visible_tool_and_documents_mcp_meta_tools() {
     assert_eq!(specs.len(), 1);
     assert_eq!(specs[0].name.0, "compose");
     assert_eq!(
+        specs[0].input_schema["properties"]["intent"]["type"],
+        "string"
+    );
+    assert!(
+        specs[0].input_schema["properties"]["intent"]["description"]
+            .as_str()
+            .is_some_and(|description| description.contains("short user-facing sentence"))
+    );
+    assert!(
+        specs[0].input_schema["required"]
+            .as_array()
+            .is_none_or(|required| !required.contains(&json!("intent")))
+    );
+    assert_eq!(
         specs[0].input_schema["properties"]["background"]["oneOf"],
         json!([
             {"type": "boolean"},
@@ -1470,6 +1484,23 @@ async fn compose_background_sanitization_rejects_invalid_and_strips_before_dispa
             invoke(&runtime, value).await,
             ToolExecutionOutcome::Failed(_)
         ));
+    }
+
+    let with_intent = |intent| {
+        ToolRequest::new(
+            ToolCallId::new("call"),
+            ToolName::new("compose"),
+            json!({"script": "return 7", "intent": intent}),
+            SessionId::new("session"),
+            TurnId::new("turn"),
+        )
+    };
+    let sanitized =
+        BackgroundableCompose::sanitized(with_intent(json!("Check the runtime behavior.")))
+            .unwrap();
+    assert!(sanitized.input.get("intent").is_none());
+    for invalid in [json!(7), json!(true), json!(null), json!({})] {
+        assert!(BackgroundableCompose::sanitized(with_intent(invalid)).is_err());
     }
 }
 

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -1077,7 +1077,11 @@ fn compose_is_the_only_visible_tool_and_documents_mcp_meta_tools() {
     assert!(
         specs[0].input_schema["properties"]["intent"]["description"]
             .as_str()
-            .is_some_and(|description| description.contains("short user-facing sentence"))
+            .is_some_and(|description| {
+                description.contains("preferably 3–10 words")
+                    && description.contains("omit first-person language")
+                    && description.contains("Checking AgentKit's telemetry for useful metrics.")
+            })
     );
     assert!(
         specs[0].input_schema["required"]

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -1080,7 +1080,7 @@ fn compose_is_the_only_visible_tool_and_documents_mcp_meta_tools() {
             .is_some_and(|description| {
                 description.contains("preferably 3–10 words")
                     && description.contains("omit first-person language")
-                    && description.contains("Checking AgentKit's telemetry for useful metrics.")
+                    && !description.contains("Example:")
             })
     );
     assert!(

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -103,6 +103,7 @@ pub enum Update {
         script: Option<String>,
         output: Option<Vec<String>>,
         append_output: bool,
+        intent: Option<Option<String>>,
         backgrounded: bool,
     },
     /// Agent-advertised slash commands for one session.
@@ -331,6 +332,13 @@ impl Child {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ComposeView {
+    #[default]
+    Output,
+    Script,
+}
+
 /// A model-visible tool call and, for compose, the program running inside it.
 pub struct ToolCall {
     pub id: String,
@@ -345,14 +353,33 @@ pub struct ToolCall {
     pub children: Vec<Child>,
     /// Raw tool output, kept whole but folded away until asked for.
     pub output: Vec<String>,
+    /// User-facing summary supplied by a compose caller.
+    pub intent: Option<String>,
     pub expanded: bool,
-    /// The user explicitly chose the output's expanded or collapsed state.
+    /// The selected view for an expanded completed compose call.
+    pub compose_view: ComposeView,
+    /// The user explicitly chose the call's expanded state or compose view.
     pub expansion_explicit: bool,
     /// The call detached from its originating turn.
     pub backgrounded: bool,
 }
 
 impl ToolCall {
+    pub fn is_compose(&self) -> bool {
+        self.title == agentkit_tool_compose::COMPOSE_TOOL_NAME
+    }
+
+    pub fn display_title(&self) -> &str {
+        if !self.is_compose() {
+            return &self.title;
+        }
+        self.intent
+            .as_deref()
+            .map(str::trim)
+            .filter(|intent| !intent.is_empty())
+            .unwrap_or("Running tools.")
+    }
+
     pub fn running(&self) -> bool {
         matches!(
             self.status,
@@ -363,6 +390,15 @@ impl ToolCall {
     pub fn elapsed(&self) -> u64 {
         let end = self.finished.unwrap_or_else(Instant::now);
         u64::try_from(end.duration_since(self.started).as_millis()).unwrap_or(u64::MAX)
+    }
+
+    fn finalize_terminal_state(&mut self) {
+        if self.is_compose() && !self.expansion_explicit {
+            self.expanded = false;
+            self.compose_view = ComposeView::Output;
+        }
+        self.finished = Some(Instant::now());
+        self.finish_running_children();
     }
 
     /// Records a nested dispatch against the plan node most likely to own it.
@@ -1020,14 +1056,6 @@ impl App {
         }
     }
 
-    fn call_is_latest_message(&self, id: &str) -> bool {
-        self.call_index(id).is_some_and(|index| {
-            self.blocks[index + 1..]
-                .iter()
-                .all(|block| matches!(block, Block::TurnDuration(_)))
-        })
-    }
-
     fn block_is_dynamic(block: &Block) -> bool {
         match block {
             Block::Thought { millis, .. } => millis.is_none(),
@@ -1260,7 +1288,13 @@ impl App {
                                     .unwrap_or_default(),
                                 children: Vec::new(),
                                 output: Vec::new(),
-                                expanded: call.name == agentkit_tool_compose::COMPOSE_TOOL_NAME,
+                                intent: call
+                                    .input
+                                    .get("intent")
+                                    .and_then(serde_json::Value::as_str)
+                                    .map(str::to_string),
+                                expanded: false,
+                                compose_view: ComposeView::Output,
                                 expansion_explicit: false,
                                 backgrounded: false,
                             })),
@@ -1685,8 +1719,7 @@ impl App {
                 } else {
                     ToolCallStatus::Failed
                 };
-                call.finished = Some(Instant::now());
-                call.finish_running_children();
+                call.finalize_terminal_state();
                 finished.push(index);
             }
         }
@@ -1834,7 +1867,9 @@ impl App {
                     script: script.unwrap_or_default(),
                     children: Vec::new(),
                     output: Vec::new(),
+                    intent: None,
                     expanded,
+                    compose_view: ComposeView::Output,
                     expansion_explicit: false,
                     backgrounded,
                 }));
@@ -1847,7 +1882,6 @@ impl App {
                 output,
                 backgrounded,
             } => {
-                let expand_compose = self.call_is_latest_message(&id);
                 let completed_background = {
                     let Some(call) = self.call_mut(&id) else {
                         return;
@@ -1864,13 +1898,7 @@ impl App {
                     if let Some(status) = status {
                         call.status = status;
                         if !call.running() {
-                            if call.title == agentkit_tool_compose::COMPOSE_TOOL_NAME
-                                && !call.expansion_explicit
-                            {
-                                call.expanded = expand_compose;
-                            }
-                            call.finished = Some(Instant::now());
-                            call.finish_running_children();
+                            call.finalize_terminal_state();
                         }
                     }
                     was_running && !call.running() && call.backgrounded
@@ -1891,6 +1919,7 @@ impl App {
                 script,
                 output,
                 append_output,
+                intent,
                 backgrounded,
             } => {
                 if self.call_index(&id).is_none() {
@@ -1902,13 +1931,13 @@ impl App {
                         backgrounded,
                     });
                 }
-                let expand_compose = self.call_is_latest_message(&id);
                 let Some(call) = self.call_mut(&id) else {
                     return;
                 };
                 if let Some(title) = title {
                     if title == agentkit_tool_compose::COMPOSE_TOOL_NAME
                         && call.title != agentkit_tool_compose::COMPOSE_TOOL_NAME
+                        && call.running()
                         && !call.expansion_explicit
                     {
                         call.expanded = true;
@@ -1917,6 +1946,9 @@ impl App {
                 }
                 if let Some(kind) = kind {
                     call.kind = kind;
+                }
+                if let Some(intent) = intent {
+                    call.intent = intent;
                 }
                 if let Some(script) = script {
                     call.plan = parse_plan(&script);
@@ -1934,13 +1966,7 @@ impl App {
                 if let Some(status) = status {
                     call.status = status;
                     if !call.running() {
-                        if call.title == agentkit_tool_compose::COMPOSE_TOOL_NAME
-                            && !call.expansion_explicit
-                        {
-                            call.expanded = expand_compose;
-                        }
-                        call.finished = Some(Instant::now());
-                        call.finish_running_children();
+                        call.finalize_terminal_state();
                     }
                 }
                 if let Some(index) = self.call_index(&id) {
@@ -2170,10 +2196,22 @@ impl App {
         self.blocks.len() as u64
     }
 
-    /// Folds a tool call's raw output open or shut.
+    /// Folds a tool call's raw output open or shut. Completed compose calls
+    /// cycle through their output and source views before folding closed.
     pub fn toggle_output(&mut self, id: &str) {
         if let Some(call) = self.call_mut(id) {
-            call.expanded = !call.expanded;
+            if call.is_compose() && !call.running() {
+                match (call.expanded, call.compose_view) {
+                    (false, _) => {
+                        call.expanded = true;
+                        call.compose_view = ComposeView::Output;
+                    }
+                    (true, ComposeView::Output) => call.compose_view = ComposeView::Script,
+                    (true, ComposeView::Script) => call.expanded = false,
+                }
+            } else {
+                call.expanded = !call.expanded;
+            }
             call.expansion_explicit = true;
         }
         if let Some(index) = self.call_index(id) {
@@ -4044,6 +4082,7 @@ mod tests {
             })
             .expect("tool block");
         assert_eq!(call.status, ToolCallStatus::Completed);
+        assert!(!call.expanded);
         assert!(!app.working());
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2126,6 +2126,11 @@ fn translate(notification: UpdateSessionNotification) -> (String, Vec<Update>) {
                 MaybeUndefined::Null => Some(String::new()),
                 MaybeUndefined::Undefined => None,
             };
+            let intent = match &update.raw_input {
+                MaybeUndefined::Value(input) => Some(intent_of(input)),
+                MaybeUndefined::Null => Some(None),
+                MaybeUndefined::Undefined => None,
+            };
             let backgrounded = update
                 .raw_input
                 .value()
@@ -2157,6 +2162,7 @@ fn translate(notification: UpdateSessionNotification) -> (String, Vec<Update>) {
                 script,
                 output,
                 append_output: false,
+                intent,
                 backgrounded,
             }]
         }
@@ -2173,6 +2179,7 @@ fn translate(notification: UpdateSessionNotification) -> (String, Vec<Update>) {
                 script: None,
                 output: Some(output),
                 append_output: true,
+                intent: None,
                 backgrounded,
             }]
         }
@@ -2345,6 +2352,15 @@ fn script_of(input: &Value) -> Option<String> {
     input
         .get("script")
         .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn intent_of(input: &Value) -> Option<String> {
+    input
+        .get("intent")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|intent| !intent.is_empty())
         .map(str::to_string)
 }
 
@@ -2907,6 +2923,27 @@ mod tests {
             translate_for_session(thought, "session").as_slice(),
             [Update::AgentThought { id, text, append: false }]
                 if id == "thought" && text.is_empty()
+        ));
+    }
+
+    #[test]
+    fn translates_trimmed_compose_intent() {
+        let update = UpdateSessionNotification::new(
+            "session",
+            SessionUpdate::ToolCallUpdate(
+                wire::ToolCallUpdate::new("tool-1")
+                    .title("compose")
+                    .raw_input(json!({
+                        "script": "return 1",
+                        "intent": "  Check the project.  "
+                    })),
+            ),
+        );
+
+        assert!(matches!(
+            translate_for_session(update, "session").as_slice(),
+            [Update::ToolPatched { intent: Some(Some(intent)), script: Some(script), .. }]
+                if intent == "Check the project." && script == "return 1"
         ));
     }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1590,8 +1590,7 @@ fn tool_header(app: &App, call: &ToolCall, active: bool) -> Vec<Span<'static>> {
             format!("  · {running} in flight"),
             Style::default().fg(theme::running_color()),
         ));
-    } else if !call.children.is_empty() && !(call.is_compose() && !call.running() && !call.expanded)
-    {
+    } else if (call.expanded || call.running() || !call.is_compose()) && !call.children.is_empty() {
         spans.push(Span::styled(
             format!("  · {} calls", call.children.len()),
             theme::faint(),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -28,8 +28,8 @@ use crate::events::{GenerationOutcome, SubagentStatus};
 use super::{
     app::{
         AgentTreeRow, App, Block, CachedTranscriptBlock, CachedTranscriptImage,
-        CachedTranscriptRow, Child, CodeHit, FilePickerStatus, Phase, SessionRename, ToolCall,
-        UserMessage,
+        CachedTranscriptRow, Child, CodeHit, ComposeView, FilePickerStatus, Phase, SessionRename,
+        ToolCall, UserMessage,
     },
     command,
     image::{ImageRuntime, RESERVED_ROWS},
@@ -1196,7 +1196,7 @@ fn thought_lines(
 
 fn tool_lines(app: &App, call: &ToolCall, active: bool) -> Vec<Line<'static>> {
     let mut lines = vec![Line::from(tool_header(app, call, active))];
-    let compose = call.title == agentkit_tool_compose::COMPOSE_TOOL_NAME;
+    let compose = call.is_compose();
     if call.running() {
         if compose && !call.script.is_empty() {
             lines.extend(live_script_lines(app, call));
@@ -1219,7 +1219,11 @@ fn tool_lines(app: &App, call: &ToolCall, active: bool) -> Vec<Line<'static>> {
             )));
         }
     }
-    lines.extend(output_lines(call));
+    if compose {
+        lines.extend(completed_compose_lines(call));
+    } else {
+        lines.extend(output_lines(call));
+    }
     lines
 }
 
@@ -1422,6 +1426,80 @@ fn direct_execution_count(call: &ToolCall, index: usize) -> Option<usize> {
     })
 }
 
+fn completed_compose_lines(call: &ToolCall) -> Vec<Line<'static>> {
+    if !call.expanded {
+        let mut counts = std::collections::HashMap::<&str, usize>::new();
+        for child in &call.children {
+            *counts.entry(child.tool.as_str()).or_default() += 1;
+        }
+        let mut counts = counts.into_iter().collect::<Vec<_>>();
+        counts.sort_by(|(left_name, left_count), (right_name, right_count)| {
+            right_count
+                .cmp(left_count)
+                .then_with(|| left_name.cmp(right_name))
+        });
+        if counts.is_empty() {
+            return output_lines(call);
+        }
+        let summary = counts
+            .into_iter()
+            .take(4)
+            .map(|(name, count)| {
+                if count > 1 {
+                    format!("{name} x {count}")
+                } else {
+                    name.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" · ");
+        return vec![Line::from(vec![
+            Span::styled("   ▸ ", theme::dim()),
+            Span::styled(summary, theme::dim()),
+            Span::styled("  click or ^o to open", theme::faint()),
+        ])];
+    }
+
+    let (output_style, script_style, hint) = match call.compose_view {
+        ComposeView::Output => (
+            theme::bold(theme::accent_color()),
+            theme::faint(),
+            "  click or ^o for Script",
+        ),
+        ComposeView::Script => (
+            theme::faint(),
+            theme::bold(theme::accent_color()),
+            "  click or ^o to close",
+        ),
+    };
+    let mut lines = vec![Line::from(vec![
+        Span::styled("   ", theme::faint()),
+        Span::styled("Script", script_style),
+        Span::styled("  ", theme::faint()),
+        Span::styled("Output", output_style),
+        Span::styled(hint, theme::faint()),
+    ])];
+    match call.compose_view {
+        ComposeView::Output => lines.extend(expanded_output_lines(call)),
+        ComposeView::Script => {
+            let count = call.script.lines().count();
+            lines.extend(call.script.lines().take(MAX_OUTPUT_ROWS).map(|source| {
+                Line::from(vec![
+                    Span::styled("   │ ", theme::faint()),
+                    Span::styled(source.to_string(), theme::dim()),
+                ])
+            }));
+            if count > MAX_OUTPUT_ROWS {
+                lines.push(Line::from(Span::styled(
+                    format!("   │ … {} more lines", count - MAX_OUTPUT_ROWS),
+                    theme::faint(),
+                )));
+            }
+        }
+    }
+    lines
+}
+
 /// Raw tool output stays folded: it is machine-shaped, often thousands of
 /// lines, and unreadable inline. The fold row says how much there is and opens
 /// on a click or `^o`.
@@ -1487,7 +1565,7 @@ fn tool_header(app: &App, call: &ToolCall, active: bool) -> Vec<Span<'static>> {
     let mut spans = vec![
         Span::styled(format!("{glyph} "), style),
         Span::styled(
-            call.title.clone(),
+            call.display_title().to_string(),
             theme::bold(if active {
                 theme::accent_color()
             } else {
@@ -1512,7 +1590,8 @@ fn tool_header(app: &App, call: &ToolCall, active: bool) -> Vec<Span<'static>> {
             format!("  · {running} in flight"),
             Style::default().fg(theme::running_color()),
         ));
-    } else if !call.children.is_empty() {
+    } else if !call.children.is_empty() && !(call.is_compose() && !call.running() && !call.expanded)
+    {
         spans.push(Span::styled(
             format!("  · {} calls", call.children.len()),
             theme::faint(),
@@ -2899,34 +2978,98 @@ mod tests {
     }
 
     #[test]
-    fn completed_compose_replaces_the_script_with_output() {
+    fn compose_title_uses_trimmed_intent_or_running_tools_fallback() {
         let mut app = sample();
-        app.apply(Update::ToolUpdated {
+        let fallback = render(&mut app, 100, 30);
+        assert!(fallback.contains("Running tools."), "{fallback}");
+        assert!(!fallback.contains("compose"), "{fallback}");
+
+        app.apply(Update::ToolPatched {
             id: "call-1".into(),
-            status: Some(agent_client_protocol::schema::v2::ToolCallStatus::Completed),
+            title: None,
+            kind: None,
+            status: None,
             script: None,
-            output: vec!["compose result".into()],
+            output: None,
+            append_output: false,
+            intent: Some(Some("  Check every source file.  ".into())),
             backgrounded: false,
         });
-
-        let frame = render(&mut app, 100, 30);
-
-        assert!(!frame.contains("files = shell"), "{frame}");
-        assert!(frame.contains("compose result"), "{frame}");
-
-        app.apply(Update::AgentMessage {
-            id: "test-agent".into(),
-            text: "Moving on.".into(),
-            append: true,
-        });
-        let continued = render(&mut app, 100, 30);
-        assert!(continued.contains("Moving on."), "{continued}");
-        assert!(continued.contains("1 line of output"), "{continued}");
-        assert!(!continued.contains("compose result"), "{continued}");
+        let intent = render(&mut app, 100, 30);
+        assert!(intent.contains("Check every source file."), "{intent}");
+        assert!(!intent.contains("Running tools."), "{intent}");
     }
 
     #[test]
-    fn explicit_output_choice_survives_later_messages_and_tools() {
+    fn collapsed_compose_groups_sorts_and_caps_child_tool_names() {
+        let mut app = sample();
+        let Block::Tool(call) = app.blocks.last_mut().expect("compose call") else {
+            panic!("last block was not a tool");
+        };
+        for (index, tool) in [
+            "shell", "docs", "shell", "alpha", "edit", "docs", "fork", "shell", "alpha",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            call.attach(format!("extra-{index}"), tool.into(), tool.into());
+        }
+        app.apply(Update::ToolUpdated {
+            id: "call-1".into(),
+            status: Some(agent_client_protocol::schema::v2::ToolCallStatus::Completed),
+            script: None,
+            output: vec!["done".into()],
+            backgrounded: false,
+        });
+
+        let frame = render(&mut app, 120, 35);
+        let shell = frame.find("shell x 5").expect("shell summary");
+        let alpha = frame.find("alpha x 2").expect("alpha summary");
+        let docs = frame.find("docs x 2").expect("docs summary");
+        let edit = frame.find("edit").expect("edit summary");
+        assert!(shell < alpha && alpha < docs && docs < edit, "{frame}");
+        assert!(!frame.contains("edit x 1"), "{frame}");
+        assert!(!frame.contains("fork"), "{frame}");
+    }
+
+    #[test]
+    fn completed_compose_stays_collapsed_when_its_title_arrives_late() {
+        let mut app = App::new(
+            PathBuf::from("/Users/dev/projects/kit"),
+            "openai-subscription".into(),
+            "gpt-5.4".into(),
+            "127.0.0.1:7331".into(),
+        );
+        app.apply(Update::ToolPatched {
+            id: "late-title".into(),
+            title: None,
+            kind: None,
+            status: Some(agent_client_protocol::schema::v2::ToolCallStatus::Completed),
+            script: Some("return 1".into()),
+            output: Some(vec!["1".into()]),
+            append_output: false,
+            intent: None,
+            backgrounded: false,
+        });
+        app.apply(Update::ToolPatched {
+            id: "late-title".into(),
+            title: Some("compose".into()),
+            kind: None,
+            status: None,
+            script: None,
+            output: None,
+            append_output: false,
+            intent: None,
+            backgrounded: false,
+        });
+
+        assert!(app.blocks.iter().any(|block| {
+            matches!(block, Block::Tool(call) if call.id == "late-title" && call.is_compose() && !call.expanded)
+        }));
+    }
+
+    #[test]
+    fn completed_compose_defaults_collapsed_and_cycles_output_script_and_closed() {
         let mut app = sample();
         app.apply(Update::ToolUpdated {
             id: "call-1".into(),
@@ -2936,7 +3079,44 @@ mod tests {
             backgrounded: false,
         });
 
+        let collapsed = render(&mut app, 100, 30);
+        assert!(collapsed.contains("shell x 2"), "{collapsed}");
+        assert!(!collapsed.contains("compose result"), "{collapsed}");
+        assert!(!collapsed.contains("files = shell"), "{collapsed}");
+
         app.toggle_last_output();
+        let output = render(&mut app, 100, 30);
+        assert!(output.contains("Output"), "{output}");
+        assert!(output.contains("Script"), "{output}");
+        assert!(output.contains("compose result"), "{output}");
+        assert!(!output.contains("files = shell"), "{output}");
+
+        app.toggle_last_output();
+        let script = render(&mut app, 100, 30);
+        assert!(script.contains("Output"), "{script}");
+        assert!(script.contains("Script"), "{script}");
+        assert!(script.contains("files = shell"), "{script}");
+        assert!(!script.contains("compose result"), "{script}");
+
+        app.toggle_last_output();
+        let collapsed_again = render(&mut app, 100, 30);
+        assert!(collapsed_again.contains("shell x 2"), "{collapsed_again}");
+        assert!(!collapsed_again.contains("Output"), "{collapsed_again}");
+    }
+
+    #[test]
+    fn explicit_compose_view_survives_completion_and_later_messages() {
+        let mut app = sample();
+        app.toggle_last_output();
+        app.toggle_last_output();
+        app.apply(Update::ToolUpdated {
+            id: "call-1".into(),
+            status: Some(agent_client_protocol::schema::v2::ToolCallStatus::Completed),
+            script: None,
+            output: vec!["compose result".into()],
+            backgrounded: false,
+        });
+
         app.apply(Update::AgentMessage {
             id: "after-compose".into(),
             text: "Moving on.".into(),
@@ -2947,7 +3127,7 @@ mod tests {
                 |block| matches!(block, Block::Tool(call) if call.id == "call-1" && call.expanded),
             )
         };
-        assert!(!compose_expanded(&app));
+        assert!(compose_expanded(&app));
 
         app.toggle_last_output();
         app.apply(Update::ToolStarted {


### PR DESCRIPTION
## Summary
- Adds an optional `intent` argument to `compose` and uses it as the user-facing title in the TUI and macOS app.
- Collapses completed compose calls by default and summarizes nested tool usage by frequency.
- Adds Script and Output views for inspecting completed compose calls.

## Motivation
Compose cards currently repeat the generic tool name and make completed runs harder to scan or inspect.

## Technical details
### Completed call summaries
Nested calls are grouped by tool name, ordered by descending count with deterministic alphabetical ties, and limited to four distinct tools.

Closes [#93](https://github.com/speakeasy-api/kit/issues/93)
