### PR TITLE
fix: improve release announcement formatting and diagnostics

### DIFF
--- a/.agents/skills/announce-kit-release/SKILL.md
+++ b/.agents/skills/announce-kit-release/SKILL.md
@@ -8,31 +8,32 @@ description: Use when asked to summarize the current Kit release against the pre
 1. Confirm the current checkout, latest release tag, and immediately preceding release tag. Fail if the current revision is not the release being announced or if either comparison tag is missing.
 2. Inspect the commit subjects, changed files, user documentation, and release-range diff between the two tags. Use these only as evidence; do not put raw commits, hashes, file lists, diff statistics, or implementation details in the announcement.
 3. Translate the changes into concise customer outcomes. Group related work into a short list, lead with the release version, and mention compatibility or performance fixes only when they affect users. Do not use emojis.
-4. Include mise installation instructions in fenced `shell` code blocks. The opening fence, command text, and closing fence must be on separate lines. Never put a command on the opening-fence line or put the closing fence after a command. Use this exact payload shape:
+4. Format the payload as Slack `mrkdwn`, not GitHub Markdown. Use single asterisks for bold titles (`*What's new*`), not `**bold**` or `#` headings. If using Block Kit sections, set their text type to `mrkdwn`, not `plain_text`. Include mise installation instructions in plain triple-backtick code blocks with no language label: Slack displays labels such as `shell` as literal code rather than syntax highlighting. The opening fence, command text, and closing fence must be on separate lines. Never put a command on the opening-fence line or put the closing fence after a command. Use this exact payload shape:
 
-   ````markdown
-   ```shell
+   ````text
+   *Install or upgrade with mise*
+   ```
    mise use -g github:speakeasy-api/kit
    kit --version
    ```
 
-   To pin this version:
+   *To pin this version:*
 
-   ```shell
+   ```
    mise use -g github:speakeasy-api/kit@<version-without-v-prefix>
    ```
    ````
 
 5. Use the Slack channel ID from `SLACK_CHANNEL_ID` in the environment, or an explicit channel ID supplied in the task. Pass this ID directly to Slack tools; do not search, list, or resolve channels by name. The configured ID remains valid if the channel is renamed. If no channel ID is supplied, stop and ask for one rather than guessing a destination.
-6. Before sending or drafting, inspect the exact Slack payload. Every opening ` ```shell` fence must end immediately with a newline, every closing ` ``` ` fence must be on its own line, and prose or links must appear only after a closing fence. Reject payloads such as ` ```shell command` or `command``` `.
+6. Before sending or drafting, inspect the exact Slack payload. The release title and section titles must use Slack's single-asterisk bold syntax. Every opening and closing triple-backtick fence must be on its own line with no language label; the first line inside each code block must be an installation or verification command, not `shell` or `bash`. Prose or links must appear only after a closing fence. Reject language-tagged fences, commands on fence lines, and unclosed blocks.
 7. If the user explicitly asked to post, send the announcement directly. Otherwise, create a draft for review. Post only to the supplied channel ID; fail if it is invalid or inaccessible, and never substitute another destination.
-8. Read the sent message back from Slack and verify that the install commands did not absorb later prose or links. For a restricted bot explicitly known to lack history access, instead inspect the actual message returned in Slack's successful send response: verify the channel matches the supplied channel ID, a message timestamp is present, and the returned text has correct formatting. This verifies the send response, not a later history read. A bare success acknowledgement or the original outgoing payload is not sufficient; fail if the response lacks the posted message. If the message is malformed, replace or delete it when Slack tools allow that; otherwise post one corrected copy and report that the malformed message requires manual deletion.
+8. Read the sent message back from Slack and verify that the install commands did not absorb later prose or links. For a restricted bot explicitly known to lack history access, instead inspect the actual message returned in Slack's successful send response: verify the channel matches the supplied channel ID, a message timestamp is present, and the returned text preserves the bold title markers and unlabeled, correctly delimited code blocks. This verifies the send response, not a later history read. A bare success acknowledgement or the original outgoing payload is not sufficient; fail if the response lacks the posted message. If the message is malformed, replace or delete it when Slack tools allow that; otherwise post one corrected copy and report that the malformed message requires manual deletion.
 9. For a sent announcement, retrieve its permalink through Slack tools using the verified channel and message timestamp. Return the Slack message or draft link.
 
 ## Announcement shape
 
-- Heading: `Kit <version> is available`
+- Heading: `*Kit <version> is available*`
 - One sentence describing the overall customer benefit.
-- `What's new` with three to six outcome-focused bullets.
-- `Install or upgrade with mise` with the install, verification, and pinned-version commands.
+- `*What's new*` with three to six outcome-focused bullets.
+- `*Install or upgrade with mise*` with the install and verification commands in an unlabeled code block, then `*To pin this version:*` with the pinned-version command in a separate unlabeled code block.
 - No emojis, raw commits, hashes, diff statistics, or internal implementation notes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -647,8 +647,12 @@ jobs:
           announcement=$(sed '$ { /^session_id: /d; }' "$mcp_dir/output.txt")
           if (( kit_status != 0 )) || [[ ! $announcement =~ ^https://[a-zA-Z0-9-]+\.slack\.com/archives/${SLACK_CHANNEL_ID}/p[0-9]+$ ]]; then
             echo "::error::Kit did not confirm a posted and verified Slack announcement with a permalink (CLI exit code: $kit_status)."
-            # Bound diagnostics and prefix lines so model output is not a workflow command.
+            # Disable both modern and legacy workflow commands in model-controlled output.
+            command_token=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
+            printf '::stop-commands::%s\n' "$command_token"
             head -c 8192 <<< "$announcement" | sed 's/^/Kit: /'
+            # Truncation can remove the last newline; resume on a separate line.
+            printf '\n::%s::\n' "$command_token"
             exit 1
           fi
           printf 'Slack release announcement: %s\n' "$announcement" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -635,17 +635,20 @@ jobs:
           prompt="Use the announce-kit-release skill to post release notes for ${PREVIOUS_TAG}..${RELEASE_TAG} to Slack channel ID ${SLACK_CHANNEL_ID}, supplied by the SLACK_CHANNEL_ID environment variable. The checkout is the published release.
           Load the skill with the skill tool, discover the configured slack MCP tools with tool_search, and use only those MCP tools for Slack operations. Do not use shell, curl, or a direct Slack API client as a fallback. Use the supplied channel ID directly; do not search, list, or resolve channels by name.
           This is a noninteractive release smoke test: post directly, do not draft or request confirmation. The bot can post messages but has no channel-history access. Use the skill's restricted-bot verification: inspect the actual message returned by the successful send response, verify its channel matches ${SLACK_CHANNEL_ID}, timestamp and formatting, then retrieve its permalink through MCP. Do not call history tools or message search.
-          Do not expose credentials or read the MCP config. If any step fails, report failure and do not return a success link. Only after successful posting and verification, respond with just the Slack message permalink on its own line."
+          Do not expose credentials or read the MCP config. If any step fails, report the failing step and exact error without credentials, and do not return a success link. Only after successful posting and verification, respond with just the Slack message permalink on its own line."
+          kit_status=0
           release-kit/kit prompt \
             --root "$GITHUB_WORKSPACE" \
             --provider openrouter \
             --model "$RELEASE_NOTES_MODEL" \
             --mcp-config "$SLACK_MCP_CONFIG" \
             "$prompt" \
-            > slack-kit-output.txt
-          announcement=$(sed '$ { /^session_id: /d; }' slack-kit-output.txt)
-          if [[ ! $announcement =~ ^https://[a-zA-Z0-9-]+\.slack\.com/archives/${SLACK_CHANNEL_ID}/p[0-9]+$ ]]; then
-            echo "::error::Kit did not confirm a posted and verified Slack announcement with a permalink."
+            > "$mcp_dir/output.txt" || kit_status=$?
+          announcement=$(sed '$ { /^session_id: /d; }' "$mcp_dir/output.txt")
+          if (( kit_status != 0 )) || [[ ! $announcement =~ ^https://[a-zA-Z0-9-]+\.slack\.com/archives/${SLACK_CHANNEL_ID}/p[0-9]+$ ]]; then
+            echo "::error::Kit did not confirm a posted and verified Slack announcement with a permalink (CLI exit code: $kit_status)."
+            # Bound diagnostics and prefix lines so model output is not a workflow command.
+            head -c 8192 <<< "$announcement" | sed 's/^/Kit: /'
             exit 1
           fi
           printf 'Slack release announcement: %s\n' "$announcement" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -69,13 +69,18 @@ An issuer-gated endpoint that accepts only OAuth user sessions is not sufficient
 
 The MCP must expose posting with the actual posted message in its response and
 permalink retrieval. Invite the bot to the target channel and grant `chat:write`.
+The bot must be a channel member with this scope; MCP authentication and channel
+lookup can succeed even when posting would fail with `not_in_channel`.
 The announcement does not use channel lookup, message search, or channel-history
 tools. The final permalink must refer to the configured channel ID. Use only a trusted MCP endpoint: it
 receives the Gram API key.
 
 The workflow writes a private temporary MCP JSON file with an explicit
 `headers.Authorization` and `headers.Gram-Environment`, passes it via `--mcp-config`, and removes it on
-exit. It does not upload the config or Kit session as an artifact.
+exit. The captured CLI response uses the same temporary directory. On failure,
+the job logs the CLI exit code and up to 8 KiB of its final response (without the
+session ID) to explain which step failed. It does not upload the config or Kit
+session as an artifact.
 
 An announcement failure marks the workflow failed but does not roll back the
 already published release. Before rerunning the announcement job, check Slack:


### PR DESCRIPTION
## Summary

Use Slack-native formatting for release announcements and surface bounded Kit diagnostics when announcement delivery fails.

## Motivation

Slack displays code-fence language labels as literal content, and announcement titles need explicit Slack bold syntax. Delivery failures also hid the CLI response needed to distinguish access failures from skill, discovery, or verification failures.

## Technical details

### Slack formatting

Require single-asterisk bold titles and unlabeled triple-backtick code blocks. Update the skill's payload example and verification rules, and require `mrkdwn` text when using Block Kit sections.

### Failure diagnostics

Preserve the CLI exit status and log up to 8 KiB of its final response on either CLI failure or invalid confirmation. Strip the session ID and suspend workflow-command processing with a fresh unpredictable token while printing diagnostics, preventing both modern and legacy command injection. Prefix lines only for readability and resume command processing on a separate line even when the response is truncated. Keep captured output in the private temporary directory and remove it on exit.

Document that `chat:write` requires bot membership in the configured channel, even when MCP authentication and channel lookup succeed.
