### PR TITLE
ci: separate PR title validation from build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,29 +5,10 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
 
 jobs:
-  pr-title:
-    if: >-
-      github.event_name == 'pull_request' &&
-      (github.event.action != 'edited' || github.event.changes.title != null)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    steps:
-      - name: Validate Conventional Commit title
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        shell: bash
-        run: |
-          pattern='^[a-z][a-z0-9-]*(\([^()]+\))?(!)?: .+'
-          if [[ ! $PR_TITLE =~ $pattern ]]; then
-            echo "Pull request titles must use Conventional Commit syntax." >&2
-            echo "Examples: feat: add a feature, fix(api): correct behavior, feat!: break compatibility" >&2
-            exit 1
-          fi
-
   test:
-    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: useblacksmith/checkout@v1
@@ -41,7 +22,6 @@ jobs:
       - run: cargo test --locked
 
   macos-rust:
-    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     runs-on: blacksmith-6vcpu-macos-15
     steps:
       - uses: useblacksmith/checkout@v1
@@ -65,7 +45,6 @@ jobs:
           retention-days: 1
 
   macos-desktop:
-    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     needs: macos-rust
     runs-on: blacksmith-6vcpu-macos-15
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,13 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
-  test:
+  pr-title:
+    if: >-
+      github.event_name == 'pull_request' &&
+      (github.event.action != 'edited' || github.event.changes.title != null)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Validate Conventional Commit title
-        if: github.event_name == 'pull_request'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         shell: bash
@@ -23,6 +25,11 @@ jobs:
             echo "Examples: feat: add a feature, fix(api): correct behavior, feat!: break compatibility" >&2
             exit 1
           fi
+
+  test:
+    if: github.event_name != 'pull_request' || github.event.action != 'edited'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
       - uses: useblacksmith/checkout@v1
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -34,6 +41,7 @@ jobs:
       - run: cargo test --locked
 
   macos-rust:
+    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     runs-on: blacksmith-6vcpu-macos-15
     steps:
       - uses: useblacksmith/checkout@v1
@@ -57,6 +65,7 @@ jobs:
           retention-days: 1
 
   macos-desktop:
+    if: github.event_name != 'pull_request' || github.event.action != 'edited'
     needs: macos-rust
     runs-on: blacksmith-6vcpu-macos-15
     steps:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,21 @@
+name: pr-title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  pr-title:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Validate Conventional Commit title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        shell: bash
+        run: |
+          pattern='^[a-z][a-z0-9-]*(\([^()]+\))?(!)?: .+'
+          if [[ ! $PR_TITLE =~ $pattern ]]; then
+            echo "Pull request titles must use Conventional Commit syntax." >&2
+            echo "Examples: feat: add a feature, fix(api): correct behavior, feat!: break compatibility" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
Move Conventional Commit title validation into a lightweight, checkout-free workflow. Build CI no longer subscribes to PR edits, so title and description updates do not rerun Rust or macOS builds.

## Impact
Repository branch rules must require `pr-title` separately if title validation should block merging.

## Technical details
Separate workflow triggers prevent metadata edits from publishing skipped replacements for required build checks. Title validation runs on every PR edit, including body-only edits, as well as open, reopen, and synchronize events, so an invalid title cannot be bypassed with a description update.
