### PR TITLE
feat(acp): support client-supplied session MCP servers

### DIFF
--- a/docs/user/getting-started-and-configuration.md
+++ b/docs/user/getting-started-and-configuration.md
@@ -136,7 +136,7 @@ kit serve --root /path/to/project --http 127.0.0.1:7331
 kit serve --remote-acp --no-a2a --no-stdio --http 0.0.0.0:8081 # daemon
 ```
 
-Without `--a2a` (or its `--http` alias), `serve` binds an available loopback port. Remote ACP v1 and v2 negotiate on the standard `/acp` endpoint; `/acp/v2` is an explicit v2-only alias. Both routes use the same HTTP listener, bearer-token policy, and HTTP/SSE or WebSocket transports. The `kit serve` stdio connection remains ACP v1. Stdout remains reserved for ACP, so local stdio and remote ACP can run together. Add `--no-stdio` for a foreground daemon that does not depend on stdin; this option requires `--remote-acp`. SIGINT and, on Unix, SIGTERM stop accepts, interrupt active ACP sessions, and allow about five seconds for concurrent cleanup before remaining session actors are aborted.
+Without `--a2a` (or its `--http` alias), `serve` binds an available loopback port. Remote ACP v1 and v2 negotiate on the standard `/acp` endpoint; `/acp/v2` is an explicit v2-only alias. Both routes use the same HTTP listener, bearer-token policy, and HTTP/SSE or WebSocket transports. The `kit serve` stdio connection defaults to ACP v1; the hidden `--stdio-protocol-version 2` flag selects v2 for that connection only. Stdout remains reserved for ACP, so local stdio and remote ACP can run together. Add `--no-stdio` for a foreground daemon that does not depend on stdin; this option requires `--remote-acp`. SIGINT and, on Unix, SIGTERM stop accepts, interrupt active ACP sessions, and allow about five seconds for concurrent cleanup before remaining session actors are aborted.
 
 Add `--server-credential-file /private/token` to require the file's single bearer token for every request on the HTTP listener. A non-loopback daemon must not be exposed without authentication and suitable network controls. Use `kit acp` when the host needs only ACP on stdio and no HTTP listener. Select the wire version explicitly with `--protocol-version 1|2`; omitting it defaults to ACP v1:
 
@@ -144,6 +144,8 @@ Add `--server-credential-file /private/token` to require the file's single beare
 kit acp --root /path/to/project --protocol-version 1
 kit acp --root /path/to/project --protocol-version 2
 ```
+
+ACP clients can supply additional stdio MCP servers per session: use `mcpServers` on v1 `session/new`, `session/load`, or `session/fork`, or on v2 `session/new` or `session/resume`. V2 stdio entries require `type: "stdio"`. These servers are attachment-scoped, preserve configured servers, and must be supplied again when reattaching; Kit does not persist their launch configuration.
 
 ## Configure `~/.kit/config.toml`
 

--- a/src/protocols/acp.rs
+++ b/src/protocols/acp.rs
@@ -943,6 +943,12 @@ async fn logout_authentication(
     }
 }
 
+struct SessionSetup {
+    cwd: PathBuf,
+    additional_directories: Vec<PathBuf>,
+    mcp_servers: Vec<agentkit_acp::McpServer>,
+}
+
 struct AttachedSession<C> {
     session_id: agentkit_acp::SessionId,
     config_options: Vec<SessionConfigOption>,
@@ -1256,8 +1262,11 @@ impl Server {
         let claim = self.runtime.claim_session()?;
         let attached = self
             .attach_session(
-                request.cwd,
-                request.additional_directories,
+                SessionSetup {
+                    cwd: request.cwd,
+                    additional_directories: request.additional_directories,
+                    mcp_servers: request.mcp_servers,
+                },
                 connection,
                 claim,
                 None,
@@ -1328,8 +1337,11 @@ impl Server {
             .claim_session_load(&request.session_id.to_string())?;
         let attached = self
             .attach_session(
-                request.cwd,
-                request.additional_directories,
+                SessionSetup {
+                    cwd: request.cwd,
+                    additional_directories: request.additional_directories,
+                    mcp_servers: request.mcp_servers,
+                },
                 connection,
                 claim,
                 None,
@@ -1349,11 +1361,6 @@ impl Server {
         request: ForkSessionRequest,
         connection: ConnectionTo<Client>,
     ) -> Result<PreparedFork, AcpRuntimeError> {
-        if !request.mcp_servers.is_empty() {
-            return Err(AcpRuntimeError::Loop(
-                "Kit does not accept per-session MCP servers".into(),
-            ));
-        }
         let parent_context = fork_parent_context(request.meta.as_ref());
         let sender = self.sender(&request.session_id).await?;
         let (tx, rx) = oneshot::channel();
@@ -1370,8 +1377,11 @@ impl Server {
         let claim = self.runtime.claim_session_fork()?;
         let attached = self
             .attach_session(
-                request.cwd,
-                request.additional_directories,
+                SessionSetup {
+                    cwd: request.cwd,
+                    additional_directories: request.additional_directories,
+                    mcp_servers: request.mcp_servers,
+                },
                 connection,
                 claim,
                 Some(forked),
@@ -1388,13 +1398,17 @@ impl Server {
 
     async fn attach_session<C>(
         self: &Arc<Self>,
-        cwd: PathBuf,
-        additional_directories: Vec<PathBuf>,
+        setup: SessionSetup,
         connection: ConnectionTo<Client>,
         mut claim: crate::runtime::SessionClaim,
         forked: Option<AcpForkState>,
         commit: impl FnOnce(crate::runtime::SessionClaim) -> Result<C, AcpRuntimeError> + Send,
     ) -> Result<AttachedSession<C>, AcpRuntimeError> {
+        let SessionSetup {
+            cwd,
+            additional_directories,
+            mcp_servers,
+        } = setup;
         // Validate path serialization before admission or any binding/actor effects.
         let cwd_metadata =
             serde_json::to_value(&cwd).map_err(|error| AcpRuntimeError::Sdk(error.to_string()))?;
@@ -1410,7 +1424,16 @@ impl Server {
         // the same id and any bind failure releases the selection or reservation.
         let session_id = agentkit_acp::SessionId::new(claim.id());
         let agentkit_session_id = AgentkitSessionId::new(claim.id());
-        let mcp_events = self.runtime.subscribe_mcp(session_id.to_string())?;
+        if !additional_directories.is_empty() {
+            return Err(AcpRuntimeError::Loop(
+                "this Kit runtime does not accept additional directories".into(),
+            ));
+        }
+        // Client overlays own their manager, catalog, reload state, and event routes.
+        let mcp = self.runtime.session_mcp(mcp_servers, &cwd).await?;
+        let mcp_events = mcp
+            .subscribe(session_id.to_string())
+            .map_err(AcpRuntimeError::Loop)?;
         if crate::resilient_fs::shutdown_token().is_cancelled() {
             return Err(AcpRuntimeError::ClientClosed);
         }
@@ -1457,7 +1480,7 @@ impl Server {
         };
         let driver = match self
             .runtime
-            .start_acp_driver_with_initial(context, &mut claim, forked)
+            .start_acp_driver_with_mcp(context, &mut claim, forked, mcp)
             .await
         {
             Ok(driver) => driver,
@@ -6326,6 +6349,116 @@ pub(super) mod tests {
                 delivery == "success"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn client_mcp_servers_are_honored_by_new_load_and_fork() {
+        use agentkit_acp::{McpServer, McpServerHttp, McpServerStdio};
+
+        let root = tempfile::tempdir().unwrap();
+        let credentials = crate::credentials::CredentialStorage::Memory;
+        crate::provider::store_openrouter_test_credentials(&credentials);
+        let runtime = Runtime::new_with_provider_and_credentials(
+            root.path(),
+            "test-model",
+            crate::ProviderKind::OpenRouter,
+            credentials,
+        )
+        .unwrap();
+        let (client_transport, agent_transport) = Channel::duplex();
+        let server = tokio::spawn(serve_transport(runtime, agent_transport));
+        agent_client_protocol::Client
+            .builder()
+            .on_receive_notification(
+                async move |_notification: SessionNotification, _cx| Ok(()),
+                agent_client_protocol::on_receive_notification!(),
+            )
+            .connect_with(client_transport, async move |connection| {
+                let unsupported = vec![McpServer::Http(McpServerHttp::new(
+                    "kithub",
+                    "https://example.invalid/mcp",
+                ))];
+                // Missing executables remain discoverable connection failures; they
+                // must not prevent attachment or leak into another session.
+                let stdio = vec![McpServer::Stdio(McpServerStdio::new(
+                    "kithub",
+                    root.path().join("missing-bridge"),
+                ))];
+                connection
+                    .send_request(
+                        NewSessionRequest::new(root.path().to_path_buf())
+                            .mcp_servers(unsupported.clone()),
+                    )
+                    .block_task()
+                    .await
+                    .expect_err("new must validate client MCP servers");
+                let source = connection
+                    .send_request(
+                        NewSessionRequest::new(root.path().to_path_buf())
+                            .mcp_servers(stdio.clone()),
+                    )
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(
+                        ForkSessionRequest::new(
+                            source.session_id.clone(),
+                            root.path().to_path_buf(),
+                        )
+                        .mcp_servers(unsupported.clone()),
+                    )
+                    .block_task()
+                    .await
+                    .expect_err("fork must validate client MCP servers");
+                let fork = connection
+                    .send_request(
+                        ForkSessionRequest::new(
+                            source.session_id.clone(),
+                            root.path().to_path_buf(),
+                        )
+                        .mcp_servers(stdio.clone()),
+                    )
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(CloseSessionRequest::new(fork.session_id))
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(CloseSessionRequest::new(source.session_id.clone()))
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(
+                        LoadSessionRequest::new(
+                            source.session_id.clone(),
+                            root.path().to_path_buf(),
+                        )
+                        .mcp_servers(unsupported),
+                    )
+                    .block_task()
+                    .await
+                    .expect_err("load must validate client MCP servers");
+                connection
+                    .send_request(
+                        LoadSessionRequest::new(
+                            source.session_id.clone(),
+                            root.path().to_path_buf(),
+                        )
+                        .mcp_servers(stdio),
+                    )
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(CloseSessionRequest::new(source.session_id))
+                    .block_task()
+                    .await?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        server.abort();
+        let _ = server.await;
     }
 
     #[tokio::test]

--- a/src/protocols/acp/v2.rs
+++ b/src/protocols/acp/v2.rs
@@ -695,16 +695,19 @@ impl Server {
         &self,
         request: wire::InitializeRequest,
     ) -> Result<wire::InitializeResponse, AcpRuntimeError> {
-        if request.protocol_version < wire::ProtocolVersion::V2 {
-            return Err(AcpRuntimeError::Unsupported(
-                "ACP v2 requires protocol version 2 or newer".into(),
-            ));
-        }
+        // This handler only speaks v2. Initialization must return our supported
+        // version even when the requested version is unsupported; the client
+        // then disconnects if it cannot speak v2. It does not switch wire schemas.
+        let mut capabilities = agentkit_acp::v2::agent_capabilities();
+        capabilities
+            .session
+            .get_or_insert_with(wire::SessionCapabilities::new)
+            .mcp = Some(wire::McpCapabilities::new().stdio(wire::McpStdioCapabilities::new()));
         Ok(wire::InitializeResponse::new(
             wire::ProtocolVersion::V2,
             wire::Implementation::new("kit", env!("CARGO_PKG_VERSION")),
         )
-        .capabilities(agentkit_acp::v2::agent_capabilities())
+        .capabilities(capabilities)
         .auth_methods(if self.runtime.supports_logout_authentication() {
             terminal_auth_methods(&request.capabilities, |provider| {
                 self.runtime.supports_terminal_authentication(provider)
@@ -728,6 +731,7 @@ impl Server {
                     .into_iter()
                     .map(|path| path.0)
                     .collect(),
+                request.mcp_servers,
                 connection,
                 claim,
             )
@@ -787,6 +791,7 @@ impl Server {
                     .into_iter()
                     .map(|path| path.0)
                     .collect(),
+                request.mcp_servers,
                 connection,
                 claim,
             )
@@ -847,6 +852,7 @@ impl Server {
         self: &Arc<Self>,
         cwd: PathBuf,
         additional_directories: Vec<PathBuf>,
+        mcp_servers: Vec<wire::McpServer>,
         connection: V2ConnectionTo<Client>,
         mut claim: crate::runtime::SessionClaim,
     ) -> Result<AttachedSession, AcpRuntimeError> {
@@ -857,7 +863,36 @@ impl Server {
             .begin_attachment()
             .map_err(|()| AcpRuntimeError::ClientClosed)?;
         let session_id = wire::SessionId::new(claim.id());
-        let mcp_events = self.runtime.subscribe_mcp(session_id.to_string())?;
+        if !additional_directories.is_empty() {
+            return Err(AcpRuntimeError::Loop(
+                "this Kit runtime does not accept additional directories".into(),
+            ));
+        }
+        let servers = mcp_servers
+            .into_iter()
+            .map(|server| match server {
+                wire::McpServer::Stdio(server) => Ok(agentkit_acp::McpServer::Stdio(
+                    agentkit_acp::McpServerStdio::new(server.name, server.command.0)
+                        .args(server.args)
+                        .env(
+                            server
+                                .env
+                                .into_iter()
+                                .map(|entry| {
+                                    agentkit_acp::EnvVariable::new(entry.name, entry.value)
+                                })
+                                .collect(),
+                        ),
+                )),
+                _ => Err(AcpRuntimeError::Unsupported(
+                    "client MCP servers support only stdio transport".into(),
+                )),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let mcp = self.runtime.session_mcp(servers, &cwd).await?;
+        let mcp_events = mcp
+            .subscribe(session_id.to_string())
+            .map_err(AcpRuntimeError::Loop)?;
         let cancellation = CancellationController::new();
         let sink = ResponseReplacementSink::new(ConnectionSink(connection));
         let activity = native_activity(session_id.clone(), sink.clone());
@@ -882,7 +917,10 @@ impl Server {
             cancellation: handle.cancellation_handle(),
             response_attempt_replacement: true,
         };
-        let driver = self.runtime.start_acp_driver(context, &mut claim).await?;
+        let driver = self
+            .runtime
+            .start_acp_driver_with_mcp(context, &mut claim, None, mcp)
+            .await?;
         let current = driver.adapter.selection().map_err(AcpRuntimeError::Loop)?;
         let reasoning = driver
             .adapter
@@ -5049,6 +5087,108 @@ mod tests {
             .expect("replacement client failed");
     }
 
+    #[tokio::test]
+    async fn v2_client_mcp_servers_are_honored_by_new_and_resume() {
+        let root = tempfile::tempdir().unwrap();
+        let credentials = crate::credentials::CredentialStorage::Memory;
+        crate::provider::store_openrouter_test_credentials(&credentials);
+        let runtime = Runtime::new_with_provider_and_credentials(
+            root.path(),
+            "test-model",
+            crate::ProviderKind::OpenRouter,
+            credentials,
+        )
+        .unwrap();
+        let (client_transport, agent_transport) = agent_client_protocol::Channel::duplex();
+        let router = v2_router(runtime, SessionRegistry::new());
+        let server = tokio::spawn(async move { router.connect_to(agent_transport).await });
+        let client = agent_client_protocol::Client.v2().connect_with(
+            client_transport,
+            async move |connection| {
+                connection
+                    .send_request(terminal_auth_initialize_request())
+                    .block_task()
+                    .await?;
+                let unsupported = vec![wire::McpServer::Http(wire::McpServerHttp::new(
+                    "kithub",
+                    "https://example.invalid/mcp",
+                ))];
+                // A failed connection remains discoverable; it does not reject attachment.
+                let stdio = vec![wire::McpServer::Stdio(
+                    wire::McpServerStdio::new("kithub", root.path().join("missing-bridge"))
+                        .args(vec!["--bridge".into()])
+                        .env(vec![wire::EnvVariable::new("KIT_TEST", "value")]),
+                )];
+                let error = connection
+                    .send_request(
+                        wire::NewSessionRequest::new(root.path().to_path_buf())
+                            .mcp_servers(unsupported.clone()),
+                    )
+                    .block_task()
+                    .await
+                    .expect_err("new must reject HTTP MCP transport");
+                assert!(error.data.unwrap().to_string().contains("only stdio"));
+                let error = connection
+                    .send_request(
+                        wire::NewSessionRequest::new(root.path().to_path_buf())
+                            .additional_directories(vec![root.path().to_path_buf()])
+                            .mcp_servers(unsupported.clone()),
+                    )
+                    .block_task()
+                    .await
+                    .expect_err("additional directories must be rejected before MCP construction");
+                assert!(
+                    error
+                        .data
+                        .unwrap()
+                        .to_string()
+                        .contains("additional directories")
+                );
+                let source = connection
+                    .send_request(
+                        wire::NewSessionRequest::new(root.path().to_path_buf())
+                            .mcp_servers(stdio.clone()),
+                    )
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(wire::CloseSessionRequest::new(source.session_id.clone()))
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(
+                        wire::ResumeSessionRequest::new(
+                            source.session_id.clone(),
+                            root.path().to_path_buf(),
+                        )
+                        .mcp_servers(unsupported),
+                    )
+                    .block_task()
+                    .await
+                    .expect_err("resume must validate client MCP servers");
+                connection
+                    .send_request(
+                        wire::ResumeSessionRequest::new(
+                            source.session_id.clone(),
+                            root.path().to_path_buf(),
+                        )
+                        .mcp_servers(stdio),
+                    )
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(wire::CloseSessionRequest::new(source.session_id))
+                    .block_task()
+                    .await?;
+                Ok(())
+            },
+        );
+        let result = timeout(Duration::from_secs(15), client).await;
+        server.abort();
+        let _ = server.await;
+        result.expect("MCP lifecycle client timed out").unwrap();
+    }
+
     #[test]
     fn initialize_negotiates_v2_and_advertises_injection_and_authentication() {
         let root = tempfile::tempdir().unwrap();
@@ -5109,27 +5249,24 @@ mod tests {
             serde_json::Value::Bool(true),
         )]));
         assert!(terminal_auth_methods(&metadata_only, |_| true).is_empty());
-        let mut newer = wire::InitializeRequest::new(
-            wire::ProtocolVersion::V2,
-            wire::Implementation::new("newer-client", "0"),
-        );
-        newer.protocol_version = serde_json::from_value(json!(99)).unwrap();
-        assert_eq!(
-            server.initialize(newer).unwrap().protocol_version,
-            wire::ProtocolVersion::V2
-        );
+        for requested_version in [0, 1, 2, 99] {
+            let request = wire::InitializeRequest::new(
+                serde_json::from_value(json!(requested_version)).unwrap(),
+                wire::Implementation::new("version-test-client", "0"),
+            );
+            assert_eq!(
+                server.initialize(request).unwrap().protocol_version,
+                wire::ProtocolVersion::V2,
+                "v2 handler must advertise its supported version for request {requested_version}"
+            );
+        }
         let session = response.capabilities.session.expect("session capabilities");
+        let mcp = session.mcp.expect("session MCP capabilities");
+        assert!(mcp.stdio.is_some());
+        assert!(mcp.http.is_none());
         assert!(session.inject.is_some());
         assert!(session.delete.is_none());
         assert!(session.fork.is_none());
-        assert!(
-            server
-                .initialize(wire::InitializeRequest::new(
-                    wire::ProtocolVersion::V1,
-                    wire::Implementation::new("test-client", "0"),
-                ))
-                .is_err()
-        );
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1038,12 +1038,25 @@ impl Runtime {
         Ok(Arc::new(runtime))
     }
 
-    pub(crate) fn subscribe_mcp(
+    pub(crate) async fn session_mcp(
         &self,
-        session_id: String,
-    ) -> Result<crate::tools::mcp::McpSubscription, AcpRuntimeError> {
+        servers: Vec<agentkit_acp::McpServer>,
+        cwd: &Path,
+    ) -> Result<crate::tools::mcp::McpRuntime, AcpRuntimeError> {
+        let cwd = crate::resilient_fs::canonicalize(cwd)
+            .map_err(|error| AcpRuntimeError::Loop(error.to_string()))?;
+        if cwd != self.root {
+            return Err(AcpRuntimeError::Loop(format!(
+                "this Kit runtime is fixed to {}",
+                self.root.display()
+            )));
+        }
+        if servers.is_empty() {
+            return Ok(self.mcp.clone());
+        }
         self.mcp
-            .subscribe(session_id)
+            .with_session_servers(servers, &cwd)
+            .await
             .map_err(AcpRuntimeError::Loop)
     }
 
@@ -1133,6 +1146,17 @@ impl Runtime {
         background_jobs: BackgroundJobs,
         skills: Arc<SkillRegistry>,
     ) -> ComposeOnly {
+        self.compose_with_jobs_and_mcp(depth, subagents, background_jobs, skills, self.mcp.clone())
+    }
+
+    fn compose_with_jobs_and_mcp(
+        &self,
+        depth: usize,
+        subagents: Subagents,
+        background_jobs: BackgroundJobs,
+        skills: Arc<SkillRegistry>,
+        mcp: crate::tools::mcp::McpRuntime,
+    ) -> ComposeOnly {
         let mut children = agentkit_tools_core::ToolRegistry::new()
             .with(Observed::new(ArtifactTool::new(crate::artifacts::base(
                 &self.root,
@@ -1164,9 +1188,9 @@ impl Runtime {
                 }
             })))
             .register(Observed::new(A2aTool::new()))
-            .register(Observed::new(ToolSearch::new(self.mcp.clone())))
-            .register(Observed::new(AuthTool::new(self.mcp.clone())))
-            .register(Observed::new(McpTool::new(self.mcp.clone())));
+            .register(Observed::new(ToolSearch::new(mcp.clone())))
+            .register(Observed::new(AuthTool::new(mcp.clone())))
+            .register(Observed::new(McpTool::new(mcp)));
         if let Some(skill_tool) = &self.dynamic_skill_tool {
             children.register(observe_shared(Arc::clone(skill_tool)));
         } else {
@@ -1446,23 +1470,12 @@ impl Runtime {
         })
     }
 
-    pub(crate) async fn start_acp_driver<I>(
-        self: &Arc<Self>,
-        context: AcpDriverContext<I>,
-        claim: &mut SessionClaim,
-    ) -> Result<AcpDriver, AcpRuntimeError>
-    where
-        I: LoopObserver + Clone + 'static,
-    {
-        self.start_acp_driver_with_initial(context, claim, None)
-            .await
-    }
-
-    pub(crate) async fn start_acp_driver_with_initial<I>(
+    pub(crate) async fn start_acp_driver_with_mcp<I>(
         self: &Arc<Self>,
         context: AcpDriverContext<I>,
         claim: &mut SessionClaim,
         forked: Option<AcpForkState>,
+        mcp: crate::tools::mcp::McpRuntime,
     ) -> Result<AcpDriver, AcpRuntimeError>
     where
         I: LoopObserver + Clone + 'static,
@@ -1555,11 +1568,12 @@ impl Runtime {
         let driver = Agent::builder()
             .model(adapter.clone())
             .telemetry(self.agentkit_telemetry())
-            .add_tool_source(self.compose_with_jobs(
+            .add_tool_source(self.compose_with_jobs_and_mcp(
                 self.base_depth,
                 subagents,
                 background_jobs.clone(),
                 skills,
+                mcp,
             ))
             .task_manager(task_manager)
             .mutator(compactor)

--- a/src/tools/mcp.rs
+++ b/src/tools/mcp.rs
@@ -175,6 +175,8 @@ pub(crate) struct ConfigSource {
     path: PathBuf,
     required: bool,
     default_stdio_cwd: Option<PathBuf>,
+    // Immutable request configuration; never read from or written to disk.
+    session_bytes: Option<Arc<[u8]>>,
 }
 
 impl ConfigSource {
@@ -183,6 +185,7 @@ impl ConfigSource {
             path,
             required: true,
             default_stdio_cwd: None,
+            session_bytes: None,
         }
     }
 
@@ -191,6 +194,7 @@ impl ConfigSource {
             path,
             required: false,
             default_stdio_cwd: Some(cwd),
+            session_bytes: None,
         }
     }
 }
@@ -1402,6 +1406,9 @@ fn prepare_plugins(
 }
 
 async fn read_source(source: &ConfigSource) -> Result<Option<Vec<u8>>, String> {
+    if let Some(bytes) = &source.session_bytes {
+        return Ok(Some(bytes.to_vec()));
+    }
     let path = source.path.clone();
     match tokio::task::spawn_blocking(move || crate::config_files::read(&path))
         .await
@@ -1423,6 +1430,7 @@ fn prepare_sources(
 ) -> Result<PreparedConfiguration, String> {
     let mut prepared = plugin_prepared.clone();
     let mut entries = plugin_entries.clone();
+    let mut session_names = BTreeSet::new();
     for state in sources {
         let Some(bytes) = &state.raw else {
             continue;
@@ -1432,6 +1440,18 @@ fn prepare_sources(
             &state.source.path,
             state.source.default_stdio_cwd.as_deref(),
         )?;
+        for name in source_prepared.keys() {
+            if session_names.contains(name)
+                || (state.source.session_bytes.is_some() && prepared.contains_key(name))
+            {
+                return Err(format!(
+                    "session MCP server {name:?} conflicts with an existing server"
+                ));
+            }
+        }
+        if state.source.session_bytes.is_some() {
+            session_names.extend(source_prepared.keys().cloned());
+        }
         prepared.extend(source_prepared);
         entries.extend(source_entries);
     }
@@ -1488,6 +1508,26 @@ async fn connect_inner(
         let raw = read_source(&source).await?;
         source_states.push(SourceState { source, raw });
     }
+    let runtime = build_runtime(
+        source_states,
+        plugin_prepared,
+        plugin_entries,
+        plugin_source,
+        interactive_oauth_enabled,
+        credential_storage,
+    )?;
+    runtime.spawn_eager_initialization();
+    Ok(runtime)
+}
+
+fn build_runtime(
+    source_states: Vec<SourceState>,
+    plugin_prepared: PreparedServers,
+    plugin_entries: ServerFingerprints,
+    plugin_source: Option<crate::plugins::PluginRuntime>,
+    interactive_oauth_enabled: bool,
+    credential_storage: CredentialStorage,
+) -> Result<McpRuntime, String> {
     let (prepared, entries) = prepare_sources(&source_states, &plugin_prepared, &plugin_entries)?;
     validate_server_names(prepared.keys())?;
     let challenges = Arc::new(Mutex::new(BTreeMap::new()));
@@ -1532,11 +1572,106 @@ async fn connect_inner(
         },
         interactive_oauth_enabled,
     );
-    runtime.spawn_eager_initialization();
     Ok(runtime)
 }
 
 impl McpRuntime {
+    /// Build an isolated runtime with request-scoped stdio servers. Credentials
+    /// supplied in the request remain in an immutable in-memory config source.
+    /// Initialization is lazy: rejected or cancelled attachment must not leave
+    /// a detached initializer owning this runtime or starting its processes.
+    pub(crate) async fn with_session_servers(
+        &self,
+        servers: Vec<agentkit_acp::McpServer>,
+        cwd: &Path,
+    ) -> Result<McpRuntime, String> {
+        self.ensure_healthy()?;
+        let mut entries = BTreeMap::new();
+        for server in servers {
+            let agentkit_acp::McpServer::Stdio(server) = server else {
+                return Err("session MCP servers support only stdio transport".into());
+            };
+            if entries.contains_key(&server.name) {
+                return Err(format!("duplicate session MCP server {:?}", server.name));
+            }
+            let mut env = BTreeMap::new();
+            for variable in server.env {
+                if env.insert(variable.name, variable.value).is_some() {
+                    return Err(format!(
+                        "duplicate environment variable for session MCP server {:?}",
+                        server.name
+                    ));
+                }
+            }
+            let command = server.command.to_str().ok_or_else(|| {
+                format!("session MCP server {:?} command is not UTF-8", server.name)
+            })?;
+            entries.insert(
+                server.name,
+                Value::Object(serde_json::Map::from_iter([
+                    ("type".into(), Value::String("stdio".into())),
+                    ("command".into(), Value::String(command.into())),
+                    (
+                        "args".into(),
+                        Value::Array(server.args.into_iter().map(Value::String).collect()),
+                    ),
+                    (
+                        "env".into(),
+                        Value::Object(
+                            env.into_iter()
+                                .map(|(name, value)| (name, Value::String(value)))
+                                .collect(),
+                        ),
+                    ),
+                ])),
+            );
+        }
+        let config = Value::Object(serde_json::Map::from_iter([(
+            "mcpServers".into(),
+            Value::Object(entries.into_iter().collect()),
+        )]));
+        let bytes = serde_json::to_vec(&config)
+            .map_err(|error| format!("could not encode session MCP config: {error}"))?;
+        // Clone a consistent source/plugin generation. Release the reload lock
+        // before reads, validation, backend work, or initialization.
+        let (sources, plugins, plugin_entries, plugin_source) = {
+            let state = self.inner.reload.lock().await;
+            self.ensure_healthy()?;
+            (
+                state
+                    .sources
+                    .iter()
+                    .map(|state| state.source.clone())
+                    .collect::<Vec<_>>(),
+                state.plugins.clone(),
+                state.plugin_entries.clone(),
+                state.plugin_source.clone(),
+            )
+        };
+        let mut source_states = Vec::with_capacity(sources.len() + 1);
+        for source in sources {
+            let raw = read_source(&source).await?;
+            source_states.push(SourceState { source, raw });
+        }
+        source_states.push(SourceState {
+            source: ConfigSource {
+                path: PathBuf::from("<session MCP servers>"),
+                required: true,
+                default_stdio_cwd: Some(cwd.to_path_buf()),
+                session_bytes: Some(Arc::from(bytes.clone())),
+            },
+            raw: Some(bytes),
+        });
+        build_runtime(
+            source_states,
+            plugins,
+            plugin_entries,
+            plugin_source,
+            self.inner.interactive_oauth_enabled,
+            self.inner.credential_storage.clone(),
+        )
+    }
+
     fn ensure_healthy(&self) -> Result<(), String> {
         if self.inner.healthy.load(Ordering::Acquire) {
             Ok(())
@@ -6693,6 +6828,330 @@ mod tests {
         assert_eq!(
             runtime.inner.servers.read().await["shared"].description,
             "tools-manifest plugin MCP server"
+        );
+    }
+
+    fn session_server(name: &str) -> agentkit_acp::McpServer {
+        serde_json::from_value(json!({
+            "name": name, "command": "/kit-test-missing-session-command",
+            "args": ["session-argument"],
+            "env": [{"name": "SESSION_SECRET", "value": "memory-only-secret"}]
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn session_overlay_is_isolated_and_survives_reload() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("mcp.json");
+        let original = r#"{"mcpServers":{"configured":{"command":"kit-test-missing-command"}}}"#;
+        std::fs::write(&path, original).unwrap();
+        let base = super::connect(Some(&path), &[], false, CredentialStorage::Memory)
+            .await
+            .unwrap();
+        let first = base
+            .with_session_servers(vec![session_server("local")], directory.path())
+            .await
+            .unwrap();
+        let second = base
+            .with_session_servers(vec![session_server("local")], directory.path())
+            .await
+            .unwrap();
+        let empty = base
+            .with_session_servers(vec![], directory.path())
+            .await
+            .unwrap();
+        assert!(!Arc::ptr_eq(&base.inner, &first.inner));
+        assert!(!Arc::ptr_eq(&first.inner, &second.inner));
+        assert!(!Arc::ptr_eq(&base.inner, &empty.inner));
+        assert!(!base.inner.servers.read().await.contains_key("local"));
+        assert!(!empty.inner.servers.read().await.contains_key("local"));
+        first.reload_config().await.unwrap();
+        let state = first.inner.reload.lock().await;
+        let (prepared, _) =
+            super::prepare_sources(&state.sources, &state.plugins, &state.plugin_entries).unwrap();
+        assert!(prepared.contains_key("configured"));
+        let McpTransportBinding::Stdio(stdio) = &prepared["local"].config.transport else {
+            panic!("expected stdio");
+        };
+        assert_eq!(stdio.cwd.as_deref(), Some(directory.path()));
+        assert_eq!(stdio.args, ["session-argument"]);
+        assert_eq!(
+            stdio
+                .env
+                .iter()
+                .find(|(name, _)| name == "SESSION_SECRET")
+                .map(|(_, value)| value.as_str()),
+            Some("memory-only-secret")
+        );
+        drop(state);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn session_overlay_rejects_invalid_requests_without_mutating_base() {
+        let directory = tempfile::tempdir().unwrap();
+        let base = super::connect(None::<&Path>, &[], false, CredentialStorage::Memory)
+            .await
+            .unwrap();
+        let duplicate_env = serde_json::from_value(json!({
+            "name": "local", "command": "/missing", "args": [],
+            "env": [{"name": "KEY", "value": "secret-one"}, {"name": "KEY", "value": "secret-two"}]
+        }))
+        .unwrap();
+        let http = serde_json::from_value(json!({"type": "http", "name": "http", "url": "https://example.invalid/mcp", "headers": []})).unwrap();
+        let sse = serde_json::from_value(json!({"type": "sse", "name": "sse", "url": "https://example.invalid/sse", "headers": []})).unwrap();
+        for servers in [
+            vec![session_server("local"), session_server("local")],
+            vec![duplicate_env],
+            vec![http],
+            vec![sse],
+            vec![session_server("")],
+        ] {
+            let error = match base.with_session_servers(servers, directory.path()).await {
+                Ok(_) => panic!("invalid session servers accepted"),
+                Err(error) => error,
+            };
+            assert!(!error.contains("secret-one"));
+            assert!(!error.contains("secret-two"));
+        }
+        assert!(base.inner.servers.read().await.is_empty());
+        base.with_session_servers(vec![session_server("valid")], directory.path())
+            .await
+            .unwrap();
+    }
+
+    #[cfg(unix)]
+    fn session_stdio_fixture(directory: &Path, value: &str) -> agentkit_acp::McpServer {
+        // A real line-delimited JSON-RPC stdio server. Its marker is an external
+        // process effect, not instrumentation in the production runtime.
+        let script = r#"
+import json, os, sys
+with open(os.environ['MARKER'], 'w') as marker:
+    marker.write('started')
+for line in sys.stdin:
+    request = json.loads(line)
+    if 'id' not in request:
+        continue
+    method = request['method']
+    if method == 'initialize':
+        result = {'protocolVersion': request['params']['protocolVersion'], 'capabilities': {'tools': {}}, 'serverInfo': {'name': 'session-fixture', 'version': '1'}}
+    elif method == 'tools/list':
+        result = {'tools': [{'name': 'inspect', 'description': 'Inspect session environment', 'inputSchema': {'type': 'object'}}]}
+    elif method == 'tools/call':
+        data = {'value': os.environ['SESSION_VALUE'], 'cwd': os.getcwd(), 'pid': os.getpid()}
+        result = {'content': [{'type': 'text', 'text': json.dumps(data)}], 'structuredContent': data, 'isError': False}
+    else:
+        result = {}
+    print(json.dumps({'jsonrpc': '2.0', 'id': request['id'], 'result': result}), flush=True)
+"#;
+        serde_json::from_value(json!({
+            "name": "local", "command": "/usr/bin/env", "args": ["python3", "-u", "-c", script],
+            "env": [
+                {"name": "SESSION_VALUE", "value": value},
+                {"name": "MARKER", "value": directory.join(format!("{value}.started"))}
+            ]
+        }))
+        .unwrap()
+    }
+
+    #[cfg(unix)]
+    async fn call_session_stdio(runtime: &super::McpRuntime) -> Value {
+        use agentkit_core::{SessionId, ToolOutput, TurnId};
+        use agentkit_tools_core::{
+            AllowAllPermissions, ToolExecutionOutcome, ToolExecutionScope, ToolRequest,
+        };
+        let tool = McpTool::new(runtime.clone());
+        let scope = ToolExecutionScope {
+            executor: Arc::clone(&tool.executor),
+            session_id: SessionId::new("fixture"),
+            turn_id: TurnId::new("turn"),
+            permissions: Arc::new(AllowAllPermissions),
+            resources: Arc::new(()),
+            cancellation: None,
+        };
+        let context = scope.nested_context(MetadataMap::new());
+        let request = ToolRequest::new(
+            "call",
+            "tool",
+            json!({"name": "mcp_local_inspect", "args": {}}),
+            "fixture",
+            "turn",
+        );
+        let outcome = tool.dispatch(request, &mut context.borrowed()).await;
+        let ToolExecutionOutcome::Completed(result) = outcome else {
+            panic!("stdio call did not complete: {outcome:?}");
+        };
+        assert!(!result.result.is_error);
+        let ToolOutput::Structured(value) = result.result.output else {
+            panic!("expected structured MCP response");
+        };
+        value
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn session_overlay_stdio_is_lazy_and_executes_in_isolation() {
+        use agentkit_tools_core::ToolSource;
+        let directory = tempfile::tempdir().unwrap();
+        let cwd = directory.path().canonicalize().unwrap();
+        let path = cwd.join("mcp.json");
+        std::fs::write(&path, r#"{"mcpServers":{}}"#).unwrap();
+        let base = super::connect(Some(&path), &[], false, CredentialStorage::Memory)
+            .await
+            .unwrap();
+
+        let abandoned = base
+            .with_session_servers(vec![session_stdio_fixture(&cwd, "abandoned")], &cwd)
+            .await
+            .unwrap();
+        let weak = Arc::downgrade(&abandoned.inner);
+        drop(abandoned);
+        // A detached initializer would retain the runtime even before polling.
+        assert!(weak.upgrade().is_none());
+        assert!(!cwd.join("abandoned.started").exists());
+        assert!(
+            base.with_session_servers(
+                vec![
+                    session_stdio_fixture(&cwd, "rejected"),
+                    session_stdio_fixture(&cwd, "duplicate")
+                ],
+                &cwd
+            )
+            .await
+            .is_err()
+        );
+        assert!(!cwd.join("rejected.started").exists());
+        assert!(!cwd.join("duplicate.started").exists());
+
+        let first = base
+            .with_session_servers(vec![session_stdio_fixture(&cwd, "first")], &cwd)
+            .await
+            .unwrap();
+        let second = base
+            .with_session_servers(vec![session_stdio_fixture(&cwd, "second")], &cwd)
+            .await
+            .unwrap();
+        assert!(!cwd.join("first.started").exists());
+        assert!(!cwd.join("second.started").exists());
+        let found = first.search("inspect").await.unwrap();
+        assert_eq!(found["servers"][0]["status"], "authenticated");
+        assert!(cwd.join("first.started").exists());
+        assert!(!cwd.join("second.started").exists());
+        second.search("inspect").await.unwrap();
+        let first_result = call_session_stdio(&first).await;
+        let second_result = call_session_stdio(&second).await;
+        assert_eq!(first_result["value"], "first");
+        assert_eq!(second_result["value"], "second");
+        assert_eq!(first_result["cwd"], cwd.to_str().unwrap());
+        assert_eq!(second_result["cwd"], cwd.to_str().unwrap());
+        assert_ne!(first_result["pid"], second_result["pid"]);
+
+        // Only the refreshed overlay observes a configured-source addition.
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"added":{"command":"kit-test-missing-command"}}}"#,
+        )
+        .unwrap();
+        first.reload_config().await.unwrap();
+        assert!(first.inner.servers.read().await.contains_key("added"));
+        assert!(!second.inner.servers.read().await.contains_key("added"));
+        assert!(base.inner.servers.read().await.is_empty());
+        assert_eq!(call_session_stdio(&first).await, first_result);
+        assert_eq!(call_session_stdio(&second).await, second_result);
+        assert!(
+            base.catalog()
+                .get(&agentkit_tools_core::ToolName::new("mcp_local_inspect"))
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn session_overlay_preserves_plugin_snapshot_and_rejects_plugin_collision() {
+        let directory = tempfile::tempdir().unwrap();
+        let plugin = plugin(
+            "tools",
+            directory.path(),
+            vec![PluginMcpServer {
+                name: "plugin-local".into(),
+                transport: PluginMcpTransport::Stdio {
+                    command: "kit-test-missing-plugin".into(),
+                    args: Vec::new(),
+                    env: Default::default(),
+                    cwd: None,
+                },
+            }],
+        );
+        let base = super::connect(None::<&Path>, &[plugin], false, CredentialStorage::Memory)
+            .await
+            .unwrap();
+        assert!(
+            base.with_session_servers(vec![session_server("plugin-local")], directory.path())
+                .await
+                .is_err()
+        );
+        let overlay = base
+            .with_session_servers(vec![session_server("local")], directory.path())
+            .await
+            .unwrap();
+        overlay.reload_config().await.unwrap();
+        let records = overlay.inner.servers.read().await;
+        assert!(records["plugin-local"].plugin_owned);
+        assert!(!records["local"].plugin_owned);
+        assert!(!base.inner.servers.read().await.contains_key("local"));
+    }
+
+    #[tokio::test]
+    async fn session_overlay_collision_rejects_refresh_without_publication() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"configured":{"command":"missing"}}}"#,
+        )
+        .unwrap();
+        let base = super::connect(Some(&path), &[], false, CredentialStorage::Memory)
+            .await
+            .unwrap();
+        assert!(
+            base.with_session_servers(vec![session_server("configured")], directory.path())
+                .await
+                .is_err()
+        );
+        let overlay = base
+            .with_session_servers(vec![session_server("local")], directory.path())
+            .await
+            .unwrap();
+        let before = overlay.inner.reload.lock().await.entries.clone();
+        std::fs::write(&path, r#"{"mcpServers":{"local":{"command":"missing"}}}"#).unwrap();
+        assert!(
+            overlay
+                .reload_config()
+                .await
+                .unwrap_err()
+                .contains("conflicts")
+        );
+        assert_eq!(overlay.inner.reload.lock().await.entries, before);
+        assert!(
+            overlay
+                .inner
+                .servers
+                .read()
+                .await
+                .contains_key("configured")
+        );
+        assert!(!base.inner.servers.read().await.contains_key("local"));
+        std::fs::write(&path, r#"{"mcpServers":{}}"#).unwrap();
+        overlay.reload_config().await.unwrap();
+        assert!(overlay.inner.servers.read().await.contains_key("local"));
+        assert!(
+            !overlay
+                .inner
+                .servers
+                .read()
+                .await
+                .contains_key("configured")
         );
     }
 

--- a/src/tools/mcp.rs
+++ b/src/tools/mcp.rs
@@ -3412,22 +3412,33 @@ impl McpTool {
             Err(error) => return ToolExecutionOutcome::Failed(error),
         };
         let tool_name = ToolName::new(name.clone());
-        if self.catalog.get(&tool_name).is_none() {
-            return ToolExecutionOutcome::Failed(ToolError::InvalidInput(format!(
-                "unknown MCP tool: {}",
-                tool_name.0
-            )));
-        }
         let Some(scope) = context.execution_scope.clone() else {
             return ToolExecutionOutcome::Failed(ToolError::Unavailable(
                 "tool requires an execution scope".into(),
             ));
         };
         let timeout_name = name.clone();
-        let call = tokio::time::timeout(
-            timeout,
-            self.dispatch_call(request, scope, name, tool_name, args),
-        );
+        let call = tokio::time::timeout(timeout, async {
+            // A resumed conversation can invoke a previously discovered tool
+            // without searching this attachment's fresh, lazily populated catalog.
+            if self.catalog.get(&tool_name).is_none() {
+                if let Some((server, _, _, _)) = self.runtime.server_for_tool(&name).await {
+                    self.runtime
+                        .initialize_servers(&[server])
+                        .await
+                        .map_err(ToolError::Unavailable)?;
+                }
+                if self.catalog.get(&tool_name).is_none() {
+                    return Err(ToolError::InvalidInput(format!(
+                        "unknown MCP tool: {}",
+                        tool_name.0
+                    )));
+                }
+            }
+            Ok(self
+                .dispatch_call(request, scope, name, tool_name, args)
+                .await)
+        });
         let result = if let Some(cancellation) = context.cancellation.clone() {
             // A ready cancellation wins a simultaneous ready result. Cancellation
             // drops dispatch (including its process/ownership guards), but cannot
@@ -3444,7 +3455,8 @@ impl McpTool {
             call.await
         };
         match result {
-            Ok(call) => self.finish_dispatch(call).await,
+            Ok(Ok(call)) => self.finish_dispatch(call).await,
+            Ok(Err(error)) => ToolExecutionOutcome::FailedBeforeInvocation(error),
             Err(_) => ToolExecutionOutcome::Failed(ToolError::ExecutionFailed(format!(
                 "MCP tool {timeout_name} timed out after {} seconds; inspect remote state before retrying side effects",
                 timeout.as_secs()
@@ -6960,7 +6972,7 @@ for line in sys.stdin:
     async fn call_session_stdio(runtime: &super::McpRuntime) -> Value {
         use agentkit_core::{SessionId, ToolOutput, TurnId};
         use agentkit_tools_core::{
-            AllowAllPermissions, ToolExecutionOutcome, ToolExecutionScope, ToolRequest,
+            AllowAllPermissions, Tool, ToolExecutionOutcome, ToolExecutionScope, ToolRequest,
         };
         let tool = McpTool::new(runtime.clone());
         let scope = ToolExecutionScope {
@@ -6979,7 +6991,7 @@ for line in sys.stdin:
             "fixture",
             "turn",
         );
-        let outcome = tool.dispatch(request, &mut context.borrowed()).await;
+        let outcome = tool.invoke_outcome(request, &mut context.borrowed()).await;
         let ToolExecutionOutcome::Completed(result) = outcome else {
             panic!("stdio call did not complete: {outcome:?}");
         };
@@ -7039,7 +7051,8 @@ for line in sys.stdin:
         assert_eq!(found["servers"][0]["status"], "authenticated");
         assert!(cwd.join("first.started").exists());
         assert!(!cwd.join("second.started").exists());
-        second.search("inspect").await.unwrap();
+        // Reattachment has a fresh catalog, but remembers the discovered name.
+        // Direct invocation must initialize only this attachment's server.
         let first_result = call_session_stdio(&first).await;
         let second_result = call_session_stdio(&second).await;
         assert_eq!(first_result["value"], "first");
@@ -7065,6 +7078,135 @@ for line in sys.stdin:
                 .get(&agentkit_tools_core::ToolName::new("mcp_local_inspect"))
                 .is_none()
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn session_overlay_lazy_invocation_interrupts_initialization() {
+        use agentkit_core::{CancellationController, SessionId, TurnId};
+        use agentkit_tools_core::{
+            AllowAllPermissions, Tool, ToolError, ToolExecutionOutcome, ToolExecutionScope,
+            ToolRequest,
+        };
+
+        for cancel in [true, false] {
+            let directory = tempfile::tempdir().unwrap();
+            let cwd = directory.path().canonicalize().unwrap();
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let agentkit_acp::McpServer::Stdio(mut server) = session_stdio_fixture(&cwd, "blocked")
+            else {
+                unreachable!();
+            };
+            // Signal at the actual initialize request, then withhold the response.
+            // This exercises cancellation/timeout at the external stdio boundary.
+            server.args[3] = server.args[3].replace(
+                "if method == 'initialize':",
+                &format!(
+                    "if method == 'initialize':\n        import socket\n        signal = socket.create_connection(('127.0.0.1', {}))\n        sys.stdin.read()\n        sys.exit(0)",
+                    listener.local_addr().unwrap().port()
+                ),
+            );
+            let runtime = super::empty()
+                .with_session_servers(vec![agentkit_acp::McpServer::Stdio(server)], &cwd)
+                .await
+                .unwrap();
+            let tool = McpTool::new(runtime.clone());
+            let controller = CancellationController::new();
+            let scope = ToolExecutionScope {
+                executor: Arc::clone(&tool.executor),
+                session_id: SessionId::new("fixture"),
+                turn_id: TurnId::new("turn"),
+                permissions: Arc::new(AllowAllPermissions),
+                resources: Arc::new(()),
+                cancellation: None,
+            };
+            let mut context = scope.nested_context(MetadataMap::new());
+            context.cancellation = Some(controller.handle().checkpoint());
+            let request = ToolRequest::new(
+                "call",
+                "tool",
+                json!({"name": "mcp_local_inspect", "args": {}, "timeout_seconds": 1}),
+                "fixture",
+                "turn",
+            );
+            let mut borrowed = context.borrowed();
+            let (outcome, ()) =
+                tokio::join!(tool.invoke_outcome(request.clone(), &mut borrowed), async {
+                    let _connection =
+                        tokio::time::timeout(Duration::from_secs(5), listener.accept())
+                            .await
+                            .unwrap()
+                            .unwrap();
+                    if cancel {
+                        controller.interrupt();
+                    }
+                });
+            if cancel {
+                assert!(matches!(
+                    outcome,
+                    ToolExecutionOutcome::Failed(ToolError::Cancelled)
+                ));
+            } else {
+                assert!(
+                    matches!(outcome, ToolExecutionOutcome::Failed(ToolError::ExecutionFailed(ref error)) if error.contains("timed out"))
+                );
+            }
+            // Incomplete backend publication must fence subsequent real calls.
+            let context = scope.nested_context(MetadataMap::new());
+            assert!(matches!(
+                tool.invoke(request, &mut context.borrowed()).await,
+                Err(ToolError::Unavailable(_))
+            ));
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn session_overlay_direct_invocation_initializes_configured_server_only() {
+        let directory = tempfile::tempdir().unwrap();
+        let cwd = directory.path().canonicalize().unwrap();
+        let path = cwd.join("mcp.json");
+        let agentkit_acp::McpServer::Stdio(configured) = session_stdio_fixture(&cwd, "configured")
+        else {
+            unreachable!();
+        };
+        let env = configured
+            .env
+            .into_iter()
+            .map(|variable| (variable.name, Value::String(variable.value)))
+            .collect::<serde_json::Map<_, _>>();
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&json!({"mcpServers": {"local": {
+                "command": configured.command, "args": configured.args, "env": env
+            }}}))
+            .unwrap(),
+        )
+        .unwrap();
+        let base = super::connect(Some(&path), &[], false, CredentialStorage::Memory)
+            .await
+            .unwrap();
+        base.search("inspect").await.unwrap();
+        let original = call_session_stdio(&base).await;
+        std::fs::remove_file(cwd.join("configured.started")).unwrap();
+
+        let agentkit_acp::McpServer::Stdio(mut unrelated) =
+            session_stdio_fixture(&cwd, "unrelated")
+        else {
+            unreachable!();
+        };
+        unrelated.name = "other".into();
+        let attached = base
+            .with_session_servers(vec![agentkit_acp::McpServer::Stdio(unrelated)], &cwd)
+            .await
+            .unwrap();
+        assert!(!cwd.join("configured.started").exists());
+        assert!(!cwd.join("unrelated.started").exists());
+        let result = call_session_stdio(&attached).await;
+        assert_eq!(result["value"], "configured");
+        assert_ne!(result["pid"], original["pid"]);
+        assert!(cwd.join("configured.started").exists());
+        assert!(!cwd.join("unrelated.started").exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Support client-supplied stdio MCP servers on ACP v1 session creation, load, and fork, and ACP v2 session creation and resume. Hosts can expose session-specific tools without modifying the user's global Kit configuration.

## Technical details
### Attachment-scoped configuration
Build an isolated MCP runtime that combines configured servers with an in-memory source for client-supplied servers. Launch configuration is not persisted and must be supplied again when reattaching. Sessions without additional servers continue using the existing runtime.

### Validation and lifecycle
Reject unsupported transports, duplicate server names or environment variables, and collisions with configured or plugin servers. Initialize session servers lazily so rejected or cancelled attachments do not leave detached initializers starting processes. Route tool discovery, invocation, authentication, and MCP notifications through the session runtime.
