### PR TITLE
fix(release): handle empty model responses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -433,17 +433,50 @@ jobs:
           tar -xzf "dist/kit-v${RELEASE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
             -C release-kit
           release-kit/kit --version
-          release-kit/kit prompt \
-            --root "$GITHUB_WORKSPACE" \
-            --provider openrouter \
-            --model openai/gpt-5.6-terra \
-            "use release-notes skill for ${{ needs.verify.outputs.previous_tag }}..${{ needs.verify.outputs.release_sha }}; respond only with release notes" \
-            > kit-output.txt
-          sed '$ { /^session_id: /d; }' kit-output.txt > release-notes.md
-          if ! grep -q '[^[:space:]]' release-notes.md; then
-            echo "::error::Kit returned an empty release note."
+          generated=false
+          for attempt in 1 2 3; do
+            output="kit-output-${attempt}.txt"
+            stderr="kit-stderr-${attempt}.txt"
+            if release-kit/kit prompt \
+              --root "$GITHUB_WORKSPACE" \
+              --provider openrouter \
+              --model openai/gpt-5.6-terra \
+              "use release-notes skill for ${{ needs.verify.outputs.previous_tag }}..${{ needs.verify.outputs.release_sha }}; respond only with release notes" \
+              > "$output" 2> >(tee "$stderr" >&2)
+            then
+              sed '$ { /^session_id: /d; }' "$output" > release-notes.md
+              if grep -q '[^[:space:]]' release-notes.md; then
+                generated=true
+                break
+              fi
+            fi
+            echo "::warning::Kit release note attempt ${attempt} failed or returned no text."
+            if (( attempt < 3 )); then
+              sleep $((attempt * 5))
+            fi
+          done
+          if [[ $generated != true ]]; then
+            echo "::error::Kit failed to generate a non-empty release note after 3 attempts."
             exit 1
           fi
+      - name: Collect release note diagnostics
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p release-note-diagnostics
+          cp kit-output-*.txt kit-stderr-*.txt release-note-diagnostics/
+          if [[ -d $HOME/.kit/sessions ]]; then
+            find "$HOME/.kit/sessions" -type f -name '*.jsonl' -print0 |
+              xargs -0 -r jq -c 'select(.item.kind == "Assistant") | {session_id, item: {id: .item.id, finish_reason: .item.finish_reason, usage: .item.usage, part_kinds: [.item.parts[] | keys[0]]}}' \
+              > release-note-diagnostics/model-turns.jsonl
+          fi
+      - name: Upload release note diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-note-diagnostics
+          path: release-note-diagnostics
+          if-no-files-found: error
       - uses: actions/upload-artifact@v4
         with:
           name: release-notes

--- a/src/provider/adapter.rs
+++ b/src/provider/adapter.rs
@@ -28,6 +28,8 @@ use super::{
 const MAX_MODELS_BYTES: usize = 2 * 1024 * 1024;
 const MAX_MODELS: usize = 10_000;
 const MAX_SELECTOR_MODELS: usize = 2_000;
+pub(crate) const RESPONSE_ID_METADATA_KEY: &str = "kit.provider.response_id";
+pub(crate) const RESPONSE_MODEL_METADATA_KEY: &str = "kit.provider.response_model";
 const OPENROUTER_AUTH_REQUIRED: &str = "openrouter_auth_required: set OPENROUTER_API_KEY or run `kit auth login openrouter` before using the OpenRouter provider";
 const SPEAKEASY_AUTH_REQUIRED: &str =
     "speakeasy_auth_required: run `kit auth login speakeasy` before using the Speakeasy provider";
@@ -869,8 +871,8 @@ impl ModelTurn for KitTurn {
         &mut self,
         cancellation: Option<TurnCancellation>,
     ) -> Result<Option<ModelTurnEvent>, LoopError> {
-        match self {
-            Self::OpenAiSubscription(turn) => turn.next_event(cancellation).await,
+        let mut event = match self {
+            Self::OpenAiSubscription(turn) => turn.next_event(cancellation).await?,
             Self::OpenRouter(turn) | Self::Speakeasy(turn) => {
                 let mut event = turn.inner.next_event(cancellation).await?;
                 if let Some(ModelTurnEvent::Delta(delta)) = &mut event {
@@ -879,9 +881,29 @@ impl ModelTurn for KitTurn {
                 if let Some(context_window) = turn.context_window {
                     stamp_context_window(&mut event, context_window, "openrouter.context_length");
                 }
-                Ok(event)
+                event
             }
-        }
+        };
+        stamp_response_diagnostics(&mut event);
+        Ok(event)
+    }
+}
+
+fn stamp_response_diagnostics(event: &mut Option<ModelTurnEvent>) {
+    let Some(ModelTurnEvent::Finished(result)) = event else {
+        return;
+    };
+    if let Some(response_id) = &result.response_id {
+        result.metadata.insert(
+            RESPONSE_ID_METADATA_KEY.into(),
+            Value::String(response_id.clone()),
+        );
+    }
+    if let Some(model) = &result.model {
+        result.metadata.insert(
+            RESPONSE_MODEL_METADATA_KEY.into(),
+            Value::String(model.clone()),
+        );
     }
 }
 
@@ -1226,12 +1248,12 @@ mod tests {
 
     use super::{
         KitAdapter, KitSession, ModelSelection, OPENAI_FALLBACK, OPENROUTER_MODELS_URL,
-        OpenRouterApiKey, OpenRouterKitSession, OpenRouterProvider, ProviderKind, ReasoningEffort,
-        SelectableAdapter, SelectableSession, SessionSelection, SpeakeasyKitAdapter,
-        SpeakeasyProvider, apply_openrouter_reasoning_effort, catalog_models_url,
-        expose_background_call_ids, gram_chat_id, models_url, openai_models,
-        openrouter_config_from_env, parse_context_window, rewrite_openrouter_media,
-        stamp_context_window,
+        OpenRouterApiKey, OpenRouterKitSession, OpenRouterProvider, ProviderKind,
+        RESPONSE_ID_METADATA_KEY, RESPONSE_MODEL_METADATA_KEY, ReasoningEffort, SelectableAdapter,
+        SelectableSession, SessionSelection, SpeakeasyKitAdapter, SpeakeasyProvider,
+        apply_openrouter_reasoning_effort, catalog_models_url, expose_background_call_ids,
+        gram_chat_id, models_url, openai_models, openrouter_config_from_env, parse_context_window,
+        rewrite_openrouter_media, stamp_context_window, stamp_response_diagnostics,
     };
 
     #[test]
@@ -1844,5 +1866,31 @@ mod tests {
             assert_eq!(usage.metadata["context_window"], json!(200_000));
             assert_eq!(usage.metadata["openrouter.context_length"], json!(200_000));
         }
+    }
+
+    #[test]
+    fn response_diagnostics_are_retained_in_finished_metadata() {
+        let mut event = Some(ModelTurnEvent::Finished(ModelTurnResult {
+            finish_reason: FinishReason::Completed,
+            output_items: Vec::new(),
+            usage: None,
+            metadata: MetadataMap::new(),
+            model: Some("test/model".into()),
+            response_id: Some("generation-123".into()),
+        }));
+
+        stamp_response_diagnostics(&mut event);
+
+        let Some(ModelTurnEvent::Finished(result)) = event else {
+            panic!("expected finished event");
+        };
+        assert_eq!(
+            result.metadata.get(RESPONSE_ID_METADATA_KEY),
+            Some(&json!("generation-123"))
+        );
+        assert_eq!(
+            result.metadata.get(RESPONSE_MODEL_METADATA_KEY),
+            Some(&json!("test/model"))
+        );
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -4,10 +4,12 @@ mod openai_auth;
 mod openrouter_auth;
 mod speakeasy_auth;
 
-pub(crate) use adapter::authentication_method_id;
 pub use adapter::{
     KitAdapter, KitSession, ModelGroup, ModelSelection, ProviderKind, ReasoningEffort,
     SelectableAdapter, SelectableSession, model_catalog,
+};
+pub(crate) use adapter::{
+    RESPONSE_ID_METADATA_KEY, RESPONSE_MODEL_METADATA_KEY, authentication_method_id,
 };
 
 /// An OpenRouter API key that is redacted in diagnostics and zeroized on drop.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -16,7 +16,8 @@ use agentkit_core::{
     ToolOutput, ToolResultPart,
 };
 use agentkit_loop::{
-    Agent, LoopDriver, LoopError, LoopInterrupt, LoopObserver, LoopStep, SessionConfig,
+    Agent, LoopDriver, LoopError, LoopInterrupt, LoopObserver, LoopStep,
+    PROVIDER_FINISH_REASONS_METADATA_KEY, SessionConfig, TurnResult,
 };
 use agentkit_task_manager::{AsyncTaskManager, RoutingDecision, TaskManager, TaskManagerHandle};
 use agentkit_tool_compose::{
@@ -35,7 +36,8 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     acp_child::{AcpHarnesses, BUILTIN_HARNESS, ChildConfig},
     provider::{
-        ModelSelection, ProviderKind, ReasoningEffort, SelectableAdapter, SelectableSession,
+        ModelSelection, ProviderKind, RESPONSE_ID_METADATA_KEY, RESPONSE_MODEL_METADATA_KEY,
+        ReasoningEffort, SelectableAdapter, SelectableSession,
     },
     tools::{
         A2aTool, AuthTool, CloseTool, DocsTool, EditTool, ForkTool, McpTool, Observed, PromptTool,
@@ -2317,21 +2319,7 @@ fn record_loop_failure(
 async fn drive(driver: &mut LoopDriver<SelectableSession>) -> Result<String, LoopError> {
     loop {
         match driver.next().await? {
-            LoopStep::Finished(result) => {
-                if result.finish_reason == FinishReason::Cancelled {
-                    return Err(LoopError::Cancelled);
-                }
-                return Ok(result
-                    .items
-                    .iter()
-                    .flat_map(|item| &item.parts)
-                    .filter_map(|part| match part {
-                        Part::Text(text) => Some(text.text.as_str()),
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>()
-                    .join(""));
-            }
+            LoopStep::Finished(result) => return turn_output(&result),
             LoopStep::Interrupt(LoopInterrupt::AfterToolResult(_)) => continue,
             LoopStep::Interrupt(_) => {
                 return Err(LoopError::InvalidState(
@@ -2340,4 +2328,74 @@ async fn drive(driver: &mut LoopDriver<SelectableSession>) -> Result<String, Loo
             }
         }
     }
+}
+
+fn turn_output(result: &TurnResult) -> Result<String, LoopError> {
+    if result.finish_reason == FinishReason::Cancelled {
+        return Err(LoopError::Cancelled);
+    }
+    let output = result
+        .items
+        .iter()
+        .flat_map(|item| &item.parts)
+        .filter_map(|part| match part {
+            Part::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    if !output.trim().is_empty() {
+        return Ok(output);
+    }
+
+    let parts = result
+        .items
+        .iter()
+        .map(|item| item.parts.len())
+        .sum::<usize>();
+    let mut detail = format!(
+        "model returned no non-whitespace text (finish_reason={:?}, items={}, parts={}",
+        result.finish_reason,
+        result.items.len(),
+        parts
+    );
+    append_metadata_diagnostic(
+        &mut detail,
+        &result.metadata,
+        PROVIDER_FINISH_REASONS_METADATA_KEY,
+        "provider_finish_reasons",
+    );
+    append_metadata_diagnostic(
+        &mut detail,
+        &result.metadata,
+        RESPONSE_MODEL_METADATA_KEY,
+        "model",
+    );
+    append_metadata_diagnostic(
+        &mut detail,
+        &result.metadata,
+        RESPONSE_ID_METADATA_KEY,
+        "response_id",
+    );
+    if let Some(tokens) = result
+        .usage
+        .as_ref()
+        .and_then(|usage| usage.tokens.as_ref())
+    {
+        let _ = write!(detail, ", output_tokens={}", tokens.output_tokens);
+        if let Some(reasoning_tokens) = tokens.reasoning_tokens {
+            let _ = write!(detail, ", reasoning_tokens={reasoning_tokens}");
+        }
+    }
+    detail.push(')');
+    Err(LoopError::Provider(detail))
+}
+
+fn append_metadata_diagnostic(detail: &mut String, metadata: &MetadataMap, key: &str, label: &str) {
+    let Some(value) = metadata.get(key) else {
+        return;
+    };
+    let rendered = value.to_string();
+    let bounded = rendered.chars().take(160).collect::<String>();
+    let _ = write!(detail, ", {label}={bounded}");
 }

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -1,8 +1,10 @@
 use std::{sync::Arc, time::Duration};
 
 use agentkit_core::{
-    CancellationController, ItemKind, MetadataMap, Part, SessionId, ToolCallId, ToolOutput, TurnId,
+    CancellationController, FinishReason, Item, ItemKind, MetadataMap, Part, SessionId, TokenUsage,
+    ToolCallId, ToolOutput, TurnId, Usage,
 };
+use agentkit_loop::{PROVIDER_FINISH_REASONS_METADATA_KEY, TurnResult};
 use agentkit_task_manager::RoutingDecision;
 use agentkit_tools_core::{
     AllowAllPermissions, BasicToolExecutor, OwnedToolContext, Tool, ToolExecutionOutcome,
@@ -13,8 +15,53 @@ use serde_json::{Value, json};
 use super::{
     BackgroundJobs, BackgroundableCompose, DetachRegistration, DynamicSkillTool,
     LogoutAuthenticationError, Runtime, SessionRequest, SessionSelection, background_route,
-    load_initial_transcript,
+    load_initial_transcript, turn_output,
 };
+
+#[test]
+fn empty_turn_output_reports_provider_diagnostics() {
+    let mut metadata = MetadataMap::new();
+    metadata.insert(PROVIDER_FINISH_REASONS_METADATA_KEY.into(), json!(["stop"]));
+    metadata.insert(
+        crate::provider::RESPONSE_MODEL_METADATA_KEY.into(),
+        json!("z-ai/glm-5.3"),
+    );
+    metadata.insert(
+        crate::provider::RESPONSE_ID_METADATA_KEY.into(),
+        json!("generation-123"),
+    );
+    let result = TurnResult {
+        turn_id: TurnId::new("turn"),
+        finish_reason: FinishReason::Completed,
+        items: vec![Item::text(ItemKind::Assistant, " \n")],
+        usage: Some(Usage::new(
+            TokenUsage::new(100, 12).with_reasoning_tokens(12),
+        )),
+        metadata,
+    };
+
+    let error = turn_output(&result).unwrap_err().to_string();
+
+    assert!(error.contains("model returned no non-whitespace text"));
+    assert!(error.contains("provider_finish_reasons=[\"stop\"]"));
+    assert!(error.contains("model=\"z-ai/glm-5.3\""));
+    assert!(error.contains("response_id=\"generation-123\""));
+    assert!(error.contains("output_tokens=12"));
+    assert!(error.contains("reasoning_tokens=12"));
+}
+
+#[test]
+fn nonempty_turn_output_is_returned() {
+    let result = TurnResult {
+        turn_id: TurnId::new("turn"),
+        finish_reason: FinishReason::Completed,
+        items: vec![Item::text(ItemKind::Assistant, "release notes")],
+        usage: None,
+        metadata: MetadataMap::new(),
+    };
+
+    assert_eq!(turn_output(&result).unwrap(), "release notes");
+}
 
 #[tokio::test]
 async fn subagent_manager_survives_runtime_reconstruction() {


### PR DESCRIPTION
## Summary

Treat completed prompt turns without non-whitespace text as provider failures and retain bounded response metadata for diagnosis. Retry release-note generation within the job and upload sanitized diagnostics if all attempts fail.

## Motivation

[Release run 33810129138](https://github.com/speakeasy-api/kit/actions/runs/33810129138) received successful but empty model turns on three workflow attempts. The workflow detected the empty release notes, but the provider response ID, finish reason, token usage, and response shape were unavailable afterward.

## Impact

`kit prompt` now exits with a provider error when a completed turn has no printable text. Release-note generation can make up to three attempts with bounded backoff; after a final failure, CI uploads stderr and response metadata without model text or reasoning content.

## Technical details

### Empty-turn diagnostics

Kit carries the provider-reported model and response ID into final turn metadata before validating output. Empty-turn errors include bounded model and response identifiers, normalized and provider-native finish reasons, item and part counts, and output and reasoning token counts.

### Release diagnostics

The failure artifact records each attempt's stdout and stderr plus sanitized assistant metadata: response ID, finish reason, usage, and part kinds such as `Reasoning`, `Text`, and `ToolCall`. This is enough to correlate an OpenRouter generation and identify reasoning-only responses without publishing their content.