### PR TITLE
fix(tui): keep saved models across session transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "agentkit-provider-openai"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ecc23df8ef7142c0ad4383a985820a4369402dfe2838e01689bbbfea31beb2"
+checksum = "c677bf5485f3521227a14b7c92610cb85861f34464a3e3a9f02485ae1c0c1acd"
 dependencies = [
  "agentkit-adapter-completions",
  "agentkit-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ agentkit-loop = { version = "=0.10.11", features = ["otel"] }
 agentkit-mcp = "=0.10.6"
 agentkit-http = "=0.10.6"
 agentkit-plugins = "=0.10.7"
-agentkit-provider-openai = "=0.10.7"
+agentkit-provider-openai = "=0.10.8"
 agentkit-provider-openrouter = "=0.10.8"
 agentkit-task-manager = "=0.10.7"
 agentkit-tool-compose = { version = "=0.10.10", default-features = false, features = ["runlet"] }

--- a/src/provider/chatgpt.rs
+++ b/src/provider/chatgpt.rs
@@ -723,6 +723,7 @@ fn migrate_legacy_continuations(
             else {
                 continue;
             };
+            discard_incompatible_continuations(metadata, model, &session_id);
             migrate_legacy_continuation(
                 metadata,
                 model,
@@ -742,6 +743,27 @@ fn continuation_metadata_mut(part: &mut Part) -> Option<(&mut MetadataMap, &'sta
         Part::Reasoning(reasoning) => Some((&mut reasoning.metadata, "reasoning", true)),
         Part::Media(media) => Some((&mut media.metadata, "image_generation_call", false)),
         _ => None,
+    }
+}
+
+fn discard_incompatible_continuations(metadata: &mut MetadataMap, model: &str, session_id: &str) {
+    for key in [CONTINUATION_METADATA, LEGACY_CONTINUATION_METADATA] {
+        let incompatible = metadata
+            .get(key)
+            .and_then(Value::as_object)
+            .is_some_and(|value| {
+                value
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .is_some_and(|stored| stored != model)
+                    || value
+                        .get("session_id")
+                        .and_then(Value::as_str)
+                        .is_some_and(|stored| stored != session_id)
+            });
+        if incompatible {
+            metadata.remove(key);
+        }
     }
 }
 
@@ -1149,6 +1171,36 @@ mod tests {
             &legacy,
             &format!("openai-chatgpt-v1:{digest}:generation-2"),
         ));
+    }
+
+    #[test]
+    fn discards_continuations_bound_to_another_model_or_session() {
+        for continuation in [
+            json!({"model": "gpt-6-astra", "session_id": "session-1"}),
+            json!({"model": "gpt-5.6-sol", "session_id": "session-2"}),
+        ] {
+            let mut metadata = MetadataMap::from([
+                (CONTINUATION_METADATA.into(), continuation.clone()),
+                (LEGACY_CONTINUATION_METADATA.into(), continuation),
+                ("other".into(), json!(true)),
+            ]);
+
+            discard_incompatible_continuations(&mut metadata, "gpt-5.6-sol", "session-1");
+
+            assert!(!metadata.contains_key(CONTINUATION_METADATA));
+            assert!(!metadata.contains_key(LEGACY_CONTINUATION_METADATA));
+            assert_eq!(metadata["other"], json!(true));
+        }
+
+        let matching = json!({"model": "gpt-5.6-sol", "session_id": "session-1"});
+        let mut metadata = MetadataMap::from([(CONTINUATION_METADATA.into(), matching.clone())]);
+        discard_incompatible_continuations(&mut metadata, "gpt-5.6-sol", "session-1");
+        assert_eq!(metadata[CONTINUATION_METADATA], matching);
+
+        let malformed = json!({"model": 7, "session_id": null});
+        let mut metadata = MetadataMap::from([(CONTINUATION_METADATA.into(), malformed.clone())]);
+        discard_incompatible_continuations(&mut metadata, "gpt-5.6-sol", "session-1");
+        assert_eq!(metadata[CONTINUATION_METADATA], malformed);
     }
 
     #[test]

--- a/src/provider/chatgpt.rs
+++ b/src/provider/chatgpt.rs
@@ -289,7 +289,6 @@ impl ModelAdapter for OpenAiSubscriptionAdapter {
                 .context_windows
                 .get(&self.config.model)
                 .copied(),
-            model: self.config.model.clone(),
             authentication_binding,
         })
     }
@@ -302,7 +301,6 @@ impl ModelAdapter for OpenAiSubscriptionAdapter {
 pub struct OpenAiSubscriptionSession {
     inner: OpenAIResponsesSession,
     context_window: Option<u64>,
-    model: String,
     authentication_binding: String,
 }
 
@@ -314,7 +312,7 @@ impl ModelSession for OpenAiSubscriptionSession {
         mut request: TurnRequest,
         cancellation: Option<agentkit_core::TurnCancellation>,
     ) -> Result<Self::Turn, LoopError> {
-        migrate_legacy_continuations(&mut request, &self.model, &self.authentication_binding)?;
+        migrate_legacy_continuations(&mut request, &self.authentication_binding)?;
         let normalization_cancellation = cancellation.clone();
         let request = tokio::task::spawn_blocking(move || {
             normalize_openai_images(request, normalization_cancellation.as_ref())
@@ -712,7 +710,6 @@ fn legacy_continuation_matches_authentication(
 
 fn migrate_legacy_continuations(
     request: &mut TurnRequest,
-    model: &str,
     authentication_binding: &str,
 ) -> Result<(), LoopError> {
     let session_id = request.session_id.to_string();
@@ -723,10 +720,8 @@ fn migrate_legacy_continuations(
             else {
                 continue;
             };
-            discard_incompatible_continuations(metadata, model, &session_id);
             migrate_legacy_continuation(
                 metadata,
-                model,
                 &session_id,
                 authentication_binding,
                 expected_kind,
@@ -746,30 +741,8 @@ fn continuation_metadata_mut(part: &mut Part) -> Option<(&mut MetadataMap, &'sta
     }
 }
 
-fn discard_incompatible_continuations(metadata: &mut MetadataMap, model: &str, session_id: &str) {
-    for key in [CONTINUATION_METADATA, LEGACY_CONTINUATION_METADATA] {
-        let incompatible = metadata
-            .get(key)
-            .and_then(Value::as_object)
-            .is_some_and(|value| {
-                value
-                    .get("model")
-                    .and_then(Value::as_str)
-                    .is_some_and(|stored| stored != model)
-                    || value
-                        .get("session_id")
-                        .and_then(Value::as_str)
-                        .is_some_and(|stored| stored != session_id)
-            });
-        if incompatible {
-            metadata.remove(key);
-        }
-    }
-}
-
 fn migrate_legacy_continuation(
     metadata: &mut MetadataMap,
-    model: &str,
     session_id: &str,
     authentication_binding: &str,
     expected_kind: &str,
@@ -789,7 +762,6 @@ fn migrate_legacy_continuation(
     if object.len() != expected_len
         || object.get("schema_version").and_then(Value::as_u64) != Some(1)
         || object.get("kind").and_then(Value::as_str) != Some(expected_kind)
-        || object.get("model").and_then(Value::as_str) != Some(model)
         || object.get("session_id").and_then(Value::as_str) != Some(session_id)
         || object.get("output_index").and_then(Value::as_u64).is_none()
     {
@@ -797,6 +769,7 @@ fn migrate_legacy_continuation(
             "legacy Responses continuation metadata binding is invalid",
         ));
     }
+    let model = bounded_legacy_string(object.get("model"), "legacy model")?;
     let account_binding = object
         .get("account_binding")
         .and_then(Value::as_object)
@@ -1174,36 +1147,6 @@ mod tests {
     }
 
     #[test]
-    fn discards_continuations_bound_to_another_model_or_session() {
-        for continuation in [
-            json!({"model": "gpt-6-astra", "session_id": "session-1"}),
-            json!({"model": "gpt-5.6-sol", "session_id": "session-2"}),
-        ] {
-            let mut metadata = MetadataMap::from([
-                (CONTINUATION_METADATA.into(), continuation.clone()),
-                (LEGACY_CONTINUATION_METADATA.into(), continuation),
-                ("other".into(), json!(true)),
-            ]);
-
-            discard_incompatible_continuations(&mut metadata, "gpt-5.6-sol", "session-1");
-
-            assert!(!metadata.contains_key(CONTINUATION_METADATA));
-            assert!(!metadata.contains_key(LEGACY_CONTINUATION_METADATA));
-            assert_eq!(metadata["other"], json!(true));
-        }
-
-        let matching = json!({"model": "gpt-5.6-sol", "session_id": "session-1"});
-        let mut metadata = MetadataMap::from([(CONTINUATION_METADATA.into(), matching.clone())]);
-        discard_incompatible_continuations(&mut metadata, "gpt-5.6-sol", "session-1");
-        assert_eq!(metadata[CONTINUATION_METADATA], matching);
-
-        let malformed = json!({"model": 7, "session_id": null});
-        let mut metadata = MetadataMap::from([(CONTINUATION_METADATA.into(), malformed.clone())]);
-        discard_incompatible_continuations(&mut metadata, "gpt-5.6-sol", "session-1");
-        assert_eq!(metadata[CONTINUATION_METADATA], malformed);
-    }
-
-    #[test]
     fn migrates_legacy_continuation_before_agentkit_encoding() {
         let digest = "a".repeat(64);
         let binding = format!("openai-chatgpt-v1:{digest}:generation-1");
@@ -1220,17 +1163,30 @@ mod tests {
             "output_index": 0,
             "kind": "function_call",
         });
+        for (field, value) in [
+            ("model", json!(null)),
+            ("model", json!("")),
+            ("session_id", json!("other-session")),
+        ] {
+            let mut malformed = legacy.clone();
+            malformed[field] = value;
+            let mut metadata =
+                MetadataMap::from([(LEGACY_CONTINUATION_METADATA.into(), malformed)]);
+            assert!(
+                migrate_legacy_continuation(
+                    &mut metadata,
+                    "session-1",
+                    &binding,
+                    "function_call",
+                    false,
+                )
+                .is_err()
+            );
+        }
         let mut metadata = MetadataMap::from([(LEGACY_CONTINUATION_METADATA.into(), legacy)]);
 
-        migrate_legacy_continuation(
-            &mut metadata,
-            "gpt-5.4",
-            "session-1",
-            &binding,
-            "function_call",
-            false,
-        )
-        .unwrap();
+        migrate_legacy_continuation(&mut metadata, "session-1", &binding, "function_call", false)
+            .unwrap();
 
         assert!(!metadata.contains_key(LEGACY_CONTINUATION_METADATA));
         assert_eq!(metadata[CONTINUATION_METADATA]["schema_version"], 3);
@@ -1239,6 +1195,7 @@ mod tests {
             binding
         );
         assert_eq!(metadata[CONTINUATION_METADATA]["item_id"], "item-1");
+        assert_eq!(metadata[CONTINUATION_METADATA]["model"], "gpt-5.4");
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1109,6 +1109,7 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                 }
             };
             refresh_config_state(&mut app, Some(&config_options));
+            let mut saved_model_default = current_model_choice(Some(&config_options));
             if let Ok(mut active) = transition_session.lock() {
                 active.id = active_session_id.clone();
             }
@@ -1199,13 +1200,26 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                         .block_task()
                                         .await?;
                                     session_id = session.session_id;
+                                    let config_options = if let Some(choice) = &saved_model_default {
+                                        connection
+                                            .send_request(SetSessionConfigOptionRequest::new(
+                                                session_id.clone(),
+                                                MODEL_CONFIG_ID,
+                                                choice.id.as_str(),
+                                            ))
+                                            .block_task()
+                                            .await?
+                                            .config_options
+                                    } else {
+                                        session.config_options
+                                    };
                                     let persisted_id = durable_session_id(&session_id).map_err(|error| {
                                         agent_client_protocol::Error::into_internal_error(std::io::Error::other(error))
                                     })?;
                                     transition_route(&transition_session, persisted_id.clone());
                                     images.clear();
                                     app.start_session(persisted_id);
-                                    refresh_config_state(&mut app, Some(&session.config_options));
+                                    refresh_config_state(&mut app, Some(&config_options));
                                     if let Some(prompt) = first_prompt {
                                         let outcome = connection
                                             .send_request(wire::PromptRequest::new(
@@ -1385,7 +1399,10 @@ pub async fn run_with_reasoning_effort_and_openrouter_key(
                                             app.note(format!("model changed to {} via {}", choice.model, choice.provider));
                                             if save_defaults {
                                                 match save_model_defaults(&choice) {
-                                                    Ok(()) => app.note("saved model defaults to ~/.kit/config.toml"),
+                                                    Ok(()) => {
+                                                        saved_model_default = Some(choice.clone());
+                                                        app.note("saved model defaults to ~/.kit/config.toml");
+                                                    }
                                                     Err(error) => app.note(format!("model changed, but defaults were not saved: {error}")),
                                                 }
                                             }


### PR DESCRIPTION
## Summary

Keep a model saved as the default active for new sessions created by the running TUI. Upgrade `agentkit-provider-openai` to `0.10.8` so OpenAI sessions can replay continuation state across model changes without discarding encrypted reasoning or provider item IDs.

## Motivation

The ACP backend snapshots its startup model, so creating another session after saving a new default could revert to the previous model until Kit restarted. Separately, exact model-binding validation rejected cross-model continuation locally even though the ChatGPT API accepts it for the model boundaries exercised.

## Technical details

### Saved model defaults

Track the saved model choice in the running TUI and apply it to newly created sessions before submitting their first prompt.

### Cross-model continuation

Use the provider fix released from [AgentKit #19](https://github.com/danielkov/agentkit/pull/19), replacing this PR's continuation-discard workaround. Legacy continuation migration no longer compares the originating model with the active model; it preserves the originating model as bounded, non-empty provenance while retaining schema, session, item-kind, and authentication validation. The dependency update is limited to `agentkit-provider-openai` and its lockfile entry.
