### PR TITLE
feat(provider): discover OpenAI subscription models

### DIFF
--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -52,7 +52,7 @@ pub mod v2;
 use crate::{
     provider::{
         ModelGroup, ModelSelection, ProviderKind, ReasoningEffort, SelectableAdapter,
-        authentication_method_id, model_catalog,
+        authentication_method_id,
     },
     runtime::{AcpDriverContext, AcpForkState, BackgroundJobs, DetachRegistration, Runtime},
 };
@@ -1311,7 +1311,7 @@ impl Server {
             .adapter
             .reasoning_effort()
             .map_err(|error| record_acp_runtime_failure(&session_id, "reasoning_effort", error))?;
-        let catalog = model_catalog(&current).await;
+        let catalog = driver.adapter.model_catalog(&current).await;
         let config_options = config_options(&current, reasoning_effort, &catalog);
         let background_jobs = driver.background_jobs.clone();
         let tasks = driver.tasks.clone();

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -28,7 +28,7 @@ use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::{
-    provider::{ProviderKind, SelectableAdapter, authentication_method_id, model_catalog},
+    provider::{ProviderKind, SelectableAdapter, authentication_method_id},
     runtime::{AcpDriverContext, BackgroundJobs, Runtime},
 };
 
@@ -790,7 +790,7 @@ impl Server {
             .adapter
             .reasoning_effort()
             .map_err(AcpRuntimeError::Loop)?;
-        let catalog = model_catalog(&current).await;
+        let catalog = driver.adapter.model_catalog(&current).await;
         let config_options = v2_config_options(&current, reasoning, &catalog);
         let canonical_transcript = driver.canonical_transcript;
         let skill_catalog = skill_catalog::SkillCatalogMonitor::new(&driver.skills)

--- a/src/provider/adapter.rs
+++ b/src/provider/adapter.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 
 use super::{
     OpenAiSubscriptionAdapter, OpenAiSubscriptionSession, OpenAiSubscriptionTurn, OpenRouterApiKey,
-    SubscriptionConfig, speakeasy_auth,
+    SubscriptionConfig, chatgpt::SubscriptionModelCatalogCache, speakeasy_auth,
 };
 
 const MAX_MODELS_BYTES: usize = 2 * 1024 * 1024;
@@ -164,6 +164,7 @@ pub struct SelectableAdapter {
     selection: Arc<Mutex<SessionSelection>>,
     credential_storage: crate::credentials::CredentialStorage,
     openrouter_api_key: Option<OpenRouterApiKey>,
+    openai_model_catalog: SubscriptionModelCatalogCache,
 }
 
 impl SelectableAdapter {
@@ -213,6 +214,7 @@ impl SelectableAdapter {
             })),
             credential_storage,
             openrouter_api_key,
+            openai_model_catalog: SubscriptionModelCatalogCache::default(),
         })
     }
 
@@ -228,6 +230,30 @@ impl SelectableAdapter {
             .lock()
             .map(|value| value.reasoning_effort)
             .map_err(|_| "session selection lock is poisoned".into())
+    }
+
+    async fn discovered_openai_models(&self) -> Vec<String> {
+        let config = match SubscriptionConfig::new(OPENAI_FALLBACK[0].to_string()) {
+            Ok(config) => config.with_credential_storage(self.credential_storage.clone()),
+            Err(_) => return Vec::new(),
+        };
+        let adapter = match OpenAiSubscriptionAdapter::new_with_reasoning_effort_and_catalog(
+            config,
+            None,
+            self.openai_model_catalog.clone(),
+        ) {
+            Ok(adapter) => adapter,
+            Err(_) => return Vec::new(),
+        };
+        adapter
+            .model_catalog()
+            .await
+            .map(|catalog| catalog.visible_models().to_vec())
+            .unwrap_or_default()
+    }
+
+    pub async fn model_catalog(&self, current: &ModelSelection) -> Vec<ModelGroup> {
+        model_catalog_with_openai(current, self.discovered_openai_models()).await
     }
 
     pub fn select(&self, selection: ModelSelection) -> Result<(), String> {
@@ -277,6 +303,7 @@ pub struct SelectableSession {
     selection: Arc<Mutex<SessionSelection>>,
     credential_storage: crate::credentials::CredentialStorage,
     openrouter_api_key: Option<OpenRouterApiKey>,
+    openai_model_catalog: SubscriptionModelCatalogCache,
     config: SessionConfig,
     active: SessionSelection,
     inner: KitSession,
@@ -292,12 +319,13 @@ impl ModelAdapter for SelectableAdapter {
             .lock()
             .map(|value| value.clone())
             .map_err(|_| LoopError::InvalidState("session selection lock is poisoned".into()))?;
-        let inner = KitAdapter::new_with_credentials_and_effort(
+        let inner = KitAdapter::new_with_credentials_effort_and_catalog(
             active.model.provider,
             active.model.model.clone(),
             self.credential_storage.clone(),
             active.reasoning_effort,
             self.openrouter_api_key.as_ref(),
+            self.openai_model_catalog.clone(),
         )
         .map_err(LoopError::InvalidState)?
         .start_session(config.clone())
@@ -306,6 +334,7 @@ impl ModelAdapter for SelectableAdapter {
             selection: Arc::clone(&self.selection),
             credential_storage: self.credential_storage.clone(),
             openrouter_api_key: self.openrouter_api_key.clone(),
+            openai_model_catalog: self.openai_model_catalog.clone(),
             config,
             active,
             inner,
@@ -355,12 +384,13 @@ impl ModelSession for SelectableSession {
             .map(|value| value.clone())
             .map_err(|_| LoopError::InvalidState("session selection lock is poisoned".into()))?;
         if selected != self.active {
-            let replacement = KitAdapter::new_with_credentials_and_effort(
+            let replacement = KitAdapter::new_with_credentials_effort_and_catalog(
                 selected.model.provider,
                 selected.model.model.clone(),
                 self.credential_storage.clone(),
                 selected.reasoning_effort,
                 self.openrouter_api_key.as_ref(),
+                self.openai_model_catalog.clone(),
             )
             .map_err(LoopError::InvalidState)?
             .start_session(self.config.clone())
@@ -509,11 +539,33 @@ impl KitAdapter {
         reasoning_effort: Option<ReasoningEffort>,
         openrouter_api_key: Option<&OpenRouterApiKey>,
     ) -> Result<Self, String> {
+        Self::new_with_credentials_effort_and_catalog(
+            provider,
+            model,
+            credential_storage,
+            reasoning_effort,
+            openrouter_api_key,
+            SubscriptionModelCatalogCache::default(),
+        )
+    }
+
+    fn new_with_credentials_effort_and_catalog(
+        provider: ProviderKind,
+        model: String,
+        credential_storage: crate::credentials::CredentialStorage,
+        reasoning_effort: Option<ReasoningEffort>,
+        openrouter_api_key: Option<&OpenRouterApiKey>,
+        openai_model_catalog: SubscriptionModelCatalogCache,
+    ) -> Result<Self, String> {
         match provider {
             ProviderKind::OpenAiSubscription => {
                 let config =
                     SubscriptionConfig::new(model)?.with_credential_storage(credential_storage);
-                OpenAiSubscriptionAdapter::new_with_reasoning_effort(config, reasoning_effort)
+                OpenAiSubscriptionAdapter::new_with_reasoning_effort_and_catalog(
+                    config,
+                    reasoning_effort,
+                    openai_model_catalog,
+                )
             }
             .map(Self::OpenAiSubscription),
             ProviderKind::OpenRouter => {
@@ -972,18 +1024,29 @@ const OPENROUTER_FALLBACK: &[&str] = &[
     "google/gemini-2.5-pro",
 ];
 
-fn openai_models(current: &ModelSelection) -> Vec<String> {
-    let mut models = [
-        "gpt-5.6-sol",
-        "gpt-5.5",
-        "gpt-5.4",
-        "gpt-5.4-mini",
-        "gpt-5.3-codex-spark",
-    ]
-    .into_iter()
-    .map(str::to_string)
-    .collect::<Vec<_>>();
-    if current.provider == ProviderKind::OpenAiSubscription && !models.contains(&current.model) {
+const OPENAI_FALLBACK: &[&str] = &[
+    "gpt-5.6-sol",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
+];
+
+fn openai_models(discovered: Vec<String>, current: &ModelSelection) -> Vec<String> {
+    let mut models = if discovered.is_empty() {
+        OPENAI_FALLBACK
+            .iter()
+            .map(|model| (*model).to_string())
+            .collect::<Vec<_>>()
+    } else {
+        discovered
+    };
+    let mut seen = std::collections::HashSet::new();
+    models.retain(|model| seen.insert(model.clone()));
+    if current.provider == ProviderKind::OpenAiSubscription
+        && valid_model_id(&current.model)
+        && !models.contains(&current.model)
+    {
         models.push(current.model.clone());
     }
     models
@@ -991,44 +1054,68 @@ fn openai_models(current: &ModelSelection) -> Vec<String> {
 
 /// Returns a bounded, provider-grouped catalog. Remote discovery is best effort.
 pub async fn model_catalog(current: &ModelSelection) -> Vec<ModelGroup> {
-    let openai = openai_models(current);
+    match SelectableAdapter::new(current.provider, current.model.clone()) {
+        Ok(adapter) => adapter.model_catalog(current).await,
+        Err(_) => model_catalog_with_openai(current, std::future::ready(Vec::new())).await,
+    }
+}
+
+async fn model_catalog_with_openai(
+    current: &ModelSelection,
+    openai_catalog: impl std::future::Future<Output = Vec<String>>,
+) -> Vec<ModelGroup> {
     let openrouter_url = match std::env::var_os("OPENROUTER_BASE_URL") {
         None => catalog_models_url(None),
         Some(url) => url.to_str().and_then(|url| catalog_models_url(Some(url))),
     };
     let public_url = OPENROUTER_MODELS_URL.to_string();
     let same_catalog = openrouter_url.as_deref() == Some(public_url.as_str());
-    let (mut openrouter, mut speakeasy) = if same_catalog {
-        let models = fetch_model_ids(&public_url)
-            .await
-            .unwrap_or_else(|_| openrouter_fallback());
-        (models.clone(), models)
-    } else {
-        let openrouter_catalog = async {
-            match openrouter_url {
-                Some(url) => fetch_model_ids(&url)
-                    .await
-                    .unwrap_or_else(|_| openrouter_fallback()),
-                None => openrouter_fallback(),
-            }
-        };
-        let speakeasy_catalog = async {
-            fetch_model_ids(&public_url)
+    let other_catalogs = async move {
+        if same_catalog {
+            let models = fetch_model_ids(&public_url)
                 .await
-                .unwrap_or_else(|_| openrouter_fallback())
-        };
-        tokio::join!(openrouter_catalog, speakeasy_catalog)
+                .unwrap_or_else(|_| openrouter_fallback());
+            (models.clone(), models)
+        } else {
+            let openrouter_catalog = async {
+                match openrouter_url {
+                    Some(url) => fetch_model_ids(&url)
+                        .await
+                        .unwrap_or_else(|_| openrouter_fallback()),
+                    None => openrouter_fallback(),
+                }
+            };
+            let speakeasy_catalog = async {
+                fetch_model_ids(&public_url)
+                    .await
+                    .unwrap_or_else(|_| openrouter_fallback())
+            };
+            tokio::join!(openrouter_catalog, speakeasy_catalog)
+        }
     };
-    if current.provider == ProviderKind::OpenRouter && !openrouter.contains(&current.model) {
+    let (discovered_openai, (mut openrouter, mut speakeasy)) =
+        tokio::join!(openai_catalog, other_catalogs);
+    let openai = openai_models(discovered_openai, current);
+    let current_is_valid = valid_model_id(&current.model);
+    if current_is_valid
+        && current.provider == ProviderKind::OpenRouter
+        && !openrouter.contains(&current.model)
+    {
         openrouter.push(current.model.clone());
     }
-    if current.provider == ProviderKind::Speakeasy && !speakeasy.contains(&current.model) {
+    if current_is_valid
+        && current.provider == ProviderKind::Speakeasy
+        && !speakeasy.contains(&current.model)
+    {
         speakeasy.push(current.model.clone());
     }
     openrouter.sort();
     openrouter.dedup();
     openrouter.truncate(MAX_SELECTOR_MODELS);
-    if current.provider == ProviderKind::OpenRouter && !openrouter.contains(&current.model) {
+    if current_is_valid
+        && current.provider == ProviderKind::OpenRouter
+        && !openrouter.contains(&current.model)
+    {
         if openrouter.len() == MAX_SELECTOR_MODELS {
             openrouter.pop();
         }
@@ -1037,7 +1124,10 @@ pub async fn model_catalog(current: &ModelSelection) -> Vec<ModelGroup> {
     speakeasy.sort();
     speakeasy.dedup();
     speakeasy.truncate(MAX_SELECTOR_MODELS);
-    if current.provider == ProviderKind::Speakeasy && !speakeasy.contains(&current.model) {
+    if current_is_valid
+        && current.provider == ProviderKind::Speakeasy
+        && !speakeasy.contains(&current.model)
+    {
         if speakeasy.len() == MAX_SELECTOR_MODELS {
             speakeasy.pop();
         }
@@ -1135,12 +1225,13 @@ mod tests {
     use crate::credentials::CredentialStorage;
 
     use super::{
-        KitAdapter, KitSession, ModelSelection, OPENROUTER_MODELS_URL, OpenRouterApiKey,
-        OpenRouterKitSession, OpenRouterProvider, ProviderKind, ReasoningEffort, SelectableAdapter,
-        SelectableSession, SessionSelection, SpeakeasyKitAdapter, SpeakeasyProvider,
-        apply_openrouter_reasoning_effort, catalog_models_url, expose_background_call_ids,
-        gram_chat_id, models_url, openai_models, openrouter_config_from_env, parse_context_window,
-        rewrite_openrouter_media, stamp_context_window,
+        KitAdapter, KitSession, ModelSelection, OPENAI_FALLBACK, OPENROUTER_MODELS_URL,
+        OpenRouterApiKey, OpenRouterKitSession, OpenRouterProvider, ProviderKind, ReasoningEffort,
+        SelectableAdapter, SelectableSession, SessionSelection, SpeakeasyKitAdapter,
+        SpeakeasyProvider, apply_openrouter_reasoning_effort, catalog_models_url,
+        expose_background_call_ids, gram_chat_id, models_url, openai_models,
+        openrouter_config_from_env, parse_context_window, rewrite_openrouter_media,
+        stamp_context_window,
     };
 
     #[test]
@@ -1558,6 +1649,7 @@ mod tests {
             selection: Arc::new(Mutex::new(active.clone())),
             credential_storage: Default::default(),
             openrouter_api_key: None,
+            openai_model_catalog: Default::default(),
             config: SessionConfig::new("provider-identity-test"),
             active,
             inner,
@@ -1621,7 +1713,25 @@ mod tests {
     fn openai_catalog_keeps_the_active_custom_model() {
         let current = ModelSelection::new(ProviderKind::OpenAiSubscription, "custom-model");
 
-        assert!(openai_models(&current).contains(&current.model));
+        assert!(openai_models(Vec::new(), &current).contains(&current.model));
+    }
+
+    #[test]
+    fn openai_catalog_prefers_discovery_and_preserves_order() {
+        let current = ModelSelection::new(ProviderKind::OpenAiSubscription, "custom-model");
+        let models = openai_models(
+            vec!["second".into(), "first".into(), "second".into()],
+            &current,
+        );
+
+        assert_eq!(models, ["second", "first", "custom-model"]);
+    }
+
+    #[test]
+    fn openai_catalog_uses_fallback_only_when_discovery_is_empty() {
+        let current = ModelSelection::new(ProviderKind::OpenRouter, "other/model");
+
+        assert_eq!(openai_models(Vec::new(), &current), OPENAI_FALLBACK);
     }
 
     #[test]

--- a/src/provider/chatgpt.rs
+++ b/src/provider/chatgpt.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, io::Cursor, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    io::Cursor,
+    sync::Arc,
+    time::Duration,
+};
 
 use agentkit_core::{DataRef, ItemKind, MetadataMap, Modality, Part, ToolOutput};
 use agentkit_http::{
@@ -47,8 +53,58 @@ const JPEG_DATA_URL_PREFIX: &str = "data:image/jpeg;base64,";
 const MAX_NORMALIZED_IMAGE_BYTES: usize = ((MAX_FIELD_BYTES - JPEG_DATA_URL_PREFIX.len()) / 4) * 3;
 const MAX_SERVER_DELAY: Duration = Duration::from_secs(10 * 60);
 const MAX_SUBSCRIPTION_AUTH_TIMEOUT: Duration = Duration::from_secs(30);
+const MODEL_CATALOG_AUTH_TIMEOUT: Duration = Duration::from_secs(5);
 const LEGACY_CONTINUATION_METADATA: &str = "openai.subscription.v1";
 const CONTINUATION_METADATA: &str = "openai.responses.continuation.v1";
+
+#[derive(Clone, Default)]
+pub(crate) struct SubscriptionModelCatalogCache {
+    entry: Arc<tokio::sync::Mutex<Option<SubscriptionModelCatalogCacheEntry>>>,
+}
+
+struct SubscriptionModelCatalogCacheEntry {
+    binding: auth::CredentialBinding,
+    catalog: Arc<tokio::sync::OnceCell<Arc<SubscriptionModelCatalog>>>,
+}
+
+impl SubscriptionModelCatalogCache {
+    async fn get_or_try_init<F, Fut>(
+        &self,
+        binding: &auth::CredentialBinding,
+        init: F,
+    ) -> Result<Arc<SubscriptionModelCatalog>, LoopError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<SubscriptionModelCatalog, LoopError>>,
+    {
+        let catalog = {
+            let mut entry = self.entry.lock().await;
+            if entry.as_ref().is_none_or(|entry| entry.binding != *binding) {
+                *entry = Some(SubscriptionModelCatalogCacheEntry {
+                    binding: binding.clone(),
+                    catalog: Arc::new(tokio::sync::OnceCell::new()),
+                });
+            }
+            Arc::clone(&entry.as_ref().expect("catalog cache entry exists").catalog)
+        };
+        catalog
+            .get_or_try_init(|| async { init().await.map(Arc::new) })
+            .await
+            .cloned()
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SubscriptionModelCatalog {
+    context_windows: HashMap<String, u64>,
+    visible_models: Vec<String>,
+}
+
+impl SubscriptionModelCatalog {
+    pub(crate) fn visible_models(&self) -> &[String] {
+        &self.visible_models
+    }
+}
 
 fn subscription_resilience() -> ResilienceConfig {
     ResilienceConfig {
@@ -105,7 +161,7 @@ pub struct OpenAiSubscriptionAdapter {
     reasoning_effort: Option<super::adapter::ReasoningEffort>,
     catalog_client: reqwest::Client,
     responses_client: agentkit_http::Http,
-    context_windows: Arc<tokio::sync::OnceCell<Arc<HashMap<String, u64>>>>,
+    model_catalog: SubscriptionModelCatalogCache,
 }
 
 impl OpenAiSubscriptionAdapter {
@@ -116,6 +172,18 @@ impl OpenAiSubscriptionAdapter {
     pub(crate) fn new_with_reasoning_effort(
         config: SubscriptionConfig,
         reasoning_effort: Option<super::adapter::ReasoningEffort>,
+    ) -> Result<Self, String> {
+        Self::new_with_reasoning_effort_and_catalog(
+            config,
+            reasoning_effort,
+            SubscriptionModelCatalogCache::default(),
+        )
+    }
+
+    pub(crate) fn new_with_reasoning_effort_and_catalog(
+        config: SubscriptionConfig,
+        reasoning_effort: Option<super::adapter::ReasoningEffort>,
+        model_catalog: SubscriptionModelCatalogCache,
     ) -> Result<Self, String> {
         let client = reqwest::Client::builder()
             .no_proxy()
@@ -131,8 +199,38 @@ impl OpenAiSubscriptionAdapter {
             reasoning_effort,
             catalog_client,
             responses_client,
-            context_windows: Arc::new(tokio::sync::OnceCell::new()),
+            model_catalog,
         })
+    }
+
+    async fn catalog_with_credentials(
+        &self,
+        credentials: &auth::TokenRecord,
+        binding: &auth::CredentialBinding,
+    ) -> Result<Arc<SubscriptionModelCatalog>, LoopError> {
+        self.model_catalog
+            .get_or_try_init(binding, || {
+                fetch_model_catalog(&self.catalog_client, credentials)
+            })
+            .await
+    }
+
+    pub(crate) async fn model_catalog(&self) -> Result<Arc<SubscriptionModelCatalog>, LoopError> {
+        let credentials = tokio::time::timeout(
+            MODEL_CATALOG_AUTH_TIMEOUT,
+            load_credentials(
+                self.config.credential_storage.clone(),
+                MODEL_CATALOG_AUTH_TIMEOUT,
+            ),
+        )
+        .await
+        .map_err(|_| {
+            LoopError::Provider("OpenAI model catalog credential load timed out".into())
+        })??;
+        let binding = credentials
+            .binding()
+            .map_err(|error| LoopError::Provider(error.to_string()))?;
+        self.catalog_with_credentials(&credentials, &binding).await
     }
 }
 
@@ -155,17 +253,11 @@ impl ModelAdapter for OpenAiSubscriptionAdapter {
             .binding()
             .map_err(|error| LoopError::Provider(error.to_string()))?;
         let authentication_binding = binding_string(&binding);
-        // Catalog discovery stays independent and best-effort.
-        let context_windows = self
-            .context_windows
-            .get_or_try_init(|| async {
-                fetch_context_windows(&self.catalog_client, &credentials)
-                    .await
-                    .map(Arc::new)
-            })
+        // Catalog discovery stays independent and best-effort. A failed fetch is not cached.
+        let model_catalog = self
+            .catalog_with_credentials(&credentials, &binding)
             .await
-            .cloned()
-            .unwrap_or_default();
+            .unwrap_or_else(|_| Arc::new(SubscriptionModelCatalog::default()));
         let authentication = Authentication::new(OpenAiAuthenticationProvider {
             credential_storage: self.config.credential_storage.clone(),
             binding,
@@ -193,7 +285,10 @@ impl ModelAdapter for OpenAiSubscriptionAdapter {
             .await?;
         Ok(OpenAiSubscriptionSession {
             inner,
-            context_window: context_windows.get(&self.config.model).copied(),
+            context_window: model_catalog
+                .context_windows
+                .get(&self.config.model)
+                .copied(),
             model: self.config.model.clone(),
             authentication_binding,
         })
@@ -786,10 +881,10 @@ fn binding_string(binding: &auth::CredentialBinding) -> String {
     format!("openai-chatgpt-v1:{account_digest}:{}", binding.generation)
 }
 
-async fn fetch_context_windows(
+async fn fetch_model_catalog(
     client: &reqwest::Client,
     credentials: &auth::TokenRecord,
-) -> Result<HashMap<String, u64>, LoopError> {
+) -> Result<SubscriptionModelCatalog, LoopError> {
     let endpoint = format!("{MODELS_ENDPOINT}?client_version={MODEL_CATALOG_CLIENT_VERSION}");
     let mut request = client
         .get(endpoint)
@@ -827,16 +922,17 @@ async fn fetch_context_windows(
     }
     let value: Value =
         serde_json::from_slice(&body).map_err(|_| protocol("model catalog is not valid JSON"))?;
-    parse_context_windows(&value)
+    parse_model_catalog(&value)
 }
 
-fn parse_context_windows(value: &Value) -> Result<HashMap<String, u64>, LoopError> {
+fn parse_model_catalog(value: &Value) -> Result<SubscriptionModelCatalog, LoopError> {
     let models = value
         .get("models")
         .and_then(Value::as_array)
         .filter(|models| models.len() <= MAX_MODELS)
         .ok_or_else(|| protocol("model catalog omitted a bounded models list"))?;
-    let mut windows = HashMap::new();
+    let mut context_windows = HashMap::new();
+    let mut visible_models = Vec::new();
     for model in models {
         let Some(slug) = model
             .get("slug")
@@ -845,18 +941,32 @@ fn parse_context_windows(value: &Value) -> Result<HashMap<String, u64>, LoopErro
         else {
             continue;
         };
-        let Some(window) = model
+        if let Some(window) = model
             .get("context_window")
-            .filter(|window| !window.is_null())
-        else {
-            continue;
-        };
-        let Some(window) = window.as_u64().filter(|window| *window > 0) else {
-            continue;
-        };
-        windows.entry(slug.to_owned()).or_insert(window);
+            .and_then(Value::as_u64)
+            .filter(|window| *window > 0)
+        {
+            context_windows.entry(slug.to_owned()).or_insert(window);
+        }
+        if model.get("visibility").and_then(Value::as_str) == Some("list") {
+            let priority = model
+                .get("priority")
+                .and_then(Value::as_i64)
+                .unwrap_or(i64::MAX);
+            visible_models.push((priority, slug.to_owned()));
+        }
     }
-    Ok(windows)
+    visible_models.sort_by_key(|(priority, _)| *priority);
+    let mut seen = HashSet::new();
+    let visible_models = visible_models
+        .into_iter()
+        .map(|(_, slug)| slug)
+        .filter(|slug| seen.insert(slug.clone()))
+        .collect();
+    Ok(SubscriptionModelCatalog {
+        context_windows,
+        visible_models,
+    })
 }
 
 fn protocol(message: &str) -> LoopError {
@@ -1002,6 +1112,7 @@ mod tests {
         assert_eq!(config.initial_backoff, Duration::from_secs(1));
         assert_eq!(config.max_backoff, Duration::from_secs(60));
         assert_eq!(MAX_SERVER_DELAY, Duration::from_secs(10 * 60));
+        assert_eq!(MODEL_CATALOG_AUTH_TIMEOUT, Duration::from_secs(5));
     }
 
     #[test]
@@ -1117,16 +1228,109 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn model_catalog_cache_is_scoped_to_account_and_generation() {
+        let cache = SubscriptionModelCatalogCache::default();
+        let first_binding =
+            auth::TokenRecord::for_test_generation("token", "account-1", "generation-1")
+                .binding()
+                .unwrap();
+        let next_generation =
+            auth::TokenRecord::for_test_generation("token", "account-1", "generation-2")
+                .binding()
+                .unwrap();
+        let next_account =
+            auth::TokenRecord::for_test_generation("token", "account-2", "generation-1")
+                .binding()
+                .unwrap();
+
+        let first = cache
+            .get_or_try_init(&first_binding, || async {
+                Ok(SubscriptionModelCatalog {
+                    context_windows: HashMap::from([("first".into(), 100)]),
+                    visible_models: vec!["first".into()],
+                })
+            })
+            .await
+            .unwrap();
+        let same = cache
+            .get_or_try_init(&first_binding, || async {
+                Err(protocol("cached catalog was unexpectedly reloaded"))
+            })
+            .await
+            .unwrap();
+        assert!(Arc::ptr_eq(&first, &same));
+
+        let second = cache
+            .get_or_try_init(&next_generation, || async {
+                Ok(SubscriptionModelCatalog {
+                    context_windows: HashMap::from([("second".into(), 200)]),
+                    visible_models: vec!["second".into()],
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(second.visible_models, ["second"]);
+        assert_eq!(second.context_windows.get("first"), None);
+        assert_eq!(second.context_windows.get("second"), Some(&200));
+        assert!(!Arc::ptr_eq(&first, &second));
+
+        let third = cache
+            .get_or_try_init(&next_account, || async {
+                Ok(SubscriptionModelCatalog {
+                    context_windows: HashMap::from([("third".into(), 300)]),
+                    visible_models: vec!["third".into()],
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(third.visible_models, ["third"]);
+        assert_eq!(third.context_windows.get("second"), None);
+        assert_eq!(third.context_windows.get("third"), Some(&300));
+        assert!(!Arc::ptr_eq(&second, &third));
+    }
+
+    #[tokio::test]
+    async fn model_catalog_cache_retries_after_failure() {
+        let cache = SubscriptionModelCatalogCache::default();
+        let binding = auth::TokenRecord::for_test_generation("token", "account", "generation")
+            .binding()
+            .unwrap();
+
+        let first = cache
+            .get_or_try_init(&binding, || async { Err(protocol("temporary failure")) })
+            .await;
+        assert!(first.is_err());
+
+        let retry = cache
+            .get_or_try_init(&binding, || async {
+                Ok(SubscriptionModelCatalog {
+                    visible_models: vec!["recovered".into()],
+                    ..Default::default()
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(retry.visible_models, ["recovered"]);
+    }
+
     #[test]
-    fn catalog_parser_preserves_valid_models() {
+    fn catalog_parser_filters_orders_and_deduplicates_visible_models() {
         let too_long = format!("g{}", "x".repeat(MAX_CATALOG_MODEL_ID_BYTES));
-        let windows = parse_context_windows(&json!({"models": [
-            {"slug": "gpt-5.4", "context_window": 200000},
-            {"slug": "bad slug", "context_window": 1},
-            {"slug": too_long, "context_window": 1}
+        let catalog = parse_model_catalog(&json!({"models": [
+            {"slug": "hidden", "visibility": "hide", "priority": 0, "context_window": 300000},
+            {"slug": "later", "visibility": "list", "priority": 20, "context_window": 200000},
+            {"slug": "first", "visibility": "list", "priority": 10, "supported_in_api": false},
+            {"slug": "same-priority", "visibility": "list", "priority": 10},
+            {"slug": "later", "visibility": "list", "priority": 30},
+            {"slug": "bad slug", "visibility": "list", "priority": 1, "context_window": 1},
+            {"slug": too_long, "visibility": "list", "priority": 1, "context_window": 1}
         ]}))
         .unwrap();
-        assert_eq!(windows.get("gpt-5.4"), Some(&200000));
-        assert_eq!(windows.len(), 1);
+
+        assert_eq!(catalog.visible_models, ["first", "same-priority", "later"]);
+        assert_eq!(catalog.context_windows.get("hidden"), Some(&300000));
+        assert_eq!(catalog.context_windows.get("later"), Some(&200000));
+        assert_eq!(catalog.context_windows.len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

Discover OpenAI subscription models from the authenticated ChatGPT Codex catalog and expose visible entries through the model picker. Retain the bundled model list as a best-effort fallback and preserve the active selection when the catalog omits it.

## Motivation

OpenAI subscription model availability can vary by account and server rollout, so a hardcoded picker can drift from the models a user can access.

## Impact

OpenAI subscription users can see models advertised for their account. Catalog authentication, transport, and parsing failures remain non-fatal and continue to use the existing fallback list.

## Technical details

### Catalog projection

Kit reuses the models endpoint already queried for context-window metadata. Picker entries include only models with `visibility == "list"`, follow stable ascending priority order, and are deduplicated by validated slug. Hidden models still contribute context-window metadata.

### Cache and fallback behavior

Catalog results are cached per authenticated account and credential generation and shared across model replacements within a selectable session. Failed fetches are not cached, and inactive-provider credential discovery is bounded to five seconds.