### PR TITLE
fix(release): switch release notes model

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,7 +436,7 @@ jobs:
           release-kit/kit prompt \
             --root "$GITHUB_WORKSPACE" \
             --provider openrouter \
-            --model z-ai/glm-5.3 \
+            --model anthropic/claude-sonnet-5 \
             "use release-notes skill for ${{ needs.verify.outputs.previous_tag }}..${{ needs.verify.outputs.release_sha }}; respond only with release notes" \
             > kit-output.txt
           sed '$ { /^session_id: /d; }' kit-output.txt > release-notes.md

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -31,7 +31,7 @@ default `GITHUB_TOKEN` cannot bypass the pull-request and status-check rules.
 The newly built Linux Kit CLI reviews every change since the previous release and
 writes the GitHub release notes before the workflow attaches the archives and
 checksums. Configure the repository Actions secret `OPENROUTER_API_KEY` for this
-step. Kit uses the `release-notes` skill with the `z-ai/glm-5.3` OpenRouter model.
+step. Kit uses the `release-notes` skill with the `anthropic/claude-sonnet-5` OpenRouter model.
 
 ## macOS signing and notarization
 


### PR DESCRIPTION
## Summary

Switch release-note generation from `z-ai/glm-5.3` to `anthropic/claude-sonnet-5` and keep the release documentation aligned.

## Motivation

The current release is blocked because the configured model repeatedly exits successfully without producing release-note content. The replacement model returns normal content through the same OpenRouter and Kit path.