### PR TITLE
feat(telemetry): support OTLP HTTP transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3448,6 +3448,8 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.5",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -482,7 +482,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1180,6 +1180,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,7 +1645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3194,7 +3206,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3374,6 +3386,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry 0.32.0",
+ "reqwest",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3381,9 +3406,12 @@ checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry 0.32.0",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
+ "reqwest",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -3396,9 +3424,12 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
+ "base64 0.22.1",
+ "const-hex",
  "opentelemetry 0.32.0",
  "opentelemetry_sdk",
  "prost",
+ "serde",
  "tonic",
  "tonic-prost",
 ]
@@ -3729,6 +3760,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,7 +3890,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3957,6 +4003,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4296,7 +4351,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4355,7 +4410,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4832,7 +4887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4976,7 +5031,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5471,8 +5526,14 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-general-category"
@@ -5777,7 +5838,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ jsonwebtoken = { version = "=11.0.0", default-features = false, features = ["aws
 keyring = { version = "=4.1.6", default-features = false, features = ["v1"] }
 jsonschema = { version = "=0.52.0", default-features = false, features = ["idna"] }
 opentelemetry = { version = "=0.32.0", default-features = false, features = ["trace"] }
-opentelemetry-otlp = { version = "=0.32.0", default-features = false, features = ["grpc-tonic", "tls-webpki-roots", "trace"] }
+opentelemetry-otlp = { version = "=0.32.0", default-features = false, features = ["grpc-tonic", "http-proto", "http-json", "reqwest-client", "tls-webpki-roots", "trace"] }
 opentelemetry_sdk = { version = "=0.32.1", default-features = false, features = ["trace"] }
 ratatui = { version = "=0.30.2", default-features = false, features = ["crossterm", "layout-cache"] }
 ratatui-image = { version = "=11.0.6", default-features = false, features = ["crossterm"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ keyring = { version = "=4.1.6", default-features = false, features = ["v1"] }
 jsonschema = { version = "=0.52.0", default-features = false, features = ["idna"] }
 opentelemetry = { version = "=0.32.0", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "=0.32.0", default-features = false, features = ["grpc-tonic", "http-proto", "http-json", "reqwest-client", "tls-webpki-roots", "trace"] }
-opentelemetry_sdk = { version = "=0.32.1", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "=0.32.1", default-features = false, features = ["experimental_trace_batch_span_processor_with_async_runtime", "rt-tokio", "trace"] }
 ratatui = { version = "=0.30.2", default-features = false, features = ["crossterm", "layout-cache"] }
 ratatui-image = { version = "=11.0.6", default-features = false, features = ["crossterm"] }
 reqwest = { version = "=0.13.4", default-features = false, features = ["blocking", "form", "rustls", "stream"] }

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ When the provider reports 80% context-window use, Kit converts older history int
 - **Crash-safe.** Kit permits only one live process to modify each session. Kit reclaims a stale lock only when the operating system confirms that no process holds it. Use `--force` only with `--resume <session-id>` to reclaim a stale lock. The TUI also reclaims a stale lock when you switch sessions. Kit replaces an incomplete tool call with an explicit synthetic error result.
 - **OpenAI subscription retries.** Kit retries eligible transient failures with deterministic full-jitter backoff. Eligible failures include 408, 425, 429, 500, 502, 503, 504, and 529 responses. They also include transport failures and stream failures before the first token. The retry deadline is 24 hours. Kit reuses the same idempotency key. `openai-subscription` does not retry authentication failures, quota failures, or failures after output starts.
 - **Daemon operation.** `kit serve --remote-acp --no-stdio` runs independently of stdin. `SIGINT` and `SIGTERM` stop new connections, interrupt live sessions, and allow five seconds for draining. One bearer token file protects the HTTP listener.
-- **Observability.** Set `otel_endpoint = "http://localhost:4317"` to export AgentKit GenAI spans through OTLP/gRPC. Kit exports spans for the main agent, ACP sessions, nested children, and the compactor. Kit disables message-content capture by default. Kit limits captured message content when you enable it.
+- **Observability.** Set `otel_endpoint = "http://localhost:4317"` to export AgentKit GenAI spans. OTLP/gRPC remains the default; set `otel_protocol` to `http/protobuf` or `http/json` to use an HTTP trace transport. Kit exports spans for the main agent, ACP sessions, nested children, and the compactor. Kit disables message-content capture by default. Kit limits captured message content when you enable it.
 
 See [Security, limits, and troubleshooting](docs/user/security-limits-and-troubleshooting.md) for the trust model, operational limits, and recovery guidance.
 
@@ -285,6 +285,7 @@ credential_store = "file"          # memory | keychain | file
 credential_dir = "~/.kit/credentials"
 mcp_config = "~/.kit/mcp.json"
 otel_endpoint = "http://localhost:4317"
+otel_protocol = "grpc"                  # grpc | http/protobuf | http/json
 
 [acp.claude]
 command = "npx"

--- a/docs/user/getting-started-and-configuration.md
+++ b/docs/user/getting-started-and-configuration.md
@@ -158,6 +158,7 @@ model = "gpt-5.4"
 reasoning_effort = "medium" # low, medium, or high
 a2a = "127.0.0.1:7331"
 otel_endpoint = "http://localhost:4317"
+otel_protocol = "grpc" # grpc, http/protobuf, or http/json
 otel_capture_message_content = false
 otel_message_content_max_messages = 64
 otel_message_content_max_bytes = 16384
@@ -199,7 +200,7 @@ subdir = "agent-plugins/example"
 
 `root`, `provider`, `model`, and credential settings apply to all four runtime commands. Subagent model aliases and explicit-override allowlists are scoped by fully qualified harness under `[subagent.harnesses."acp.name"]`. Omitting `allow_model_overrides` permits all explicit model selections accepted by that harness; an empty list disables explicit model overrides. This policy does not restrict the harness's inherited or default model.
 
-`a2a` applies to `serve` and `tui`. Configured plugins can provide MCP servers without `mcp_config`; supported `stdio` and `streamable-http` declarations are registered, while `sse` declarations are skipped with a stderr diagnostic. MCP servers merge by name in this order: plugins, configured `mcp_config`, `<canonical-root>/.mcp.json`, then `--mcp-config`. Higher layers replace whole conflicts while preserving non-conflicting lower entries; live removal reveals the next lower layer. Plugin data is stored under `<config-directory>/plugin-data/<plugin-manifest-name>`. See [Agent Plugins](agent-plugins.md) for placeholders, collision rules, and ACP child behavior. `otel_endpoint` enables OTLP/gRPC export of AgentKit's GenAI trace spans. Use a collector endpoint such as `http://localhost:4317` without a `/v1/traces` suffix. `credential_store` selects one backend for OpenAI, Speakeasy, and MCP and defaults to `memory`; selecting `file` requires `credential_dir`, while a credential directory is invalid with `memory` or `keychain`. Memory credentials are process-local and are not shared with the TUI server process or nested Kit children. Standalone OpenAI and Speakeasy login requires persistent `keychain` or `file` storage. ACP profiles are direct executable-and-argument configurations, not shell command strings. `[subagent].harness` must name an available fully qualified profile such as `acp.review`; otherwise startup reports `unknown subagent ACP harness`. When no subagent harness is selected, the built-in `acp.kit` profile is used.
+`a2a` applies to `serve` and `tui`. Configured plugins can provide MCP servers without `mcp_config`; supported `stdio` and `streamable-http` declarations are registered, while `sse` declarations are skipped with a stderr diagnostic. MCP servers merge by name in this order: plugins, configured `mcp_config`, `<canonical-root>/.mcp.json`, then `--mcp-config`. Higher layers replace whole conflicts while preserving non-conflicting lower entries; live removal reveals the next lower layer. Plugin data is stored under `<config-directory>/plugin-data/<plugin-manifest-name>`. See [Agent Plugins](agent-plugins.md) for placeholders, collision rules, and ACP child behavior. `otel_endpoint` enables OTLP export of AgentKit's GenAI trace spans. `otel_protocol` accepts exactly `grpc`, `http/protobuf`, or `http/json`; gRPC is the default. For either HTTP protocol, Kit appends `/v1/traces` to a base endpoint unless it already ends with that path. `credential_store` selects one backend for OpenAI, Speakeasy, and MCP and defaults to `memory`; selecting `file` requires `credential_dir`, while a credential directory is invalid with `memory` or `keychain`. Memory credentials are process-local and are not shared with the TUI server process or nested Kit children. Standalone OpenAI and Speakeasy login requires persistent `keychain` or `file` storage. ACP profiles are direct executable-and-argument configurations, not shell command strings. `[subagent].harness` must name an available fully qualified profile such as `acp.review`; otherwise startup reports `unknown subagent ACP harness`. When no subagent harness is selected, the built-in `acp.kit` profile is used.
 
 ### Configuration precedence and built-in defaults
 
@@ -211,8 +212,12 @@ For settings exposed by a command, precedence is:
 
 The OpenTelemetry endpoint follows the same CLI-over-TOML precedence, then falls
 back to the standard `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. If none
-is set, trace export is disabled. Message capture is disabled by default because
-structured prompts, tool arguments, outputs, file content, and compaction summaries
+is set, trace export is disabled. The trace protocol precedence is
+`--otel-protocol`, `otel_protocol`, `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`,
+`OTEL_EXPORTER_OTLP_PROTOCOL`, then `grpc`. Kit passes
+`OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_TRACES_HEADERS` to the upstream
+exporter. Message capture is disabled by default because structured prompts, tool
+arguments, outputs, file content, and compaction summaries
 can contain secrets. Kit resolves `--otel-capture-message-content BOOL`, the TOML
 `otel_capture_message_content` value, and
 `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` in that order. The environment
@@ -233,6 +238,7 @@ target, and span busy/idle metadata are omitted. For example:
 ```sh
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 kit prompt "Summarize this project"
 kit prompt --otel-endpoint http://localhost:4317 "Summarize this project"
+kit prompt --otel-protocol http/protobuf --otel-endpoint https://otel.example.com/ingest "Summarize this project"
 kit prompt --otel-capture-message-content true --otel-message-content-max-messages 32 "Summarize this project"
 ```
 

--- a/src/acp_child.rs
+++ b/src/acp_child.rs
@@ -1677,8 +1677,9 @@ mod tests {
             legacy_mcp_config: false,
             mcp_config: None,
             credential_storage: CredentialStorage::Filesystem(root.path().join("credentials")),
-            telemetry: crate::telemetry::Settings::try_new(
-                Some("http://collector:4317".into()),
+            telemetry: crate::telemetry::Settings::try_new_with_protocol(
+                Some("http://collector:4318".into()),
+                crate::telemetry::Protocol::HttpJson,
                 false,
                 12,
                 4096,
@@ -1735,7 +1736,11 @@ mod tests {
         }));
         assert!(
             args.windows(2)
-                .any(|pair| pair == ["--otel-endpoint", "http://collector:4317"])
+                .any(|pair| pair == ["--otel-endpoint", "http://collector:4318/v1/traces"])
+        );
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--otel-protocol", "http/json"])
         );
         assert!(
             args.windows(2)

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ struct Cli {
 }
 
 const OTEL_ENDPOINT_ENV: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+const OTEL_PROTOCOL_ENV: &str = "OTEL_EXPORTER_OTLP_PROTOCOL";
+const OTEL_TRACES_PROTOCOL_ENV: &str = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL";
 const OTEL_CAPTURE_MESSAGE_CONTENT_ENV: &str = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
 const OPENROUTER_API_KEY_ENV: &str = "OPENROUTER_API_KEY";
 
@@ -49,9 +51,12 @@ fn resolve_openrouter_api_key(
 
 #[derive(Args)]
 struct TelemetryArgs {
-    /// OTLP/gRPC collector endpoint for OpenTelemetry trace export.
+    /// OTLP collector endpoint for OpenTelemetry trace export.
     #[arg(long, global = true)]
     otel_endpoint: Option<String>,
+    /// OTLP trace transport: grpc, http/protobuf, or http/json.
+    #[arg(long, global = true)]
+    otel_protocol: Option<kit::telemetry::Protocol>,
     /// Capture structured GenAI input and output messages in exported spans.
     #[arg(long, global = true, value_name = "BOOL", action = clap::ArgAction::Set)]
     otel_capture_message_content: Option<bool>,
@@ -227,6 +232,7 @@ struct Config {
     reasoning_effort: Option<kit::ReasoningEffort>,
     a2a: Option<String>,
     otel_endpoint: Option<String>,
+    otel_protocol: Option<kit::telemetry::Protocol>,
     otel_capture_message_content: Option<bool>,
     otel_message_content_max_messages: Option<usize>,
     otel_message_content_max_bytes: Option<usize>,
@@ -365,7 +371,18 @@ impl Config {
         args: &TelemetryArgs,
         endpoint_environment: Option<String>,
         capture_environment: Option<String>,
+        traces_protocol_environment: Option<String>,
+        protocol_environment: Option<String>,
     ) -> io::Result<kit::telemetry::Settings> {
+        let protocol = if let Some(value) = args.otel_protocol.or(self.otel_protocol) {
+            value
+        } else if let Some(value) = traces_protocol_environment {
+            parse_otel_protocol(OTEL_TRACES_PROTOCOL_ENV, &value)?
+        } else if let Some(value) = protocol_environment {
+            parse_otel_protocol(OTEL_PROTOCOL_ENV, &value)?
+        } else {
+            kit::telemetry::Protocol::default()
+        };
         let capture_message_content = if let Some(value) = args.otel_capture_message_content {
             value
         } else if let Some(value) = self.otel_capture_message_content {
@@ -384,8 +401,9 @@ impl Config {
             .otel_message_content_max_bytes
             .or(self.otel_message_content_max_bytes)
             .unwrap_or(kit::telemetry::DEFAULT_MESSAGE_CONTENT_MAX_BYTES);
-        kit::telemetry::Settings::try_new(
+        kit::telemetry::Settings::try_new_with_protocol(
             self.otel_endpoint(args.otel_endpoint.clone(), endpoint_environment),
+            protocol,
             capture_message_content,
             max_messages,
             max_bytes,
@@ -410,6 +428,15 @@ impl Config {
         }
         Ok((harnesses, selected))
     }
+}
+
+fn parse_otel_protocol(name: &str, value: &str) -> io::Result<kit::telemetry::Protocol> {
+    value.parse().map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid {name}: {error}"),
+        )
+    })
 }
 
 fn parse_otel_boolean(name: &str, value: &str) -> io::Result<bool> {
@@ -908,6 +935,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &cli.telemetry,
         env::var(OTEL_ENDPOINT_ENV).ok(),
         env::var(OTEL_CAPTURE_MESSAGE_CONTENT_ENV).ok(),
+        env::var(OTEL_TRACES_PROTOCOL_ENV).ok(),
+        env::var(OTEL_PROTOCOL_ENV).ok(),
     )?;
     let _telemetry = kit::telemetry::init(&telemetry_settings)?;
     if let Command::Auth {
@@ -1209,9 +1238,9 @@ mod tests {
 
     use super::{
         AuthAction, AuthProvider, Cli, Command, Config, CredentialArgs, CredentialStoreKind,
-        McpArgs, OTEL_CAPTURE_MESSAGE_CONTENT_ENV, ReasoningEffortArg, SessionsAction,
-        format_sessions, init_config, resolve_openrouter_api_key, supervise_serve_with_trigger,
-        validate_auth_storage,
+        McpArgs, OTEL_CAPTURE_MESSAGE_CONTENT_ENV, OTEL_TRACES_PROTOCOL_ENV, ReasoningEffortArg,
+        SessionsAction, format_sessions, init_config, resolve_openrouter_api_key,
+        supervise_serve_with_trigger, validate_auth_storage,
     };
 
     #[test]
@@ -1255,6 +1284,7 @@ provider = "openrouter"
 reasoning_effort = "medium"
 a2a = "127.0.0.1:7331"
 otel_endpoint = "http://configured:4317"
+otel_protocol = "http/protobuf"
 otel_capture_message_content = true
 otel_message_content_max_messages = 20
 otel_message_content_max_bytes = 200
@@ -1305,6 +1335,8 @@ credential_dir = "/configured/credentials"
         let cli = Cli::try_parse_from([
             "kit",
             "prompt",
+            "--otel-protocol",
+            "http/json",
             "--otel-capture-message-content",
             "false",
             "--otel-message-content-max-messages",
@@ -1319,12 +1351,15 @@ credential_dir = "/configured/credentials"
                 &cli.telemetry,
                 Some("http://environment:4317".into()),
                 Some("invalid-but-overridden".into()),
+                None,
+                None,
             )
             .unwrap();
         assert_eq!(
             telemetry.endpoint.as_deref(),
-            Some("http://configured:4317")
+            Some("http://configured:4317/v1/traces")
         );
+        assert_eq!(telemetry.protocol, kit::telemetry::Protocol::HttpJson);
         assert!(!telemetry.capture_message_content);
         assert_eq!(telemetry.message_content_max_messages, 5);
         assert_eq!(telemetry.message_content_max_bytes, 100);
@@ -1502,7 +1537,13 @@ credential_store = "keychain"
             Cli::try_parse_from(["kit", "--otel-endpoint", "", "prompt", "hello"]).unwrap();
         assert_eq!(
             configured
-                .telemetry_settings(&disabled_cli.telemetry, environment.clone(), None)
+                .telemetry_settings(
+                    &disabled_cli.telemetry,
+                    environment.clone(),
+                    None,
+                    None,
+                    None,
+                )
                 .unwrap()
                 .endpoint,
             None
@@ -1514,15 +1555,89 @@ credential_store = "keychain"
     }
 
     #[test]
+    fn protocol_precedence_is_cli_then_toml_then_trace_env_then_generic_env() {
+        let default_cli = Cli::try_parse_from(["kit", "prompt", "hello"]).unwrap();
+        let defaults = Config::default();
+        assert_eq!(
+            defaults
+                .telemetry_settings(
+                    &default_cli.telemetry,
+                    None,
+                    None,
+                    None,
+                    Some("http/json".into()),
+                )
+                .unwrap()
+                .protocol,
+            kit::telemetry::Protocol::HttpJson
+        );
+        assert_eq!(
+            defaults
+                .telemetry_settings(
+                    &default_cli.telemetry,
+                    None,
+                    None,
+                    Some("http/protobuf".into()),
+                    Some("http/json".into()),
+                )
+                .unwrap()
+                .protocol,
+            kit::telemetry::Protocol::HttpProtobuf
+        );
+
+        let configured: Config = toml::from_str("otel_protocol = 'grpc'").unwrap();
+        assert_eq!(
+            configured
+                .telemetry_settings(
+                    &default_cli.telemetry,
+                    None,
+                    None,
+                    Some("invalid".into()),
+                    Some("invalid".into()),
+                )
+                .unwrap()
+                .protocol,
+            kit::telemetry::Protocol::Grpc
+        );
+        let cli = Cli::try_parse_from(["kit", "prompt", "--otel-protocol", "http/json", "hello"])
+            .unwrap();
+        assert_eq!(
+            configured
+                .telemetry_settings(
+                    &cli.telemetry,
+                    None,
+                    None,
+                    Some("invalid".into()),
+                    Some("invalid".into()),
+                )
+                .unwrap()
+                .protocol,
+            kit::telemetry::Protocol::HttpJson
+        );
+
+        let error = defaults
+            .telemetry_settings(
+                &default_cli.telemetry,
+                None,
+                None,
+                Some("http".into()),
+                None,
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains(OTEL_TRACES_PROTOCOL_ENV));
+        assert!(toml::from_str::<Config>("otel_protocol = 'http'").is_err());
+    }
+
+    #[test]
     fn telemetry_environment_is_strict_and_settings_are_bounded() {
         let config = Config::default();
         let cli = Cli::try_parse_from(["kit", "prompt", "hello"]).unwrap();
         let enabled = config
-            .telemetry_settings(&cli.telemetry, None, Some("TrUe".into()))
+            .telemetry_settings(&cli.telemetry, None, Some("TrUe".into()), None, None)
             .unwrap();
         assert!(enabled.capture_message_content);
         let error = config
-            .telemetry_settings(&cli.telemetry, None, Some("yes".into()))
+            .telemetry_settings(&cli.telemetry, None, Some("yes".into()), None, None)
             .unwrap_err();
         assert!(error.to_string().contains(OTEL_CAPTURE_MESSAGE_CONTENT_ENV));
 
@@ -1536,14 +1651,14 @@ credential_store = "keychain"
         .unwrap();
         assert!(
             config
-                .telemetry_settings(&invalid.telemetry, None, None)
+                .telemetry_settings(&invalid.telemetry, None, None, None, None)
                 .is_err()
         );
 
         let configured_false: Config =
             toml::from_str("otel_capture_message_content = false").unwrap();
         let disabled = configured_false
-            .telemetry_settings(&cli.telemetry, None, Some("true".into()))
+            .telemetry_settings(&cli.telemetry, None, Some("true".into()), None, None)
             .unwrap();
         assert!(!disabled.capture_message_content);
         assert!(
@@ -1761,12 +1876,14 @@ future_option = true
     }
 
     #[test]
-    fn otel_endpoint_is_a_global_command_line_option() {
+    fn otel_trace_settings_are_global_command_line_options() {
         let cli = Cli::try_parse_from([
             "kit",
             "prompt",
             "--otel-endpoint",
             "http://collector:4317",
+            "--otel-protocol",
+            "http/protobuf",
             "--otel-capture-message-content",
             "true",
             "--otel-message-content-max-messages",
@@ -1780,9 +1897,16 @@ future_option = true
             cli.telemetry.otel_endpoint.as_deref(),
             Some("http://collector:4317")
         );
+        assert_eq!(
+            cli.telemetry.otel_protocol,
+            Some(kit::telemetry::Protocol::HttpProtobuf)
+        );
         assert_eq!(cli.telemetry.otel_capture_message_content, Some(true));
         assert_eq!(cli.telemetry.otel_message_content_max_messages, Some(12));
         assert_eq!(cli.telemetry.otel_message_content_max_bytes, Some(4096));
+        assert!(
+            Cli::try_parse_from(["kit", "prompt", "--otel-protocol", "http", "hello",]).is_err()
+        );
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -244,19 +244,34 @@ fn build_exporter(
     }
 }
 
+fn build_provider(
+    exporter: opentelemetry_otlp::SpanExporter,
+    protocol: Protocol,
+) -> opentelemetry_sdk::trace::SdkTracerProvider {
+    let resource = opentelemetry_sdk::Resource::builder()
+        .with_service_name(env!("CARGO_PKG_NAME"))
+        .build();
+    let builder = opentelemetry_sdk::trace::SdkTracerProvider::builder().with_resource(resource);
+    match protocol {
+        Protocol::Grpc => builder.with_batch_exporter(exporter).build(),
+        Protocol::HttpProtobuf | Protocol::HttpJson => {
+            let processor = opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor::builder(
+                exporter,
+                opentelemetry_sdk::runtime::Tokio,
+            )
+            .build();
+            builder.with_span_processor(processor).build()
+        }
+    }
+}
+
 /// Installs OTLP trace export when an endpoint is configured.
 pub fn init(settings: &Settings) -> Result<Option<Guard>, Box<dyn std::error::Error>> {
     let Some(endpoint) = settings.endpoint.as_deref() else {
         return Ok(None);
     };
     let exporter = build_exporter(endpoint, settings.protocol)?;
-    let resource = opentelemetry_sdk::Resource::builder()
-        .with_service_name(env!("CARGO_PKG_NAME"))
-        .build();
-    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-        .with_resource(resource)
-        .with_batch_exporter(exporter)
-        .build();
+    let provider = build_provider(exporter, settings.protocol);
     let tracer = provider.tracer(env!("CARGO_PKG_NAME"));
     let layer = tracing_opentelemetry::layer()
         .with_tracer(tracer)
@@ -271,9 +286,17 @@ pub fn init(settings: &Settings) -> Result<Option<Guard>, Box<dyn std::error::Er
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        io::{Read as _, Write as _},
+        net::TcpListener,
+        thread,
+    };
+
+    use opentelemetry::trace::{Span as _, Tracer as _, TracerProvider as _};
+
     use super::{
         DEFAULT_MESSAGE_CONTENT_MAX_BYTES, DEFAULT_MESSAGE_CONTENT_MAX_MESSAGES, LevelFilter,
-        Protocol, Settings, build_exporter, exported_targets,
+        Protocol, Settings, build_exporter, build_provider, exported_targets,
     };
 
     #[test]
@@ -367,20 +390,57 @@ mod tests {
         }
     }
 
-    #[test]
-    fn http_exporters_build_without_connecting() {
-        for protocol in [Protocol::HttpProtobuf, Protocol::HttpJson] {
-            let settings = Settings::try_new_with_protocol(
-                Some("https://collector.example".into()),
-                protocol,
-                false,
-                12,
-                4096,
+    fn serve_otlp_response(
+        content_type: &'static str,
+        body: &'static [u8],
+    ) -> (String, thread::JoinHandle<Vec<u8>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = vec![0; 8192];
+            let length = stream.read(&mut request).unwrap();
+            request.truncate(length);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
             )
             .unwrap();
+            stream.write_all(body).unwrap();
+            request
+        });
+        (format!("http://{address}"), server)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn http_transports_export_span_batches() {
+        for (protocol, content_type, response_body) in [
+            (Protocol::HttpProtobuf, "application/x-protobuf", &[][..]),
+            (Protocol::HttpJson, "application/json", &b"{}"[..]),
+        ] {
+            let (endpoint, server) = serve_otlp_response(content_type, response_body);
+            let settings =
+                Settings::try_new_with_protocol(Some(endpoint), protocol, false, 12, 4096).unwrap();
+            let exporter = build_exporter(settings.endpoint.as_deref().unwrap(), protocol).unwrap();
+            let provider = build_provider(exporter, protocol);
+            let tracer = provider.tracer("http-export-test");
+            let mut span = tracer.start("test span");
+            span.end();
+            provider.shutdown().unwrap();
+
+            let request = server.join().unwrap();
+            let header_end = request
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+                .unwrap();
+            let request = String::from_utf8(request[..header_end].to_vec())
+                .unwrap()
+                .to_ascii_lowercase();
+            assert!(request.starts_with("post /v1/traces http/1.1"), "{request}");
             assert!(
-                build_exporter(settings.endpoint.as_deref().unwrap(), protocol).is_ok(),
-                "failed to build {protocol} exporter"
+                request.contains(&format!("content-type: {content_type}")),
+                "{request}"
             );
         }
     }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -3,7 +3,7 @@
 use agentkit_loop::{MessageCapture, TelemetryConfig};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::{Protocol as OtlpProtocol, WithExportConfig as _};
-use std::{fmt, str::FromStr, sync::mpsc, thread, time::Duration};
+use std::{fmt, mem::ManuallyDrop, str::FromStr, sync::mpsc, thread, time::Duration};
 use tracing_subscriber::{
     Layer as _,
     filter::{LevelFilter, Targets},
@@ -209,9 +209,12 @@ fn shutdown_provider_with_timeout(
     timeout: Duration,
 ) -> Result<(), String> {
     let (sender, receiver) = mpsc::sync_channel(1);
+    // A failed spawn must leak the provider because dropping it here can block past the timeout.
+    let provider = ManuallyDrop::new(provider);
     let shutdown = thread::Builder::new()
         .name("kit-otel-shutdown".into())
         .spawn(move || {
+            let provider = ManuallyDrop::into_inner(provider);
             let _ = sender.send(provider.shutdown_with_timeout(timeout));
         })
         .map_err(|error| format!("could not start OpenTelemetry shutdown: {error}"))?;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -3,7 +3,7 @@
 use agentkit_loop::{MessageCapture, TelemetryConfig};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::{Protocol as OtlpProtocol, WithExportConfig as _};
-use std::{fmt, str::FromStr};
+use std::{fmt, str::FromStr, sync::mpsc, thread, time::Duration};
 use tracing_subscriber::{
     Layer as _,
     filter::{LevelFilter, Targets},
@@ -202,12 +202,55 @@ fn http_trace_endpoint(endpoint: &str) -> Result<String, String> {
     })
 }
 
+const PROVIDER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn shutdown_provider_with_timeout(
+    provider: opentelemetry_sdk::trace::SdkTracerProvider,
+    timeout: Duration,
+) -> Result<(), String> {
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let shutdown = thread::Builder::new()
+        .name("kit-otel-shutdown".into())
+        .spawn(move || {
+            let _ = sender.send(provider.shutdown_with_timeout(timeout));
+        })
+        .map_err(|error| format!("could not start OpenTelemetry shutdown: {error}"))?;
+
+    match receiver.recv_timeout(timeout) {
+        Ok(result) => {
+            shutdown
+                .join()
+                .map_err(|_| "OpenTelemetry shutdown thread panicked".to_string())?;
+            result.map_err(|error| error.to_string())
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(format!(
+            "OpenTelemetry shutdown timed out after {timeout:?}"
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let _ = shutdown.join();
+            Err("OpenTelemetry shutdown thread disconnected".into())
+        }
+    }
+}
+
 /// Keeps the tracer provider alive and flushes queued spans when Kit exits.
-pub struct Guard(opentelemetry_sdk::trace::SdkTracerProvider);
+pub struct Guard {
+    provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+    protocol: Protocol,
+}
 
 impl Drop for Guard {
     fn drop(&mut self) {
-        if let Err(error) = self.0.shutdown() {
+        let Some(provider) = self.provider.take() else {
+            return;
+        };
+        let result = match self.protocol {
+            Protocol::Grpc => provider.shutdown().map_err(|error| error.to_string()),
+            Protocol::HttpProtobuf | Protocol::HttpJson => {
+                shutdown_provider_with_timeout(provider, PROVIDER_SHUTDOWN_TIMEOUT)
+            }
+        };
+        if let Err(error) = result {
             eprintln!("could not shut down OpenTelemetry exporter: {error}");
         }
     }
@@ -281,7 +324,10 @@ pub fn init(settings: &Settings) -> Result<Option<Guard>, Box<dyn std::error::Er
         .with_target(false)
         .with_filter(exported_targets());
     tracing_subscriber::registry().with(layer).try_init()?;
-    Ok(Some(Guard(provider)))
+    Ok(Some(Guard {
+        provider: Some(provider),
+        protocol: settings.protocol,
+    }))
 }
 
 #[cfg(test)]
@@ -290,6 +336,7 @@ mod tests {
         io::{Read as _, Write as _},
         net::TcpListener,
         thread,
+        time::{Duration, Instant},
     };
 
     use opentelemetry::trace::{Span as _, Tracer as _, TracerProvider as _};
@@ -297,6 +344,7 @@ mod tests {
     use super::{
         DEFAULT_MESSAGE_CONTENT_MAX_BYTES, DEFAULT_MESSAGE_CONTENT_MAX_MESSAGES, LevelFilter,
         Protocol, Settings, build_exporter, build_provider, exported_targets,
+        shutdown_provider_with_timeout,
     };
 
     #[test]
@@ -393,6 +441,7 @@ mod tests {
     fn serve_otlp_response(
         content_type: &'static str,
         body: &'static [u8],
+        delay: Duration,
     ) -> (String, thread::JoinHandle<Vec<u8>>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
@@ -401,6 +450,7 @@ mod tests {
             let mut request = vec![0; 8192];
             let length = stream.read(&mut request).unwrap();
             request.truncate(length);
+            thread::sleep(delay);
             write!(
                 stream,
                 "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -419,7 +469,8 @@ mod tests {
             (Protocol::HttpProtobuf, "application/x-protobuf", &[][..]),
             (Protocol::HttpJson, "application/json", &b"{}"[..]),
         ] {
-            let (endpoint, server) = serve_otlp_response(content_type, response_body);
+            let (endpoint, server) =
+                serve_otlp_response(content_type, response_body, Duration::ZERO);
             let settings =
                 Settings::try_new_with_protocol(Some(endpoint), protocol, false, 12, 4096).unwrap();
             let exporter = build_exporter(settings.endpoint.as_deref().unwrap(), protocol).unwrap();
@@ -443,6 +494,28 @@ mod tests {
                 "{request}"
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stalled_http_export_does_not_exceed_shutdown_deadline() {
+        let delay = Duration::from_secs(1);
+        let timeout = Duration::from_millis(50);
+        let (endpoint, server) = serve_otlp_response("application/json", b"{}", delay);
+        let settings =
+            Settings::try_new_with_protocol(Some(endpoint), Protocol::HttpJson, false, 12, 4096)
+                .unwrap();
+        let exporter =
+            build_exporter(settings.endpoint.as_deref().unwrap(), Protocol::HttpJson).unwrap();
+        let provider = build_provider(exporter, Protocol::HttpJson);
+        let tracer = provider.tracer("stalled-http-export-test");
+        let mut span = tracer.start("test span");
+        span.end();
+
+        let started = Instant::now();
+        let error = shutdown_provider_with_timeout(provider, timeout).unwrap_err();
+        assert!(error.contains("timed out"), "{error}");
+        assert!(started.elapsed() < delay);
+        server.join().unwrap();
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -2,7 +2,8 @@
 
 use agentkit_loop::{MessageCapture, TelemetryConfig};
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry_otlp::WithExportConfig as _;
+use opentelemetry_otlp::{Protocol as OtlpProtocol, WithExportConfig as _};
+use std::{fmt, str::FromStr};
 use tracing_subscriber::{
     Layer as _,
     filter::{LevelFilter, Targets},
@@ -14,11 +15,49 @@ pub const DEFAULT_MESSAGE_CONTENT_MAX_BYTES: usize = 16_384;
 pub const MAX_MESSAGE_CONTENT_MESSAGES: usize = 1_024;
 pub const MAX_MESSAGE_CONTENT_BYTES: usize = 1_048_576;
 
+/// Supported OTLP transports for trace export.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Deserialize)]
+pub enum Protocol {
+    #[default]
+    #[serde(rename = "grpc")]
+    Grpc,
+    #[serde(rename = "http/protobuf")]
+    HttpProtobuf,
+    #[serde(rename = "http/json")]
+    HttpJson,
+}
+
+impl fmt::Display for Protocol {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Grpc => "grpc",
+            Self::HttpProtobuf => "http/protobuf",
+            Self::HttpJson => "http/json",
+        })
+    }
+}
+
+impl FromStr for Protocol {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "grpc" => Ok(Self::Grpc),
+            "http/protobuf" => Ok(Self::HttpProtobuf),
+            "http/json" => Ok(Self::HttpJson),
+            _ => Err(format!(
+                "invalid OTLP trace protocol {value:?}; expected grpc, http/protobuf, or http/json"
+            )),
+        }
+    }
+}
+
 /// Fully resolved telemetry settings. Kit owns environment, TOML, and CLI
 /// resolution; AgentKit receives no process environment configuration.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Settings {
     pub endpoint: Option<String>,
+    pub protocol: Protocol,
     pub capture_message_content: bool,
     pub message_content_max_messages: usize,
     pub message_content_max_bytes: usize,
@@ -27,6 +66,22 @@ pub struct Settings {
 impl Settings {
     pub fn try_new(
         endpoint: Option<String>,
+        capture_message_content: bool,
+        message_content_max_messages: usize,
+        message_content_max_bytes: usize,
+    ) -> Result<Self, String> {
+        Self::try_new_with_protocol(
+            endpoint,
+            Protocol::default(),
+            capture_message_content,
+            message_content_max_messages,
+            message_content_max_bytes,
+        )
+    }
+
+    pub fn try_new_with_protocol(
+        endpoint: Option<String>,
+        protocol: Protocol,
         capture_message_content: bool,
         message_content_max_messages: usize,
         message_content_max_bytes: usize,
@@ -41,8 +96,16 @@ impl Settings {
                 "otel_message_content_max_bytes must be between 1 and {MAX_MESSAGE_CONTENT_BYTES}"
             ));
         }
+        let endpoint = endpoint.filter(|value| !value.is_empty());
+        let endpoint = match (endpoint, protocol) {
+            (Some(endpoint), Protocol::HttpProtobuf | Protocol::HttpJson) => {
+                Some(http_trace_endpoint(&endpoint)?)
+            }
+            (endpoint, Protocol::Grpc) | (endpoint @ None, _) => endpoint,
+        };
         Ok(Self {
-            endpoint: endpoint.filter(|value| !value.is_empty()),
+            endpoint,
+            protocol,
             capture_message_content,
             message_content_max_messages,
             message_content_max_bytes,
@@ -81,8 +144,12 @@ impl Settings {
     pub fn append_cli_args(&self, command: &mut tokio::process::Command) {
         command
             .env_remove("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .env_remove("OTEL_EXPORTER_OTLP_PROTOCOL")
+            .env_remove("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
             .arg("--otel-endpoint")
             .arg(self.endpoint.as_deref().unwrap_or_default())
+            .arg("--otel-protocol")
+            .arg(self.protocol.to_string())
             .arg("--otel-capture-message-content")
             .arg(self.capture_message_content.to_string())
             .arg("--otel-message-content-max-messages")
@@ -96,11 +163,43 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             endpoint: None,
+            protocol: Protocol::default(),
             capture_message_content: false,
             message_content_max_messages: DEFAULT_MESSAGE_CONTENT_MAX_MESSAGES,
             message_content_max_bytes: DEFAULT_MESSAGE_CONTENT_MAX_BYTES,
         }
     }
+}
+
+fn http_trace_endpoint(endpoint: &str) -> Result<String, String> {
+    let parsed = reqwest::Url::parse(endpoint)
+        .map_err(|error| format!("invalid OTLP HTTP trace endpoint {endpoint:?}: {error}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host().is_none() {
+        return Err(format!(
+            "invalid OTLP HTTP trace endpoint {endpoint:?}: expected an http or https URL with a host"
+        ));
+    }
+    if parsed.fragment().is_some() {
+        return Err(format!(
+            "invalid OTLP HTTP trace endpoint {endpoint:?}: URL fragments are not supported"
+        ));
+    }
+
+    let normalized = parsed.as_str();
+    let (base, query) = normalized
+        .split_once('?')
+        .map_or((normalized, None), |(base, query)| (base, Some(query)));
+    let base = base.trim_end_matches('/');
+    let path = parsed.path().trim_end_matches('/');
+    let suffix = if path.ends_with("/v1/traces") {
+        ""
+    } else {
+        "/v1/traces"
+    };
+    Ok(match query {
+        Some(query) => format!("{base}{suffix}?{query}"),
+        None => format!("{base}{suffix}"),
+    })
 }
 
 /// Keeps the tracer provider alive and flushes queued spans when Kit exits.
@@ -120,15 +219,37 @@ fn exported_targets() -> Targets {
         .with_target("agentkit_mcp", LevelFilter::INFO)
 }
 
-/// Installs OTLP/gRPC trace export when an endpoint is configured.
+fn build_exporter(
+    endpoint: &str,
+    protocol: Protocol,
+) -> Result<opentelemetry_otlp::SpanExporter, opentelemetry_otlp::ExporterBuildError> {
+    // Leave headers unset so the upstream exporter applies its standard generic
+    // and trace-specific header environment variables.
+    match protocol {
+        Protocol::Grpc => opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_protocol(OtlpProtocol::Grpc)
+            .with_endpoint(endpoint)
+            .build(),
+        Protocol::HttpProtobuf => opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_protocol(OtlpProtocol::HttpBinary)
+            .with_endpoint(endpoint)
+            .build(),
+        Protocol::HttpJson => opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_protocol(OtlpProtocol::HttpJson)
+            .with_endpoint(endpoint)
+            .build(),
+    }
+}
+
+/// Installs OTLP trace export when an endpoint is configured.
 pub fn init(settings: &Settings) -> Result<Option<Guard>, Box<dyn std::error::Error>> {
     let Some(endpoint) = settings.endpoint.as_deref() else {
         return Ok(None);
     };
-    let exporter = opentelemetry_otlp::SpanExporter::builder()
-        .with_tonic()
-        .with_endpoint(endpoint)
-        .build()?;
+    let exporter = build_exporter(endpoint, settings.protocol)?;
     let resource = opentelemetry_sdk::Resource::builder()
         .with_service_name(env!("CARGO_PKG_NAME"))
         .build();
@@ -152,12 +273,13 @@ pub fn init(settings: &Settings) -> Result<Option<Guard>, Box<dyn std::error::Er
 mod tests {
     use super::{
         DEFAULT_MESSAGE_CONTENT_MAX_BYTES, DEFAULT_MESSAGE_CONTENT_MAX_MESSAGES, LevelFilter,
-        Settings, exported_targets,
+        Protocol, Settings, build_exporter, exported_targets,
     };
 
     #[test]
     fn settings_are_bounded_and_default_to_capture_off() {
         let defaults = Settings::default();
+        assert_eq!(defaults.protocol, Protocol::Grpc);
         assert!(!defaults.capture_message_content);
         let config = defaults.agentkit_config().unwrap();
         assert_eq!(config.input_messages(), None);
@@ -174,6 +296,93 @@ mod tests {
         assert!(Settings::try_new(None, true, 1, 0).is_err());
         assert!(Settings::try_new(None, true, super::MAX_MESSAGE_CONTENT_MESSAGES + 1, 1).is_err());
         assert!(Settings::try_new(None, true, 1, super::MAX_MESSAGE_CONTENT_BYTES + 1).is_err());
+    }
+
+    #[test]
+    fn protocol_parsing_and_display_use_standard_values() {
+        for (value, protocol) in [
+            ("grpc", Protocol::Grpc),
+            ("http/protobuf", Protocol::HttpProtobuf),
+            ("http/json", Protocol::HttpJson),
+        ] {
+            assert_eq!(value.parse::<Protocol>().unwrap(), protocol);
+            assert_eq!(protocol.to_string(), value);
+        }
+        let error = "http".parse::<Protocol>().unwrap_err();
+        assert!(error.contains("grpc, http/protobuf, or http/json"));
+        assert!("HTTP/JSON".parse::<Protocol>().is_err());
+    }
+
+    #[test]
+    fn http_endpoints_gain_one_trace_suffix_and_preserve_queries() {
+        for (endpoint, expected) in [
+            (
+                "https://otel.example.com/ingest",
+                "https://otel.example.com/ingest/v1/traces",
+            ),
+            (
+                "https://otel.example.com/ingest/",
+                "https://otel.example.com/ingest/v1/traces",
+            ),
+            (
+                "https://otel.example.com/ingest/v1/traces",
+                "https://otel.example.com/ingest/v1/traces",
+            ),
+            (
+                "https://otel.example.com/ingest?token=a%2Fb",
+                "https://otel.example.com/ingest/v1/traces?token=a%2Fb",
+            ),
+        ] {
+            let settings = Settings::try_new_with_protocol(
+                Some(endpoint.into()),
+                Protocol::HttpProtobuf,
+                false,
+                12,
+                4096,
+            )
+            .unwrap();
+            assert_eq!(settings.endpoint.as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn invalid_http_endpoints_are_rejected_clearly() {
+        for endpoint in [
+            "collector:4318",
+            "ftp://collector:4318",
+            "https://collector/#part",
+        ] {
+            let error = Settings::try_new_with_protocol(
+                Some(endpoint.into()),
+                Protocol::HttpJson,
+                false,
+                12,
+                4096,
+            )
+            .unwrap_err();
+            assert!(
+                error.contains("invalid OTLP HTTP trace endpoint"),
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
+    fn http_exporters_build_without_connecting() {
+        for protocol in [Protocol::HttpProtobuf, Protocol::HttpJson] {
+            let settings = Settings::try_new_with_protocol(
+                Some("https://collector.example".into()),
+                protocol,
+                false,
+                12,
+                4096,
+            )
+            .unwrap();
+            assert!(
+                build_exporter(settings.endpoint.as_deref().unwrap(), protocol).is_ok(),
+                "failed to build {protocol} exporter"
+            );
+        }
     }
 
     #[test]
@@ -194,17 +403,40 @@ mod tests {
     }
 
     #[test]
-    fn child_args_propagate_endpoint_explicit_false_and_bounds() {
-        let settings =
-            Settings::try_new(Some("http://collector:4317".into()), false, 12, 4096).unwrap();
+    fn child_args_propagate_protocol_endpoint_explicit_false_and_bounds() {
+        let settings = Settings::try_new_with_protocol(
+            Some("http://collector:4318".into()),
+            Protocol::HttpJson,
+            false,
+            12,
+            4096,
+        )
+        .unwrap();
         let mut command = tokio::process::Command::new("kit");
         settings.append_cli_args(&mut command);
-        assert!(
-            command
-                .as_std()
-                .get_envs()
-                .any(|(name, value)| { name == "OTEL_EXPORTER_OTLP_ENDPOINT" && value.is_none() })
-        );
+        for expected in [
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_PROTOCOL",
+            "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+        ] {
+            assert!(
+                command
+                    .as_std()
+                    .get_envs()
+                    .any(|(name, value)| { name == expected && value.is_none() })
+            );
+        }
+        for inherited in [
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+        ] {
+            assert!(
+                command
+                    .as_std()
+                    .get_envs()
+                    .all(|(name, _)| name != inherited)
+            );
+        }
         let args: Vec<_> = command
             .as_std()
             .get_args()
@@ -214,7 +446,9 @@ mod tests {
             args,
             [
                 "--otel-endpoint",
-                "http://collector:4317",
+                "http://collector:4318/v1/traces",
+                "--otel-protocol",
+                "http/json",
                 "--otel-capture-message-content",
                 "false",
                 "--otel-message-content-max-messages",
@@ -236,7 +470,10 @@ mod tests {
             .map(|value| value.to_string_lossy().into_owned())
             .collect();
 
-        assert_eq!(&args[..2], ["--otel-endpoint", ""]);
+        assert_eq!(
+            &args[..4],
+            ["--otel-endpoint", "", "--otel-protocol", "grpc"]
+        );
         assert!(
             args.windows(2)
                 .any(|pair| { pair == ["--otel-capture-message-content", "false"] })

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3527,8 +3527,9 @@ a = [still text]
 
     #[test]
     fn forwards_all_resolved_telemetry_settings_to_the_tui_child() {
-        let settings = crate::telemetry::Settings::try_new(
-            Some("http://collector:4317".into()),
+        let settings = crate::telemetry::Settings::try_new_with_protocol(
+            Some("http://collector:4318".into()),
+            crate::telemetry::Protocol::HttpProtobuf,
             false,
             12,
             4096,
@@ -3541,7 +3542,9 @@ a = [still text]
             args,
             [
                 "--otel-endpoint",
-                "http://collector:4317",
+                "http://collector:4318/v1/traces",
+                "--otel-protocol",
+                "http/protobuf",
                 "--otel-capture-message-content",
                 "false",
                 "--otel-message-content-max-messages",


### PR DESCRIPTION
## Summary

Add configurable OTLP trace export over gRPC, HTTP/protobuf, and HTTP/JSON. Expose protocol selection through CLI, TOML, and standard OpenTelemetry environment variables, and propagate the resolved transport to nested Kit processes.

## Motivation

OTLP collectors such as Gram expose standard HTTP trace ingestion endpoints rather than gRPC. Supporting both HTTP encodings lets Kit export its existing GenAI spans directly to those collectors.

## Impact

OTLP/gRPC remains the default, so existing configurations retain their current transport. HTTP configurations treat `otel_endpoint` as a base endpoint and append `/v1/traces` when needed; trace export remains disabled when no endpoint is configured.

## Technical details

### Configuration precedence

Protocol resolution uses CLI, then `config.toml`, then `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, then `OTEL_EXPORTER_OTLP_PROTOCOL`, and finally the gRPC default. `kit init` leaves the protocol unset so environment selection remains effective.

### HTTP export

The HTTP exporters preserve the standard generic and trace-specific OTLP header variables. The implementation enables the pinned OpenTelemetry HTTP protobuf and JSON features and reuses Kit's existing reqwest/rustls client stack.


### Batch processing

HTTP transports use the SDK Tokio-backed batch span processor so the async reqwest exporter is driven by a compatible runtime. gRPC retains the existing thread-backed batch processor.


HTTP shutdown is independently bounded to five seconds so a stalled collector cannot delay Kit exit beyond the provider deadline.
