### PR TITLE
fix(provider): refresh OpenAI catalog client version

### DIFF
--- a/src/provider/chatgpt.rs
+++ b/src/provider/chatgpt.rs
@@ -35,7 +35,7 @@ use super::{
 
 const ENDPOINT: &str = "https://chatgpt.com/backend-api/codex/responses";
 const MODELS_ENDPOINT: &str = "https://chatgpt.com/backend-api/codex/models";
-const MODEL_CATALOG_CLIENT_VERSION: &str = "0.144.0";
+const MODEL_CATALOG_CLIENT_VERSION: &str = "0.153.3";
 const MAX_MODELS_BYTES: usize = 2 * 1024 * 1024;
 const MAX_MODELS: usize = 1_000;
 const MAX_CATALOG_MODEL_ID_BYTES: usize = 128;


### PR DESCRIPTION
## Summary

Update the Codex client version sent to OpenAI's subscription model catalog from 0.144.0 to 0.153.3 so Kit receives listings available to current stable Codex clients.

## Motivation

OpenAI's catalog uses `client_version` to control model visibility. Advertising the older version omits newly listed models such as `gpt-6-astra` even when the account has access.
