### PR TITLE
fix(release): use GPT-5.6 Terra for notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,7 +436,7 @@ jobs:
           release-kit/kit prompt \
             --root "$GITHUB_WORKSPACE" \
             --provider openrouter \
-            --model anthropic/claude-sonnet-5 \
+            --model openai/gpt-5.6-terra \
             "use release-notes skill for ${{ needs.verify.outputs.previous_tag }}..${{ needs.verify.outputs.release_sha }}; respond only with release notes" \
             > kit-output.txt
           sed '$ { /^session_id: /d; }' kit-output.txt > release-notes.md

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -31,7 +31,7 @@ default `GITHUB_TOKEN` cannot bypass the pull-request and status-check rules.
 The newly built Linux Kit CLI reviews every change since the previous release and
 writes the GitHub release notes before the workflow attaches the archives and
 checksums. Configure the repository Actions secret `OPENROUTER_API_KEY` for this
-step. Kit uses the `release-notes` skill with the `anthropic/claude-sonnet-5` OpenRouter model.
+step. Kit uses the `release-notes` skill with the `openai/gpt-5.6-terra` OpenRouter model.
 
 ## macOS signing and notarization
 


### PR DESCRIPTION
## Summary

Use `openai/gpt-5.6-terra` for automated release-note generation and update the release documentation to match.

## Impact

Future release workflows will generate notes with GPT-5.6 Terra through the existing OpenRouter integration.