### PR TITLE
fix(deps): update agentkit-provider-openai to 0.10.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-provider-openai"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a666ab2c12b086546feb07a1219332e0266b2c5a9ec847ef8b509c5386fd9e"
+checksum = "b1ecc23df8ef7142c0ad4383a985820a4369402dfe2838e01689bbbfea31beb2"
 dependencies = [
  "agentkit-adapter-completions",
  "agentkit-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ agentkit-loop = { version = "=0.10.11", features = ["otel"] }
 agentkit-mcp = "=0.10.6"
 agentkit-http = "=0.10.6"
 agentkit-plugins = "=0.10.7"
-agentkit-provider-openai = "=0.10.6"
+agentkit-provider-openai = "=0.10.7"
 agentkit-provider-openrouter = "=0.10.8"
 agentkit-task-manager = "=0.10.7"
 agentkit-tool-compose = { version = "=0.10.10", default-features = false, features = ["runlet"] }


### PR DESCRIPTION
## Summary

Update the exact `agentkit-provider-openai` dependency pin from 0.10.6 to 0.10.7.

## Motivation

This release makes transient HTTP 404 responses retryable for the ChatGPT-private Responses profile and removes the cumulative event-count limit from otherwise bounded Responses streams.

## Impact

ChatGPT subscription sessions can recover from transient infrastructure 404s using Kit's existing retry budget and backoff. Large Responses streams remain bounded by wire-byte, field-size, and collection-cardinality limits without failing solely because of cumulative SSE event count.

## Technical details

The lockfile update changes only the provider crate version and checksum; it introduces no transitive package or feature changes.
