### PR TITLE
fix: explicitly stop turns awaiting background results

### DIFF
--- a/src/provider/adapter.rs
+++ b/src/provider/adapter.rs
@@ -391,7 +391,7 @@ fn expose_background_call_ids(request: &mut TurnRequest) {
             };
             if text.contains(DETACHED) {
                 *text = format!(
-                    "Tool call ID: {} is running in the background.\nNo independent work left? STOP (see system instructions).",
+                    "Tool call ID: {} is running in the background.\nNo independent work left? STOP.",
                     result.call_id
                 );
             }
@@ -1585,7 +1585,7 @@ mod tests {
         };
         assert_eq!(
             text,
-            "Tool call ID: call_background is running in the background.\nNo independent work left? STOP (see system instructions)."
+            "Tool call ID: call_background is running in the background.\nNo independent work left? STOP."
         );
     }
 

--- a/src/provider/adapter.rs
+++ b/src/provider/adapter.rs
@@ -391,7 +391,7 @@ fn expose_background_call_ids(request: &mut TurnRequest) {
             };
             if text.contains(DETACHED) {
                 *text = format!(
-                    "Tool call ID: {} is running in the background.\nIt runs until result or failure is delivered.",
+                    "Tool call ID: {} is running in the background.\nNo independent work left? STOP (see system instructions).",
                     result.call_id
                 );
             }
@@ -1554,7 +1554,7 @@ mod tests {
     }
 
     #[test]
-    fn detached_results_tell_the_model_their_call_id() {
+    fn detached_results_tell_the_model_their_call_id_and_remind_it_to_stop() {
         let mut request = TurnRequest {
             session_id: SessionId::new("session"),
             turn_id: TurnId::new("turn"),
@@ -1585,7 +1585,7 @@ mod tests {
         };
         assert_eq!(
             text,
-            "Tool call ID: call_background is running in the background.\nIt runs until result or failure is delivered."
+            "Tool call ID: call_background is running in the background.\nNo independent work left? STOP (see system instructions)."
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1609,8 +1609,8 @@ impl Runtime {
                 "Parallelize independent work deliberately. Prefer one compose program whenever the remaining tool graph is known: keep intermediate results inside it when they can directly drive downstream work, and return only the bare minimum information necessary to plan the next turn or provide the final answer. ",
                 "Background long-running compose work when it can run across a turn boundary; it also suits one-shot triggers. ",
                 "Set the outer `background` argument to `true` to detach immediately or to a positive integer to wait that many seconds before detaching. ",
-                "After detaching, continue any independent work, including launching more detached work. When no independent work remains and you need background results, STOP: end your turn now with the response `STOP`. ",
-                "`STOP` is a valid intermediate response, not completion or abandonment of the user's task. The harness automatically resumes you with the background result; you do not need to finish the user's answer before ending this turn. ",
+                "After detaching, continue any independent work, including launching more detached work. When no independent work remains and you need background results, STOP: end your turn now. ",
+                "Stopping is a valid intermediate response, not completion or abandonment of the user's task. The harness automatically resumes you with the background result. ",
                 "Do not call tools to wait, sleep, poll for completion, or keep the turn alive. ",
                 "Keep work foregrounded when the next step needs its result in the current turn, and do not treat backgrounding as durable job execution.\n\n",
                 "{}"

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1609,7 +1609,9 @@ impl Runtime {
                 "Parallelize independent work deliberately. Prefer one compose program whenever the remaining tool graph is known: keep intermediate results inside it when they can directly drive downstream work, and return only the bare minimum information necessary to plan the next turn or provide the final answer. ",
                 "Background long-running compose work when it can run across a turn boundary; it also suits one-shot triggers. ",
                 "Set the outer `background` argument to `true` to detach immediately or to a positive integer to wait that many seconds before detaching. ",
-                "After detaching, continue any independent work, including launching more detached work. When the remaining work depends on background results, yield; yielding continues the task with those results, so the user's answer need not be completed first. ",
+                "After detaching, continue any independent work, including launching more detached work. When no independent work remains and you need background results, STOP: end your turn now with the response `STOP`. ",
+                "`STOP` is a valid intermediate response, not completion or abandonment of the user's task. The harness automatically resumes you with the background result; you do not need to finish the user's answer before ending this turn. ",
+                "Do not call tools to wait, sleep, poll for completion, or keep the turn alive. ",
                 "Keep work foregrounded when the next step needs its result in the current turn, and do not treat backgrounding as durable job execution.\n\n",
                 "{}"
             ),

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -2334,10 +2334,14 @@ fn system_prompt_guides_compose_and_subagent_hygiene() {
     assert!(prompt.contains("when it can run across a turn boundary"));
     assert!(prompt.contains("it also suits one-shot triggers"));
     assert!(prompt.contains("including launching more detached work"));
-    assert!(prompt.contains("STOP: end your turn now with the response `STOP`"));
-    assert!(prompt.contains("`STOP` is a valid intermediate response"));
+    assert!(prompt.contains("STOP: end your turn now."));
+    assert!(prompt.contains("Stopping is a valid intermediate response"));
     assert!(prompt.contains("The harness automatically resumes you with the background result"));
-    assert!(prompt.contains("Do not call tools to wait, sleep, poll for completion, or keep the turn alive"));
+    assert!(
+        prompt.contains(
+            "Do not call tools to wait, sleep, poll for completion, or keep the turn alive"
+        )
+    );
     assert!(prompt.contains("the next step needs its result in the current turn"));
     assert!(
         prompt.contains("Prefer one compose program whenever the remaining tool graph is known")

--- a/src/runtime/tests.rs
+++ b/src/runtime/tests.rs
@@ -2334,9 +2334,10 @@ fn system_prompt_guides_compose_and_subagent_hygiene() {
     assert!(prompt.contains("when it can run across a turn boundary"));
     assert!(prompt.contains("it also suits one-shot triggers"));
     assert!(prompt.contains("including launching more detached work"));
-    assert!(prompt.contains("When the remaining work depends on background results, yield"));
-    assert!(prompt.contains("yielding continues the task with those results"));
-    assert!(prompt.contains("the user's answer need not be completed first"));
+    assert!(prompt.contains("STOP: end your turn now with the response `STOP`"));
+    assert!(prompt.contains("`STOP` is a valid intermediate response"));
+    assert!(prompt.contains("The harness automatically resumes you with the background result"));
+    assert!(prompt.contains("Do not call tools to wait, sleep, poll for completion, or keep the turn alive"));
     assert!(prompt.contains("the next step needs its result in the current turn"));
     assert!(
         prompt.contains("Prefer one compose program whenever the remaining tool graph is known")


### PR DESCRIPTION
## Summary
Explicitly instruct the model to stop its turn when background work is pending and no independent work remains, without requiring a literal response. Explain in the system prompt that stopping lets the harness resume with the result rather than completing or abandoning the task, and prohibit tool calls used merely to wait or keep the turn alive.

Replace the background tool-result message’s second sentence with a compact reminder: “No independent work left? STOP.”
