### PR TITLE
chore(deps): update A2A, MCP, and supporting crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "a2a-protocol-client"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02930993bf289383cd0939aef809a6b1a09e680dcc2ea40dbe4d364db56437c3"
+checksum = "3846e4fc2d44959059b93dc0d7807ae9700ac2419f0b22fe202a38514e268adb"
 dependencies = [
  "a2a-protocol-types",
  "base64 0.22.1",
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "a2a-protocol-server"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7fd6f1c3f8f8d57eb32acf7ccaac1bad7db361ca9d5a3f84b4d84f362dbed3"
+checksum = "ca3bd9cd4d971d9e0a767639d9fa844a1d4e082c152021e83b8939be66552995"
 dependencies = [
  "a2a-protocol-types",
  "bytes",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "a2a-protocol-types"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceb66392420388f11dcc604ee556d868baf567a1578c0fe18a55814b27f8944e"
+checksum = "a0b0da2749580c8e52f78e2efa852fb61844ec39bff7ea8fb80439a5a17c1a96"
 dependencies = [
  "serde",
  "serde_json",
@@ -2521,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.52.0"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee5867390f14ee43278d8d05d3af5f5314eeccb4684e6049033f2ba4ae3d4ae"
+checksum = "93e842fa72fd1e50ca4676a527641c13f5ee0d423ac699bfe1cd2afa3a4fdbac"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2550,18 +2550,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.52.0"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7bbc0f53dcb425cf3bae539be26b406b7053e6995e34e4b04477091e600044"
+checksum = "f5d90ea83fa606c96f0b4737ecedf1fa6b624272022edc42039565f8d8af0b78"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.52.0"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3e24abcd5f7eff512eb6bb915ac67772f2e7142ae5b5ac67b4ac75bd417d46"
+checksum = "da4ab4cbe58181a117d8c3582844ce20b07184319b51ba6d756596c1c451aebc"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2569,6 +2569,7 @@ dependencies = [
  "num-cmp",
  "num-traits",
  "serde_json",
+ "zmij",
 ]
 
 [[package]]
@@ -2602,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "4.1.6"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72585bb6cc9bc370d1d545b7e23fcce71dfd4461c5e15275e3cf51bdfd9a980a"
+checksum = "2270074a3d26bcac93c1dc5d2845eb4c089e8d761ccf6e0ea266a16004640627"
 dependencies = [
  "apple-native-keyring-store",
  "keyring-core",
@@ -3659,9 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-image"
-version = "11.0.6"
+version = "11.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000b7a22eae639460bc6ec8bb1cc689ecae5b0ed21935cd7d7dd52d38270c86"
+checksum = "399baa06251282b0c1bbb5762848cf98a6b7b84f44af7f0daf3213ace16df4f0"
 dependencies = [
  "base64-simd",
  "icy_sixel",
@@ -3725,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.52.0"
+version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6326ce79629af4702ac033666390011ccc70fe82ffedd62824d061f133bd10b"
+checksum = "d38a014525040cdc9893361b7419bcf1f43b7ba7055eabaf6d91d6b75caa8b3f"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3827,9 +3828,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -4753,9 +4754,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ rust-version = "1.94.0"
 publish = false
 
 [dependencies]
-a2a-protocol-client = "=0.10.0"
-a2a-protocol-server = { version = "=0.10.0", default-features = false }
-a2a-protocol-types = "=0.10.0"
+a2a-protocol-client = "=0.11.0"
+a2a-protocol-server = { version = "=0.11.0", default-features = false }
+a2a-protocol-types = "=0.11.0"
 agent-client-protocol = { version = "=2.0.0", features = ["unstable_session_fork", "unstable_session_inject"] }
 agent-client-protocol-schema = { git = "https://github.com/danielkov/agent-client-protocol", rev = "6e7e044f9464c4fd652d90699a09e9edc8b3bbad", features = ["unstable_session_notices"] }
 agent-client-protocol-http = { version = "=2.0.0", default-features = false, features = ["server"] }
@@ -43,16 +43,16 @@ hyper = "=1.11.1"
 hyper-util = { version = "=0.1.20", features = ["server", "http1", "http2", "tokio"] }
 image = { version = "=0.25.10", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
 jsonwebtoken = { version = "=11.0.0", default-features = false, features = ["aws_lc_rs"] }
-keyring = { version = "=4.1.6", default-features = false, features = ["v1"] }
-jsonschema = { version = "=0.52.0", default-features = false, features = ["idna"] }
+keyring = { version = "=4.2.0", default-features = false, features = ["v1"] }
+jsonschema = { version = "=0.52.1", default-features = false, features = ["idna"] }
 neo_frizbee = "=0.11.0"
 opentelemetry = { version = "=0.32.0", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "=0.32.0", default-features = false, features = ["grpc-tonic", "http-proto", "http-json", "reqwest-client", "tls-webpki-roots", "trace"] }
 opentelemetry_sdk = { version = "=0.32.1", default-features = false, features = ["experimental_trace_batch_span_processor_with_async_runtime", "rt-tokio", "trace"] }
 ratatui = { version = "=0.30.2", default-features = false, features = ["crossterm", "layout-cache"] }
-ratatui-image = { version = "=11.0.6", default-features = false, features = ["crossterm"] }
+ratatui-image = { version = "=11.0.8", default-features = false, features = ["crossterm"] }
 reqwest = { version = "=0.13.4", default-features = false, features = ["blocking", "form", "rustls", "stream"] }
-rmcp = { version = "=3.1.4", default-features = false, features = ["auth", "client"] }
+rmcp = { version = "=3.2.0", default-features = false, features = ["auth", "client"] }
 runlet = "=0.5.0"
 serde = { version = "=1.0.229", features = ["derive"] }
 serde_json = "=1.0.151"
@@ -60,7 +60,7 @@ shlex = "=2.0.1"
 sha2 = "=0.11.0"
 subtle = "=2.6.1"
 tar = { version = "=0.4.46", default-features = false }
-toml = "=1.1.4"
+toml = "=1.1.5"
 tokio = { version = "=1.53.1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "=0.7.19", features = ["compat"] }
 tower = { version = "=0.5.3", features = ["util"] }


### PR DESCRIPTION
## Summary

Update the exact dependency pins for A2A, MCP, JSON Schema validation, keyring, terminal images, and TOML. This brings in fractional `multipleOf` validation fixes, terminal-image detection and Sixel rendering fixes, and MCP HTTP transport improvements.

## Impact

- RMCP now defaults to 16 concurrent ordinary HTTP POSTs, with a separate control slot and 5-second control/session-recovery timeouts. Cancellation, ordering, recovery, and discovery behavior also change.
- Terminal-detection fallback can enable images where Kit previously fell back to text.
- A2A 0.11 changes REST/gRPC error mappings and push-webhook content type; Kit's current JSON-RPC transport path is unaffected.

## Technical details

| Dependency | Update |
| --- | --- |
| `a2a-protocol-client`, `a2a-protocol-server`, `a2a-protocol-types` | 0.10.0 → 0.11.0 |
| `jsonschema` | 0.52.0 → 0.52.1 |
| `keyring` | 4.1.6 → 4.2.0 |
| `ratatui-image` | 11.0.6 → 11.0.8 |
| `rmcp` | 3.1.4 → 3.2.0 |
| `toml` | 1.1.4 → 1.1.5, retaining spec-1.1.0 |

The lockfile also updates the required `jsonschema-regex`, `jsonschema-value`, and `referencing` companions to 0.52.1. The new `jsonschema-value` dependency on `zmij` reuses its existing locked version.

Preserve all existing feature selections and leave upstream-constrained `generic-array`, `matchit`, `smallvec`, and the `thiserror` family unchanged. Exclude unrelated Windows dependency deduplication from the lockfile.