### PR TITLE
fix(tui): use full-height prompt marker

### DIFF
--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -47,7 +47,7 @@ type TranscriptTag = (Option<String>, Option<CodeHit>, Option<usize>);
 type TaggedTranscriptLine = (LinkedLine, TranscriptTag);
 
 pub fn draw(frame: &mut Frame<'_>, app: &mut App, images: &mut ImageRuntime) {
-    // Two border columns plus the `›` gutter; the prompt grows as the wrapped
+    // Two border columns plus the `>` gutter; the prompt grows as the wrapped
     // text needs more rows, up to the cap.
     let start_width = frame
         .area()
@@ -2026,7 +2026,7 @@ fn draw_prompt_editor(
     let [gutter, field] =
         Layout::horizontal([Constraint::Length(2), Constraint::Min(1)]).areas(area);
     frame.render_widget(
-        Paragraph::new(Span::styled("›", theme::bold(theme::accent_color()))),
+        Paragraph::new(Span::styled(">", theme::bold(theme::accent_color()))),
         gutter,
     );
 
@@ -4467,7 +4467,7 @@ mod tests {
         let rows = frame.lines().collect::<Vec<_>>();
         let input = rows
             .iter()
-            .position(|row| row.starts_with("│› message kit…"))
+            .position(|row| row.starts_with("│> message kit…"))
             .expect("prompt input");
 
         assert!(rows[input - 1].starts_with('╭'));
@@ -4494,6 +4494,6 @@ mod tests {
         assert!(frame.lines().any(|line| line.trim() == "▔".repeat(86)));
         assert!(frame.contains(" ready"));
         assert!(frame.contains("⏎ send   ⇧⏎ newline   ^l log   ^c quit"));
-        assert!(frame.contains("message kit"));
+        assert!(frame.contains("> message kit…"));
     }
 }


### PR DESCRIPTION
## Summary
- replace the short Unicode `›` composer marker with a full-height ASCII `>`
- keep the existing one-cell gutter padding beside the marker
- assert the marker in both the initial welcome composer and the compact post-message composer

The larger first-message card does not need a stretched or repeated marker: its extra rows are reserved for the provider/model metadata and spacing. The marker is rendered only in the editable row, so it stays aligned with the input text in both layouts.

## Automated tests
- `cargo fmt --check`
- `cargo test -q tui::ui::tests`

## Manual test
1. Run `cargo run -- tui --root /path/to/a/test/project` from this branch.
2. On the welcome screen, confirm the `>` matches the input text's line height, has a space before `message kit…`, and does not extend into the metadata row.
3. Send a message, then confirm the compact composer uses the same full-height `>` with the rounded border providing vertical padding.
4. Enter a long or multiline prompt and confirm wrapping, cursor movement, and the marker's alignment with the first visible input row still work.
